### PR TITLE
refactor: introduce BaseGenerator for text helpers

### DIFF
--- a/src/action/base_generator.py
+++ b/src/action/base_generator.py
@@ -1,0 +1,38 @@
+"""Shared base class for simple text generation helpers."""
+from __future__ import annotations
+
+from typing import Optional
+
+from src.llm.mistral_interface import MistralLLM
+
+
+class BaseGenerator:
+    """Utility class that wraps an optional LLM with a prompt template.
+
+    Subclasses provide a ``template`` that is used to format incoming prompts.
+    The :meth:`generate` method then handles calling the LLM or returning a
+    fallback when the LLM is not available.
+    """
+
+    def __init__(self, llm: Optional[MistralLLM], template: str) -> None:
+        self.llm = llm
+        self.template = template
+
+    def generate(
+        self, prompt: str, fallback_text: str, max_tokens: int = 512
+    ) -> str:
+        """Generate text using the LLM if available.
+
+        Parameters
+        ----------
+        prompt:
+            The core idea or command to feed into the template.
+        fallback_text:
+            Text returned when ``llm`` is ``None``.
+        max_tokens:
+            Maximum amount of tokens for the generation.
+        """
+        if self.llm is None:
+            return fallback_text
+        formatted_prompt = self.template.format(prompt=prompt)
+        return self.llm.generate(formatted_prompt, max_tokens=max_tokens)

--- a/src/action/description_writer.py
+++ b/src/action/description_writer.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 from typing import Optional
 
 from src.llm.mistral_interface import MistralLLM
+from .base_generator import BaseGenerator
 
 
-class DescriptionWriter:
+class DescriptionWriter(BaseGenerator):
     """Создает повествовательные описания с помощью LLM."""
 
     def __init__(self, llm: Optional[MistralLLM]) -> None:
-        self.llm = llm
+        super().__init__(llm, template="Опиши: {prompt}")
 
     def write(self, description: str, max_tokens: int = 512) -> str:
         """Сгенерировать описание для указанной идеи."""
-        if self.llm is None:
-            return f"📜 Описание: {description}"
-        prompt = f"Опиши: {description}"
-        return self.llm.generate(prompt, max_tokens=max_tokens)
+        fallback = f"📜 Описание: {description}"
+        return self.generate(description, fallback, max_tokens=max_tokens)

--- a/src/action/dialogue_master.py
+++ b/src/action/dialogue_master.py
@@ -5,17 +5,16 @@ from __future__ import annotations
 from typing import Optional
 
 from src.llm.mistral_interface import MistralLLM
+from .base_generator import BaseGenerator
 
 
-class DialogueMaster:
+class DialogueMaster(BaseGenerator):
     """Помогаю героям говорить живо."""
 
     def __init__(self, llm: Optional[MistralLLM]) -> None:
-        self.llm = llm
+        super().__init__(llm, template="Сгенерируй диалог: {prompt}")
 
     def create(self, command: str, max_tokens: int = 512) -> str:
         """Создаю диалог с помощью LLM, если она доступна."""
-        if self.llm is None:
-            return "💬 Модель недоступна для генерации диалога"
-        prompt = f"Сгенерируй диалог: {command}"
-        return self.llm.generate(prompt, max_tokens=max_tokens)
+        fallback = "💬 Модель недоступна для генерации диалога"
+        return self.generate(command, fallback, max_tokens=max_tokens)

--- a/src/action/scene_painter.py
+++ b/src/action/scene_painter.py
@@ -6,18 +6,17 @@ from typing import Optional
 
 from src.llm.mistral_interface import MistralLLM
 from src.models import Scene
+from .base_generator import BaseGenerator
 
 
-class ScenePainter:
+class ScenePainter(BaseGenerator):
     """Создаю яркие описания сцен."""
 
     def __init__(self, llm: Optional[MistralLLM]) -> None:
-        self.llm = llm
+        super().__init__(llm, template="Опиши сцену: {prompt}")
 
     def paint(self, description: str, max_tokens: int = 512) -> Scene:
         """Генерирую сцену через LLM."""
-        if self.llm is None:
-            return Scene(description=description, content="🎨 Модель недоступна для генерации сцены")
-        prompt = f"Опиши сцену: {description}"
-        content = self.llm.generate(prompt, max_tokens=max_tokens)
+        fallback = "🎨 Модель недоступна для генерации сцены"
+        content = self.generate(description, fallback, max_tokens=max_tokens)
         return Scene(description=description, content=content)


### PR DESCRIPTION
## Summary
- add BaseGenerator class centralizing LLM calls with prompt templates
- refactor DescriptionWriter, ScenePainter, and DialogueMaster to extend BaseGenerator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fb003a4c83238950ce3f07063fcf