### PR TITLE
Add dialog controller and scenario tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 import logging
 from pathlib import Path
 from src.core.neyra_brain import Neyra
-from src.cli.prompt_cli import run_cli
+from src.interaction.dialog_controller import DialogController
 
 def setup_logging() -> None:
     """Настраиваю систему для записи того, что думает Нейра"""
@@ -58,7 +58,8 @@ def main() -> None:
             print("Добавьте .txt файлы в папку data/books/ и я их изучу!")
             
         print("\n💫 Нейра готова к работе! Используйте теги для общения.")
-        run_cli(neyra)
+        controller = DialogController(neyra)
+        controller.interact()
         
     except Exception as e:  # pylint: disable=broad-except
         logger.error(f"Ошибка при пробуждении Нейры: {e}")

--- a/src/interaction/__init__.py
+++ b/src/interaction/__init__.py
@@ -2,6 +2,7 @@
 
 from .tag_processor import TagProcessor, ProcessedTag
 from .history import RequestHistory
+from .dialog_controller import DialogController
 
-__all__ = ["TagProcessor", "ProcessedTag", "RequestHistory"]
+__all__ = ["TagProcessor", "ProcessedTag", "RequestHistory", "DialogController"]
 

--- a/src/interaction/dialog_controller.py
+++ b/src/interaction/dialog_controller.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+from typing import Callable, Any
+
+
+class DialogController:
+    """Простейший контроллер диалога, задающий уточняющие вопросы."""
+
+    class Step(Enum):
+        """Шаги взаимодействия с пользователем."""
+
+        WAITING_COMMAND = auto()
+        WAITING_CLARIFICATION = auto()
+        PROCESSING = auto()
+
+    def __init__(
+        self,
+        neyra: Any,
+        input_func: Callable[[str], str] | None = None,
+        output_func: Callable[[str], None] | None = None,
+    ) -> None:
+        self.neyra = neyra
+        self.input_func = input_func or input
+        self.output_func = output_func or print
+        self.step: DialogController.Step = DialogController.Step.WAITING_COMMAND
+
+    def interact(self) -> None:
+        """Запускает цикл диалога."""
+
+        while True:
+            command = self.input_func("> ")
+            if command.strip() == "/exit":
+                break
+            if not command.strip():
+                continue
+
+            self.step = DialogController.Step.WAITING_CLARIFICATION
+            clarification = self.input_func("Уточните, пожалуйста: ")
+
+            full_command = f"{command} {clarification}".strip()
+            self.step = DialogController.Step.PROCESSING
+            result = self.neyra.process_command(full_command)
+            self.output_func(result)
+            self.step = DialogController.Step.WAITING_COMMAND
+
+
+__all__ = ["DialogController"]

--- a/tests/test_interaction/test_dialog_controller.py
+++ b/tests/test_interaction/test_dialog_controller.py
@@ -1,0 +1,50 @@
+from src.interaction.dialog_controller import DialogController
+
+
+class DummyNeyra:
+    def __init__(self):
+        self.commands = []
+        self.state_at_call = None
+
+    def process_command(self, command: str) -> str:
+        self.commands.append(command)
+        return "processed: " + command
+
+
+def test_dialog_flow(capsys):
+    inputs = iter(["привет", "добавь детали", "/exit"])
+    neyra = DummyNeyra()
+    controller = DialogController(neyra)
+    states = []
+
+    def fake_input(prompt: str) -> str:  # noqa: D401 - simple test helper
+        states.append(controller.step)
+        return next(inputs)
+
+    controller.input_func = fake_input
+
+    def patched_process(command: str) -> str:
+        neyra.state_at_call = controller.step
+        return DummyNeyra.process_command(neyra, command)
+
+    neyra.process_command = patched_process  # type: ignore[method-assign]
+
+    controller.interact()
+
+    assert states == [
+        DialogController.Step.WAITING_COMMAND,
+        DialogController.Step.WAITING_CLARIFICATION,
+        DialogController.Step.WAITING_COMMAND,
+    ]
+    assert neyra.state_at_call == DialogController.Step.PROCESSING
+    assert neyra.commands == ["привет добавь детали"]
+    captured = capsys.readouterr()
+    assert "processed: привет добавь детали" in captured.out
+
+
+def test_process_called_once():
+    inputs = iter(["первая", "вторая", "/exit"])
+    neyra = DummyNeyra()
+    controller = DialogController(neyra, input_func=lambda _: next(inputs))
+    controller.interact()
+    assert neyra.commands == ["первая вторая"]


### PR DESCRIPTION
## Summary
- Introduce `DialogController` that asks clarifying questions before processing commands
- Replace CLI usage in `main.py` with the new dialog controller
- Add scenario tests covering controller step transitions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e1d9c0a08323a75a1138f52dea20