### PR TITLE
feat(cli): add prompt toolkit autocomplete

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@
 import logging
 from pathlib import Path
 from src.core.neyra_brain import Neyra
+from src.cli.prompt_cli import run_cli
 
 def setup_logging() -> None:
     """Настраиваю систему для записи того, что думает Нейра"""
@@ -57,6 +58,7 @@ def main() -> None:
             print("Добавьте .txt файлы в папку data/books/ и я их изучу!")
             
         print("\n💫 Нейра готова к работе! Используйте теги для общения.")
+        run_cli(neyra)
         
     except Exception as e:  # pylint: disable=broad-except
         logger.error(f"Ошибка при пробуждении Нейры: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ python-dotenv>=1.0.0
 tqdm>=4.66.0
 click>=8.1.0
 colorama>=0.4.6
+prompt_toolkit>=3.0.0
 
 # Качество кода
 pytest>=7.4.0

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,3 @@
+"""CLI utilities for Neyra."""
+
+__all__ = []

--- a/src/cli/prompt_cli.py
+++ b/src/cli/prompt_cli.py
@@ -1,0 +1,105 @@
+"""Interactive command line interface for Neyra using prompt_toolkit.
+
+Provides tag and command autocompletion and handles basic slash
+commands like ``/help`` and ``/exit``.  Suggestions are accepted with
+``Tab``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.key_binding import KeyBindings
+
+from src.core.neyra_config import TagSystemConfig
+
+
+class _NeyraCompleter(Completer):
+    """Autocomplete tags starting with ``@`` and commands starting with ``/``."""
+
+    def __init__(self, tags: Iterable[str], commands: Iterable[str]) -> None:
+        self._tags = list(tags)
+        self._commands = list(commands)
+
+    def get_completions(self, document, complete_event):  # type: ignore[override]
+        text = document.text_before_cursor
+        word = document.get_word_before_cursor(pattern=re.compile(r"[^\s]+"))
+        if not word:
+            return
+        if word.startswith("@"):  # Tag completion
+            prefix = word[1:].lower()
+            for tag in self._tags:
+                if tag.lower().startswith(prefix):
+                    yield Completion(f"@{tag}: ", start_position=-len(word))
+        elif word.startswith("/"):  # Slash command completion
+            prefix = word[1:].lower()
+            for cmd in self._commands:
+                if cmd.lower().startswith(prefix):
+                    yield Completion(f"/{cmd}", start_position=-len(word))
+
+
+def _collect_tags() -> List[str]:
+    """Extract tag names from :class:`TagSystemConfig`."""
+
+    patterns = {**TagSystemConfig.CORE_TAGS, **TagSystemConfig.EXTENDED_TAGS}
+    tags: List[str] = []
+    for pattern in patterns.values():
+        start = pattern.find("@") + 1
+        end = pattern.find(":", start)
+        if start > 0 and end > start:
+            tags.append(pattern[start:end])
+    return tags
+
+
+COMMANDS = [
+    "help",
+    "exit",
+    "внешность",
+    "стиль",
+    "сцена",
+    "сгенерировать",
+]
+
+
+def run_cli(neyra) -> None:
+    """Run interactive CLI loop for the given :class:`Neyra` instance."""
+
+    completer = _NeyraCompleter(_collect_tags(), COMMANDS)
+
+    kb = KeyBindings()
+
+    @kb.add("tab")
+    def _(event) -> None:
+        buffer = event.current_buffer
+        if buffer.complete_state:
+            buffer.complete_next()
+        else:
+            buffer.start_completion(select_first=False)
+
+    session = PromptSession(completer=completer, key_bindings=kb)
+
+    print("Введите команды. Используйте /help для помощи, /exit для выхода.")
+    while True:
+        try:
+            text = session.prompt("> ")
+        except (KeyboardInterrupt, EOFError):  # pragma: no cover - interactive
+            print()
+            break
+        clean = text.strip()
+        if not clean:
+            continue
+        lower = clean.lower()
+        if lower == "/exit":
+            break
+        if lower == "/help":
+            print("Доступные теги:", ", ".join(_collect_tags()))
+            print("Доступные команды:", ", ".join(f"/{c}" for c in COMMANDS))
+            continue
+        result = neyra.process_command(text)
+        print(result)
+
+
+__all__ = ["run_cli"]


### PR DESCRIPTION
## Summary
- integrate prompt_toolkit in main CLI entrypoint
- provide interactive CLI with tag and slash-command autocompletion
- add Tab key binding to cycle through suggestions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d8c80d108323994daf259717364e