### PR TITLE
feat: add entity hints autocomplete

### DIFF
--- a/src/cli/prompt_cli.py
+++ b/src/cli/prompt_cli.py
@@ -15,17 +15,30 @@ from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.key_binding import KeyBindings
 
 from src.core.neyra_config import TagSystemConfig
+from src.interaction import TagProcessor
 
 
 class _NeyraCompleter(Completer):
-    """Autocomplete tags starting with ``@`` and commands starting with ``/``."""
+    """Autocomplete tags, commands and entity names within tags."""
 
-    def __init__(self, tags: Iterable[str], commands: Iterable[str]) -> None:
+    def __init__(self, tags: Iterable[str], commands: Iterable[str], processor: TagProcessor) -> None:
         self._tags = list(tags)
         self._commands = list(commands)
+        self._processor = processor
 
     def get_completions(self, document, complete_event):  # type: ignore[override]
         text = document.text_before_cursor
+
+        # Detect if the cursor is inside a tag after a colon.  In this case we
+        # provide entity name suggestions and automatically close the tag when a
+        # completion is accepted.
+        tag_match = re.search(r"@[^@:\s]+:\s*([^@]*)$", text)
+        if tag_match:
+            prefix = tag_match.group(1)
+            for suggestion in self._processor.generate_hints(prefix):
+                yield Completion(f"{suggestion}@ ", start_position=-len(prefix))
+            return
+
         word = document.get_word_before_cursor(pattern=re.compile(r"[^\s]+"))
         if not word:
             return
@@ -67,7 +80,8 @@ COMMANDS = [
 def run_cli(neyra) -> None:
     """Run interactive CLI loop for the given :class:`Neyra` instance."""
 
-    completer = _NeyraCompleter(_collect_tags(), COMMANDS)
+    processor = TagProcessor()
+    completer = _NeyraCompleter(_collect_tags(), COMMANDS, processor)
 
     kb = KeyBindings()
 

--- a/src/interaction/tag_processor.py
+++ b/src/interaction/tag_processor.py
@@ -176,6 +176,17 @@ class TagProcessor:
                 pool.append(item)
         return pool
 
+    def generate_hints(self, prefix: str) -> List[str]:
+        """Generate autocomplete hints for entity names.
+
+        This helper simply proxies to :meth:`suggest_entities` but provides a
+        clearer semantic name for callers such as the interactive CLI.  The
+        method collects suggestions from the knowledge base and the recent
+        entity history and returns all entries that begin with ``prefix``.
+        """
+
+        return self.suggest_entities(prefix)
+
     # ------------------------------------------------------------------
     # Style example extraction
     def extract_style_examples(self, text: str) -> List[str]:

--- a/tests/test_interaction/test_tag_processor.py
+++ b/tests/test_interaction/test_tag_processor.py
@@ -50,6 +50,13 @@ def test_suggest_entities(tmp_path) -> None:
     assert "Лили" in suggestions
 
 
+def test_generate_hints(tmp_path) -> None:
+    _prepare_kb(tmp_path)
+    processor = TagProcessor()
+    hints = processor.generate_hints("Л")
+    assert "Лили" in hints
+
+
 def test_extract_style_examples(tmp_path) -> None:
     processor = TagProcessor()
     text = "[Пример стиля автора, из главы 1]\nТишина.\n[Пример окончен]"


### PR DESCRIPTION
## Summary
- expose `generate_hints` in TagProcessor for prefix-based name suggestions
- wire entity suggestions into the CLI autocompleter and auto-close tags on selection
- test helper ensuring hint generation works

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890db0f4bf08323865ea19c0e4c09f7