### PR TITLE
feat: add streamlit web app and shared command handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ pip install -r requirements.txt
 python main.py
 ```
 
+### Веб-интерфейс Streamlit
+
+Для запуска минимального веб-клиента используйте команду:
+
+```bash
+streamlit run web/app.py
+```
+
 ## 🔧 Структура "мозга" Нейры
 
 ```

--- a/src/cli/prompt_cli.py
+++ b/src/cli/prompt_cli.py
@@ -16,7 +16,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from rich.console import Console
 from rich.panel import Panel
 
-from src.interaction import TagProcessor
+from src.interaction import TagProcessor, handle_command
 
 
 class _NeyraCompleter(Completer):
@@ -89,23 +89,15 @@ def run_cli(neyra, *, use_color: bool = True) -> None:
         clean = text.strip()
         if not clean:
             continue
-        if clean.startswith("/"):
-            result = processor.execute_slash(clean)
-            if result == "__exit__":
-                break
-            if result:
-                console.print(Panel(result, style="cyan"))
+        result = handle_command(neyra, text, processor)
+        if result.is_exit:
+            break
+        if not result.text:
             continue
-        result = neyra.process_command(text)
-        lower = result.lower()
-        if "@" in result:
-            console.print(Panel(result, style="cyan"))
-        elif "эмоци" in lower:
-            console.print(Panel(result, style="magenta"))
-        elif any(word in lower for word in ["опис", "сцена"]):
-            console.print(Panel(result, style="green"))
+        if result.style:
+            console.print(Panel(result.text, style=result.style))
         else:
-            console.print(result)
+            console.print(result.text)
 
 
 __all__ = ["run_cli"]

--- a/src/interaction/__init__.py
+++ b/src/interaction/__init__.py
@@ -3,6 +3,14 @@
 from .tag_processor import TagProcessor, ProcessedTag
 from .history import RequestHistory
 from .dialog_controller import DialogController
+from .command_handler import CommandResult, handle_command
 
-__all__ = ["TagProcessor", "ProcessedTag", "RequestHistory", "DialogController"]
+__all__ = [
+    "TagProcessor",
+    "ProcessedTag",
+    "RequestHistory",
+    "DialogController",
+    "CommandResult",
+    "handle_command",
+]
 

--- a/src/interaction/command_handler.py
+++ b/src/interaction/command_handler.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Utility helpers for processing user commands.
+
+This module provides :func:`handle_command` which routes user input either
+through the :class:`TagProcessor` slash command system or to the main
+``Neyra`` instance.  The logic was previously embedded in the CLI and is
+now shared with the web interface as well.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .tag_processor import TagProcessor
+
+
+@dataclass
+class CommandResult:
+    """Result returned by :func:`handle_command`.
+
+    Attributes
+    ----------
+    text:
+        Response generated for the user.
+    style:
+        Optional style hint (``cyan``, ``magenta``, ``green``) used by the
+        CLI and the web client for colouring the output.
+    is_exit:
+        Flag indicating that the application should terminate.
+    """
+
+    text: str = ""
+    style: Optional[str] = None
+    is_exit: bool = False
+
+
+def handle_command(neyra, text: str, processor: TagProcessor) -> CommandResult:
+    """Process a single user command."""
+
+    clean = text.strip()
+    if not clean:
+        return CommandResult()
+
+    if clean.startswith("/"):
+        result = processor.execute_slash(clean)
+        if result == "__exit__":
+            return CommandResult(is_exit=True)
+        return CommandResult(text=result or "", style="cyan")
+
+    result = neyra.process_command(text)
+    lower = result.lower()
+    style = None
+    if "@" in result:
+        style = "cyan"
+    elif "эмоци" in lower:
+        style = "magenta"
+    elif any(word in lower for word in ["опис", "сцена"]):
+        style = "green"
+    return CommandResult(text=result, style=style)
+
+
+__all__ = ["CommandResult", "handle_command"]

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,31 @@
+import streamlit as st
+
+from src.core.neyra_brain import Neyra
+from src.interaction import TagProcessor, handle_command
+
+st.title("Нейра в браузере")
+
+if "neyra" not in st.session_state:
+    st.session_state.neyra = Neyra()
+    st.session_state.processor = TagProcessor()
+    st.session_state.history = []
+
+user_input = st.text_input("Введите команду")
+if st.button("Отправить") and user_input:
+    result = handle_command(st.session_state.neyra, user_input, st.session_state.processor)
+    if result.is_exit:
+        st.write("Сессия завершена.")
+    elif result.text:
+        color = {
+            "cyan": "cyan",
+            "magenta": "magenta",
+            "green": "green",
+        }.get(result.style or "", "black")
+        st.markdown(f"<span style='color:{color}'>{result.text}</span>", unsafe_allow_html=True)
+        st.session_state.history.append((user_input, result.text))
+
+if st.session_state.history:
+    st.write("## История")
+    for command, response in st.session_state.history:
+        st.write(f"**> {command}**")
+        st.write(response)


### PR DESCRIPTION
## Summary
- create `handle_command` helper to reuse CLI logic
- add basic Streamlit web interface in `web/app.py`
- document `streamlit run web/app.py` usage

## Testing
- `pip install rich`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890ec49eaa883239418888377f4fd9d