### PR TITLE
feat(interface): add rich styling with color toggle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ tqdm>=4.66.0
 click>=8.1.0
 colorama>=0.4.6
 prompt_toolkit>=3.0.0
+rich>=13.0.0
 
 # Качество кода
 pytest>=7.4.0

--- a/src/cli/prompt_cli.py
+++ b/src/cli/prompt_cli.py
@@ -13,6 +13,8 @@ from typing import Iterable
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.key_binding import KeyBindings
+from rich.console import Console
+from rich.panel import Panel
 
 from src.interaction import TagProcessor
 
@@ -56,7 +58,7 @@ class _NeyraCompleter(Completer):
 COMMANDS = TagProcessor.SLASH_COMMANDS
 
 
-def run_cli(neyra) -> None:
+def run_cli(neyra, *, use_color: bool = True) -> None:
     """Run interactive CLI loop for the given :class:`Neyra` instance."""
 
     processor = TagProcessor()
@@ -73,6 +75,7 @@ def run_cli(neyra) -> None:
             buffer.start_completion(select_first=False)
 
     session = PromptSession(completer=completer, key_bindings=kb)
+    console = Console(no_color=not use_color)
 
     print("Введите команды. Используйте /help для помощи, /exit для выхода.")
     while True:
@@ -91,10 +94,18 @@ def run_cli(neyra) -> None:
             if result == "__exit__":
                 break
             if result:
-                print(result)
+                console.print(Panel(result, style="cyan"))
             continue
         result = neyra.process_command(text)
-        print(result)
+        lower = result.lower()
+        if "@" in result:
+            console.print(Panel(result, style="cyan"))
+        elif "эмоци" in lower:
+            console.print(Panel(result, style="magenta"))
+        elif any(word in lower for word in ["опис", "сцена"]):
+            console.print(Panel(result, style="green"))
+        else:
+            console.print(result)
 
 
 __all__ = ["run_cli"]

--- a/src/interaction/dialog_controller.py
+++ b/src/interaction/dialog_controller.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from enum import Enum, auto
 from typing import Callable, Any
 
+from rich.console import Console
+from rich.panel import Panel
+
 
 class DialogController:
     """Простейший контроллер диалога, задающий уточняющие вопросы."""
@@ -22,20 +25,23 @@ class DialogController:
         *,
         exit_command: str = "/exit",
         clarification_prompt: str = "Уточните, пожалуйста: ",
+        use_color: bool = True,
     ) -> None:
         """Создаёт контроллер диалога.
 
         Args:
             neyra: Объект с методом ``process_command``.
             input_func: Функция получения ввода (по умолчанию ``input``).
-            output_func: Функция вывода (по умолчанию ``print``).
+            output_func: Функция вывода (по умолчанию ``rich`` console).
             exit_command: Команда завершения диалога.
             clarification_prompt: Подсказка для уточняющего вопроса.
+            use_color: Включает цветной вывод. Отключите для монохромных терминалов.
         """
 
         self.neyra = neyra
         self.input_func = input_func or input
-        self.output_func = output_func or print
+        self.console = Console(no_color=not use_color)
+        self.output_func = output_func or self._render_output
         self.exit_command = exit_command
         self.clarification_prompt = clarification_prompt
         self.step: DialogController.Step = DialogController.Step.WAITING_COMMAND
@@ -58,6 +64,18 @@ class DialogController:
             result = self.neyra.process_command(full_command)
             self.output_func(result)
             self.step = DialogController.Step.WAITING_COMMAND
+
+    def _render_output(self, message: str) -> None:
+        """Выводит ответ Нейры, выделяя важные части."""
+        lower = message.lower()
+        if "@" in message:
+            self.console.print(Panel(message, style="cyan"))
+        elif "эмоци" in lower:
+            self.console.print(Panel(message, style="magenta"))
+        elif any(word in lower for word in ["опис", "сцена"]):
+            self.console.print(Panel(message, style="green"))
+        else:
+            self.console.print(message)
 
 
 __all__ = ["DialogController"]


### PR DESCRIPTION
## Summary
- integrate rich Console in dialog controller and CLI
- highlight tags, emotions and descriptions in panels
- allow disabling colored output for monochrome terminals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e630baa08323be50dc3fe844afe6