### PR TITLE
Add story models and integrate with memory

### DIFF
--- a/src/action/scene_painter.py
+++ b/src/action/scene_painter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from src.llm.mistral_interface import MistralLLM
+from src.models import Scene
 
 
 class ScenePainter:
@@ -13,9 +14,10 @@ class ScenePainter:
     def __init__(self, llm: Optional[MistralLLM]) -> None:
         self.llm = llm
 
-    def paint(self, description: str, max_tokens: int = 512) -> str:
+    def paint(self, description: str, max_tokens: int = 512) -> Scene:
         """Генерирую сцену через LLM."""
         if self.llm is None:
-            return "🎨 Модель недоступна для генерации сцены"
+            return Scene(description=description, content="🎨 Модель недоступна для генерации сцены")
         prompt = f"Опиши сцену: {description}"
-        return self.llm.generate(prompt, max_tokens=max_tokens)
+        content = self.llm.generate(prompt, max_tokens=max_tokens)
+        return Scene(description=description, content=content)

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -13,6 +13,7 @@ from src.utils.encoding_detector import detect_encoding
 from src.llm.mistral_interface import MistralLLM
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory
+from src.models import Character
 
 
 class Neyra:
@@ -99,12 +100,14 @@ class Neyra:
             if name not in stop_words and len(name) >= 3:
                 if name not in self.characters_memory:
                     self.characters_memory.add(
-                        name,
-                        {
-                            "first_mention": True,
-                            "personality_traits": [],
-                            "emotional_moments": [],
-                        },
+                        Character(
+                            name=name,
+                            personality_traits=[],
+                            emotional_moments=[],
+                            relationships={},
+                            growth_arc=[],
+                            first_mention=True,
+                        )
                     )
         self.characters_memory.save()
 
@@ -192,11 +195,7 @@ class Neyra:
         else:
             # Добавляю нового персонажа
             self.characters_memory.add(
-                name,
-                {
-                    "personality_traits": [],
-                    "emotional_moments": [],
-                },
+                Character(name=name, personality_traits=[], emotional_moments=[])
             )
             self.characters_memory.save()
             return f"👤 Знакомлюсь с {name}! Запоминаю: {action}"

--- a/src/memory/character_memory.py
+++ b/src/memory/character_memory.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
-from typing import Any, Dict
+from typing import Dict
+
+from src.models import Character
 
 
 class CharacterMemory:
@@ -19,7 +21,7 @@ class CharacterMemory:
 
     def __init__(self, storage_path: str | Path | None = None) -> None:
         self.storage_path = Path(storage_path or "data/characters.json")
-        self._data: Dict[str, Dict[str, Any]] = {}
+        self._data: Dict[str, Character] = {}
         self._load()
 
     # ------------------------------------------------------------------
@@ -27,16 +29,20 @@ class CharacterMemory:
         """Load previously saved memory from disk if available."""
         if self.storage_path.exists():
             try:
-                self._data = json.loads(self.storage_path.read_text(encoding="utf-8"))
+                raw_data = json.loads(self.storage_path.read_text(encoding="utf-8"))
+                self._data = {
+                    name: Character.from_dict({"name": name, **info})
+                    for name, info in raw_data.items()
+                }
             except Exception:
                 self._data = {}
 
     # ------------------------------------------------------------------
-    def add(self, name: str, info: Dict[str, Any]) -> None:
+    def add(self, character: Character) -> None:
         """Add or update information about a character."""
-        self._data[name] = info
+        self._data[character.name] = character
 
-    def get(self, name: str | None = None) -> Dict[str, Any] | None:
+    def get(self, name: str | None = None) -> Character | Dict[str, Character] | None:
         """Retrieve information about a character or all characters."""
         if name is None:
             return self._data
@@ -46,7 +52,7 @@ class CharacterMemory:
         """Persist current memory to the storage file."""
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
         self.storage_path.write_text(
-            json.dumps(self._data, ensure_ascii=False, indent=2),
+            json.dumps({name: char.to_dict() for name, char in self._data.items()}, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+from .character import Character
+from .scene import Scene
+from .chapter import Chapter
+
+__all__ = ["Character", "Scene", "Chapter"]

--- a/src/models/chapter.py
+++ b/src/models/chapter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+from .scene import Scene
+
+
+@dataclass
+class Chapter:
+    """Representation of a book chapter."""
+
+    title: str
+    summary: str = ""
+    scenes: List[Scene] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "scenes": [scene.to_dict() for scene in self.scenes],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Chapter":
+        scenes_data = data.get("scenes", [])
+        scenes = [Scene.from_dict(s) for s in scenes_data]
+        return cls(
+            title=data.get("title", ""),
+            summary=data.get("summary", ""),
+            scenes=scenes,
+        )
+
+
+__all__ = ["Chapter"]

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+
+@dataclass
+class Character:
+    """Representation of a story character."""
+
+    name: str
+    personality_traits: List[str] = field(default_factory=list)
+    emotional_moments: List[str] = field(default_factory=list)
+    relationships: Dict[str, str] = field(default_factory=dict)
+    growth_arc: List[str] = field(default_factory=list)
+    first_mention: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the character to a JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "personality_traits": list(self.personality_traits),
+            "emotional_moments": list(self.emotional_moments),
+            "relationships": dict(self.relationships),
+            "growth_arc": list(self.growth_arc),
+            "first_mention": self.first_mention,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Character":
+        """Deserialize a :class:`Character` from a dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            personality_traits=list(data.get("personality_traits", [])),
+            emotional_moments=list(data.get("emotional_moments", [])),
+            relationships=dict(data.get("relationships", {})),
+            growth_arc=list(data.get("growth_arc", [])),
+            first_mention=bool(data.get("first_mention", False)),
+        )
+
+
+__all__ = ["Character"]

--- a/src/models/scene.py
+++ b/src/models/scene.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class Scene:
+    """Representation of a narrative scene."""
+
+    description: str
+    content: str
+    emotion: str = ""
+    style: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "description": self.description,
+            "content": self.content,
+            "emotion": self.emotion,
+            "style": self.style,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Scene":
+        return cls(
+            description=data.get("description", ""),
+            content=data.get("content", ""),
+            emotion=data.get("emotion", ""),
+            style=data.get("style", ""),
+        )
+
+
+__all__ = ["Scene"]

--- a/src/tags/command_executor.py
+++ b/src/tags/command_executor.py
@@ -15,6 +15,7 @@ from src.tags.manager import (
 from src.action.dialogue_master import DialogueMaster
 from src.action.scene_painter import ScenePainter
 from src.action.description_writer import DescriptionWriter
+from src.models import Character, Scene
 
 
 DEFAULT_DIALOGUE_STYLE = "дружеский"
@@ -104,7 +105,8 @@ class CommandExecutor:
         command_lower = command.lower()
 
         if any(word in command_lower for word in ["сцена", "создай сцену", "опиши"]):
-            return self._create_creative_scene(command, context)
+            scene = self._create_creative_scene(command, context)
+            return scene.content
         if any(word in command_lower for word in ["диалог", "разговор", "беседа"]):
             return self._create_smart_dialogue(command, context)
         if any(word in command_lower for word in ["персонаж", "герой", "характер"]):
@@ -113,7 +115,7 @@ class CommandExecutor:
             return self._continue_story(command, context)
         return f"✨ Понимаю: '{command}'. Готова к творчеству!"
 
-    def _create_creative_scene(self, description: str, context: Dict[str, Any]) -> str:
+    def _create_creative_scene(self, description: str, context: Dict[str, Any]) -> Scene:
         emotion = context.get("emotion", "нейтральная")
         style = context.get("style", "современный")
 
@@ -148,7 +150,7 @@ class CommandExecutor:
             emotional_words = self.emotional_palettes[emotion]
             emotion_addition = f" {random.choice(emotional_words)} оттенок"
 
-        return (
+        content = (
             f"🎨 Создаю сцену: {description}\n\n"
             f"{base_scene}.{emotion_addition}\n\n"
             "Детали проявляются постепенно: каждый предмет здесь имеет свою историю, "
@@ -156,6 +158,8 @@ class CommandExecutor:
             "вот-вот произойдет что-то важное.\n\n"
             f"(Эмоция: {emotion}, Стиль: {style})"
         )
+
+        return Scene(description=description, content=content, emotion=emotion, style=style)
 
     def _create_smart_dialogue(self, command: str, context: Dict[str, Any]) -> str:
         characters = context.get("characters", ["Персонаж А", "Персонаж Б"])
@@ -203,17 +207,12 @@ class CommandExecutor:
 
         if self.neyra_brain is not None and hasattr(self.neyra_brain, "characters_memory"):
             memory = self.neyra_brain.characters_memory
-            data = memory.get(name)
-            if data is None:
-                data = {
-                    "personality_traits": [trait],
-                    "emotional_moments": [],
-                    "relationships": {},
-                    "growth_arc": [],
-                }
+            character = memory.get(name)
+            if character is None:
+                character = Character(name=name, personality_traits=[trait])
             else:
-                data["personality_traits"].append(trait)
-            memory.add(name, data)
+                character.personality_traits.append(trait)
+            memory.add(character)
             memory.save()
 
         insights = [
@@ -261,8 +260,10 @@ class CommandExecutor:
     def _build_scene(self, scene_description: str, context: Dict[str, Any]) -> str:
         max_tokens = getattr(self.neyra_brain, "llm_max_tokens", 512)
         if self.scene_painter.llm is not None:
-            return self.scene_painter.paint(scene_description, max_tokens=max_tokens)
-        return self._create_creative_scene(scene_description, context)
+            scene = self.scene_painter.paint(scene_description, max_tokens=max_tokens)
+        else:
+            scene = self._create_creative_scene(scene_description, context)
+        return scene.content
 
     def _write_description(self, description: str, context: Dict[str, Any]) -> str:
         max_tokens = getattr(self.neyra_brain, "llm_max_tokens", 512)


### PR DESCRIPTION
## Summary
- Introduced dataclasses for `Character`, `Scene` and `Chapter` models with serialization helpers
- Refactored command execution and scene painting to build objects using the new models
- Migrated character memory to persist model instances instead of raw dicts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f8d60f20832398ab208be192d330