### PR TITLE
refactor: import TagSystemConfig at module level

### DIFF
--- a/src/core/neyra_config.py
+++ b/src/core/neyra_config.py
@@ -2,11 +2,14 @@
 Конфигурация личности Нейры.
 Здесь живут все настройки того, какой должна быть Нейра.
 """
+
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
+
 try:
     import torch  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover
+
     class _Cuda:
         @staticmethod
         def is_available() -> bool:
@@ -19,52 +22,56 @@ except ModuleNotFoundError:  # pragma: no cover
 @dataclass
 class NeyraPersonality:
     """Черты характера Нейры"""
-    curiosity_level: float = 0.9       # Любознательность (0-1)
-    creativity_boost: float = 0.8      # Творческий потенциал
-    empathy_factor: float = 0.85       # Эмпатия к персонажам
+
+    curiosity_level: float = 0.9  # Любознательность (0-1)
+    creativity_boost: float = 0.8  # Творческий потенциал
+    empathy_factor: float = 0.85  # Эмпатия к персонажам
     attention_to_detail: float = 0.95  # Внимание к деталям
-    humor_tendency: float = 0.3        # Склонность к юмору
-    encouragement_level: float = 0.9   # Уровень поддержки
+    humor_tendency: float = 0.3  # Склонность к юмору
+    encouragement_level: float = 0.9  # Уровень поддержки
 
 
 @dataclass
 class TagSystemConfig:
     """Настройки системы тегов - сердца Нейры"""
+
     # Основные теги
     CORE_TAGS = {
-        'neyra_command': r'@Нейра:\s*([^@]+)@',
-        'memory_recall': r'@Вспомни:\s*([^@]+)@',
-        'character_work': r'@Персонаж:\s*([^@]+)@',
-        'style_guide': r'@Стиль:\s*([^@]+)@',
-        'emotion_paint': r'@Эмоция:\s*([^@]+)@',
-        'consistency_check': r'@Проверь:\s*([^@]+)@',
-        'dialogue_create': r'@Диалог:\s*([^@]+)@',
-        'scene_build': r'@Сцена:\s*([^@]+)@',
-        'description_write': r'@Описание:\s*([^@]+)@'
+        "neyra_command": r"@Нейра:\s*([^@]+)@",
+        "memory_recall": r"@Вспомни:\s*([^@]+)@",
+        "character_work": r"@Персонаж:\s*([^@]+)@",
+        "style_guide": r"@Стиль:\s*([^@]+)@",
+        "emotion_paint": r"@Эмоция:\s*([^@]+)@",
+        "consistency_check": r"@Проверь:\s*([^@]+)@",
+        "dialogue_create": r"@Диалог:\s*([^@]+)@",
+        "scene_build": r"@Сцена:\s*([^@]+)@",
+        "description_write": r"@Описание:\s*([^@]+)@",
     }
 
     # Дополнительные теги
     EXTENDED_TAGS = {
-        'length_control': r'@Длина:\s*([^@]+)@',
-        'tone_setting': r'@Тон:\s*([^@]+)@',
-        'time_context': r'@Время:\s*([^@]+)@',
-        'location_context': r'@Место:\s*([^@]+)@',
-        'genre_guide': r'@Жанр:\s*([^@]+)@'
+        "length_control": r"@Длина:\s*([^@]+)@",
+        "tone_setting": r"@Тон:\s*([^@]+)@",
+        "time_context": r"@Время:\s*([^@]+)@",
+        "location_context": r"@Место:\s*([^@]+)@",
+        "genre_guide": r"@Жанр:\s*([^@]+)@",
     }
 
 
 @dataclass
 class ModelConfig:
     """Настройки языковой модели для мозга Нейры"""
+
     model_name: str = "llama2-7b-chat"
     quantization: str = "4bit"
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
-    max_memory: Dict[str, str] = None
+    max_memory: Optional[Dict[str, str]] = None
 
 
 @dataclass
 class GenerationConfig:
     """Как Нейра создает тексты"""
+
     temperature: float = 0.7
     top_p: float = 0.9
     max_length: int = 1000
@@ -74,6 +81,7 @@ class GenerationConfig:
 @dataclass
 class MemoryConfig:
     """Настройки памяти Нейры"""
+
     max_characters: int = 1000
     max_events: int = 10000
     pattern_threshold: int = 5

--- a/src/tags/tag_parser.py
+++ b/src/tags/tag_parser.py
@@ -2,18 +2,21 @@
 Система тегов - это язык общения с Нейрой.
 Здесь я учусь понимать команды пользователя.
 """
+
 import re
 from typing import List, Dict
 from dataclasses import dataclass
+from src.core.neyra_config import TagSystemConfig
 
 
 @dataclass
 class Tag:
     """Один тег - одна команда для Нейры"""
-    type: str           # Тип команды
-    content: str        # Содержание команды
-    position: tuple     # Позиция в тексте
-    priority: int = 1   # Приоритет выполнения
+
+    type: str  # Тип команды
+    content: str  # Содержание команды
+    position: tuple  # Позиция в тексте
+    priority: int = 1  # Приоритет выполнения
 
 
 class TagParser:
@@ -21,10 +24,9 @@ class TagParser:
 
     def __init__(self) -> None:
         """Инициализирую свой словарь понимания тегов"""
-        from src.core.neyra_config import TagSystemConfig
         self.tag_patterns: Dict[str, str] = {
             **TagSystemConfig.CORE_TAGS,
-            **TagSystemConfig.EXTENDED_TAGS
+            **TagSystemConfig.EXTENDED_TAGS,
         }
 
     def parse_user_input(self, text: str) -> List[Tag]:
@@ -40,9 +42,7 @@ class TagParser:
             matches = re.finditer(pattern, text, re.IGNORECASE)
             for match in matches:
                 tag = Tag(
-                    type=tag_type,
-                    content=match.group(1).strip(),
-                    position=match.span()
+                    type=tag_type, content=match.group(1).strip(), position=match.span()
                 )
                 tags.append(tag)
 
@@ -58,7 +58,7 @@ class TagParser:
             suggestions.append("@Персонаж: имя - действие@")
 
         # Если текст эмоциональный, предлагаю @Эмоция:@
-        emotion_words = ['грустно', 'радостно', 'страшно', 'весело']
+        emotion_words = ["грустно", "радостно", "страшно", "весело"]
         if any(word in context.lower() for word in emotion_words):
             suggestions.append("@Эмоция: чувство@")
 


### PR DESCRIPTION
## Summary
- import TagSystemConfig at module level in tag_parser for clarity
- fix ModelConfig typing so static analysis passes

## Testing
- `python -m py_compile src/tags/tag_parser.py`
- `mypy src/tags/tag_parser.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d65c6b808323b9f2e4223e19a5d4