### PR TITLE
Ensure consistent smart dialogue style and add test

### DIFF
--- a/src/tags/command_executor.py
+++ b/src/tags/command_executor.py
@@ -12,6 +12,9 @@ from src.action.scene_painter import ScenePainter
 from src.action.description_writer import DescriptionWriter
 
 
+DEFAULT_DIALOGUE_STYLE = "дружеский"
+
+
 class CommandExecutor:
     """Я выполняю команды с творческим подходом и пониманием контекста.
 
@@ -154,7 +157,7 @@ class CommandExecutor:
                 "opening": ["Позвольте заметить", "Следует отметить", "Я вынужден сказать"],
                 "response": ["Безусловно", "Разумеется", "Я полностью согласен"],
             },
-            "дружеский": {
+            DEFAULT_DIALOGUE_STYLE: {
                 "opening": ["Слушай", "Знаешь что", "Кстати говоря"],
                 "response": ["Точно!", "Да ладно!", "Не может быть!"],
             },
@@ -164,7 +167,7 @@ class CommandExecutor:
             },
         }
 
-        style = "дружеский"
+        style = DEFAULT_DIALOGUE_STYLE
         template = dialogue_templates[style]
 
         return (

--- a/tests/test_tags/test_command_executor.py
+++ b/tests/test_tags/test_command_executor.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from src.tags.command_executor import CommandExecutor
 from src.tags.tag_parser import Tag
@@ -40,3 +41,14 @@ def test_description_handler_without_llm():
     tag = Tag(type='description_write', content='тихий лес', position=(0, 0))
     result = executor.execute_command(tag)
     assert 'Описание' in result
+
+
+def test_create_smart_dialogue_without_llm_selects_default_template():
+    executor = CommandExecutor()
+    context = {"characters": ["Алиса", "Боб"]}
+    with patch("src.tags.command_executor.random.choice", side_effect=lambda seq: seq[0]):
+        result = executor._create_smart_dialogue("Привет", context)
+
+    assert "Слушай" in result
+    assert "Точно!" in result
+    assert "Стиль: дружеский" in result


### PR DESCRIPTION
## Summary
- Keep smart dialogue style naming consistent via `DEFAULT_DIALOGUE_STYLE`.
- Add regression test for `_create_smart_dialogue` when no LLM is available.

## Testing
- `pytest tests/test_tags/test_command_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890cb854fdc832388a79ecb580a0954