### PR TITLE
feat(cli): add slash command dispatcher

### DIFF
--- a/src/cli/prompt_cli.py
+++ b/src/cli/prompt_cli.py
@@ -8,13 +8,12 @@ commands like ``/help`` and ``/exit``.  Suggestions are accepted with
 from __future__ import annotations
 
 import re
-from typing import Iterable, List
+from typing import Iterable
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.key_binding import KeyBindings
 
-from src.core.neyra_config import TagSystemConfig
 from src.interaction import TagProcessor
 
 
@@ -54,34 +53,14 @@ class _NeyraCompleter(Completer):
                     yield Completion(f"/{cmd}", start_position=-len(word))
 
 
-def _collect_tags() -> List[str]:
-    """Extract tag names from :class:`TagSystemConfig`."""
-
-    patterns = {**TagSystemConfig.CORE_TAGS, **TagSystemConfig.EXTENDED_TAGS}
-    tags: List[str] = []
-    for pattern in patterns.values():
-        start = pattern.find("@") + 1
-        end = pattern.find(":", start)
-        if start > 0 and end > start:
-            tags.append(pattern[start:end])
-    return tags
-
-
-COMMANDS = [
-    "help",
-    "exit",
-    "внешность",
-    "стиль",
-    "сцена",
-    "сгенерировать",
-]
+COMMANDS = TagProcessor.SLASH_COMMANDS
 
 
 def run_cli(neyra) -> None:
     """Run interactive CLI loop for the given :class:`Neyra` instance."""
 
     processor = TagProcessor()
-    completer = _NeyraCompleter(_collect_tags(), COMMANDS, processor)
+    completer = _NeyraCompleter(TagProcessor.available_tags(), COMMANDS, processor)
 
     kb = KeyBindings()
 
@@ -107,12 +86,12 @@ def run_cli(neyra) -> None:
         clean = text.strip()
         if not clean:
             continue
-        lower = clean.lower()
-        if lower == "/exit":
-            break
-        if lower == "/help":
-            print("Доступные теги:", ", ".join(_collect_tags()))
-            print("Доступные команды:", ", ".join(f"/{c}" for c in COMMANDS))
+        if clean.startswith("/"):
+            result = processor.execute_slash(clean)
+            if result == "__exit__":
+                break
+            if result:
+                print(result)
             continue
         result = neyra.process_command(text)
         print(result)

--- a/src/interaction/tag_processor.py
+++ b/src/interaction/tag_processor.py
@@ -14,7 +14,9 @@ import re
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Deque, Dict, List, Optional
+from typing import Callable, Deque, Dict, List, Optional
+
+from src.core.neyra_config import TagSystemConfig
 
 
 @dataclass
@@ -39,10 +41,28 @@ class TagProcessor:
         Optional language model used when generation is requested.
     """
 
+    SLASH_COMMANDS = [
+        "help",
+        "exit",
+        "внешность",
+        "стиль",
+        "сцена",
+        "сгенерировать",
+    ]
+
     def __init__(self, kb_path: str | Path = "data/knowledge_base", llm: Optional[object] = None) -> None:
         self.kb_path = Path(kb_path)
         self.llm = llm
         self.entity_history: Deque[str] = deque(maxlen=100)
+
+        self._slash_handlers: Dict[str, Callable[[str], Optional[str]]] = {
+            "help": self._cmd_help,
+            "exit": self._cmd_exit,
+            "внешность": lambda arg: self._character_command(arg, "внешность"),
+            "стиль": lambda arg: self._character_command(arg, "стиль"),
+            "сцена": lambda arg: self._character_command(arg, "сцена"),
+            "сгенерировать": self._generate_text,
+        }
 
         index_file = self.kb_path / "index.json"
         if index_file.exists():
@@ -186,6 +206,42 @@ class TagProcessor:
         """
 
         return self.suggest_entities(prefix)
+
+    # ------------------------------------------------------------------
+    # Slash command helpers
+    @staticmethod
+    def available_tags() -> List[str]:
+        patterns = {**TagSystemConfig.CORE_TAGS, **TagSystemConfig.EXTENDED_TAGS}
+        tags: List[str] = []
+        for pattern in patterns.values():
+            start = pattern.find("@") + 1
+            end = pattern.find(":", start)
+            if start > 0 and end > start:
+                tags.append(pattern[start:end])
+        return tags
+
+    def supported_slash_commands(self) -> List[str]:
+        return list(self._slash_handlers.keys())
+
+    def execute_slash(self, command: str) -> Optional[str]:
+        text = command.strip()
+        if text.startswith("/"):
+            text = text[1:]
+        name, _, arg = text.partition(" ")
+        handler = self._slash_handlers.get(name.lower())
+        if not handler:
+            return None
+        result = handler(arg.strip())
+        return result
+
+    def _cmd_help(self, _arg: str) -> str:
+        tags = ", ".join(self.available_tags())
+        cmds = ", ".join(f"/{c}" for c in self.supported_slash_commands())
+        return f"Доступные теги: {tags}\nДоступные команды: {cmds}"
+
+    @staticmethod
+    def _cmd_exit(_arg: str) -> str:
+        return "__exit__"
 
     # ------------------------------------------------------------------
     # Style example extraction

--- a/tests/test_interaction/test_tag_processor.py
+++ b/tests/test_interaction/test_tag_processor.py
@@ -72,3 +72,9 @@ def test_execute_generation_without_llm() -> None:
     output = processor.execute(tag)
     assert "Сгенерируй сцену: лесное приключение" in output
 
+
+def test_execute_slash_generation() -> None:
+    processor = TagProcessor()
+    output = processor.execute_slash("/сгенерировать лес")
+    assert "Сгенерируй сцену: лес" in output
+


### PR DESCRIPTION
## Summary
- expose slash command list and dispatcher in `TagProcessor`
- wire CLI autocomplete to supported `/` commands
- handle `/` commands like `/help` and `/сгенерировать` in CLI loop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890df38d19883238e402d96b9cbe9aa