### PR TITLE
Add caching for book loading and analysis

### DIFF
--- a/docs/cache_invalidation.md
+++ b/docs/cache_invalidation.md
@@ -1,0 +1,20 @@
+# Cache invalidation
+
+`CacheManager` stores JSON files inside the `.cache` directory and mirrors the
+content in memory. It is used for:
+
+- loading books (`Neyra.load_book`)
+- analysing books (`memory.knowledge_base.analyze_book`)
+- generating scenes (`Neyra._create_scene`)
+
+## Invalidation rules
+
+- Entries related to book files (`load_book` and `analyze_book`) include the
+  file modification time. If the file on disk changes, the cached value is
+  ignored and recomputed automatically.
+- Scene generation is cached by the description string and persists until
+  explicitly cleared.
+- Use `CacheManager.invalidate(key)` to drop a specific entry or
+  `CacheManager.invalidate()` to clear the whole cache.
+
+All cache files live in the project root under `.cache/`.

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,3 @@
+from .cache_manager import CacheManager
+
+__all__ = ["CacheManager"]

--- a/src/core/cache_manager.py
+++ b/src/core/cache_manager.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+class CacheManager:
+    """Simple JSON file-based cache with optional in-memory layer.
+
+    Entries are stored as JSON files in ``cache_dir`` and mirrored in memory
+    for the lifetime of the process.  Call :py:meth:`invalidate` to remove
+    specific entries or to clear the whole cache.
+    """
+
+    def __init__(self, cache_dir: str | Path = ".cache") -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(exist_ok=True)
+        self._memory: dict[str, Any] = {}
+
+    def _path_for(self, key: str) -> Path:
+        hashed = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self.cache_dir / f"{hashed}.json"
+
+    def get(self, key: str) -> Any | None:
+        if key in self._memory:
+            return self._memory[key]
+        path = self._path_for(key)
+        if path.exists():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                return None
+            self._memory[key] = data
+            return data
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        self._memory[key] = value
+        path = self._path_for(key)
+        path.write_text(json.dumps(value, ensure_ascii=False), encoding="utf-8")
+
+    def invalidate(self, key: str | None = None) -> None:
+        """Remove a single cached entry or clear the whole cache."""
+        if key is None:
+            self._memory.clear()
+            for file in self.cache_dir.glob("*.json"):
+                try:
+                    file.unlink()
+                except FileNotFoundError:
+                    pass
+        else:
+            self._memory.pop(key, None)
+            path = self._path_for(key)
+            if path.exists():
+                path.unlink()

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -14,6 +14,7 @@ from src.llm.mistral_interface import MistralLLM
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory
 from src.models import Character
+from src.core.cache_manager import CacheManager
 
 
 class Neyra:
@@ -31,6 +32,7 @@ class Neyra:
         self.characters_memory = CharacterMemory()
         self.emotional_state = "любопытная"
         self.history = RequestHistory()
+        self.cache = CacheManager()
 
         self.logger.info("Нейра проснулась! ✨")
 
@@ -70,6 +72,14 @@ class Neyra:
                 self.logger.warning(f"Книга не найдена: {path}")
                 return
 
+            cache_key = f"load_book:{file_path}"
+            mtime = file_path.stat().st_mtime
+            cached = self.cache.get(cache_key)
+            if cached and cached.get("mtime") == mtime:
+                self.known_books.append(path)
+                print(f"📚 Изучила книгу из кэша: {file_path.name}")
+                return
+
             # Определяю кодировку
             encoding = detect_encoding(path)
             content = file_path.read_text(encoding=encoding)
@@ -81,6 +91,8 @@ class Neyra:
             print(f"   Страниц текста: {len(content) // 2000}")
             if self.characters_memory:
                 print(f"   Встретила персонажей: {len(self.characters_memory)}")
+
+            self.cache.set(cache_key, {"mtime": mtime})
 
         except Exception as e:
             self.logger.error(f"Ошибка при загрузке {path}: {e}")
@@ -161,16 +173,22 @@ class Neyra:
 
     def _create_scene(self, description: str) -> str:
         """Создаю сцену с творческим подходом."""
+        cache_key = f"scene:{description}"
+        cached = self.cache.get(cache_key)
+        if cached:
+            return cached
         templates = [
             "Туман стелился по земле, скрывая тайны наступающего утра...",
             "В комнате царила та особенная тишина, которая предшествует важным разговорам...",
-            "Солнечные лучи пробивались сквозь листву, создавая причудливую игру света и тени..."
+            "Солнечные лучи пробивались сквозь листву, создавая причудливую игру света и тени...",
         ]
-
         import random
         base_scene = random.choice(templates)
-
-        return f"🎨 Создаю сцену: {description}\n\n{base_scene}\n\n(Это базовый пример - скоро я научусь создавать уникальные сцены!)"
+        scene = (
+            f"🎨 Создаю сцену: {description}\n\n{base_scene}\n\n(Это базовый пример - скоро я научусь создавать уникальные сцены!)"
+        )
+        self.cache.set(cache_key, scene)
+        return scene
 
     def _create_dialogue(self, description: str) -> str:
         """Создаю диалог как временную заглушку."""

--- a/src/memory/knowledge_base.py
+++ b/src/memory/knowledge_base.py
@@ -18,8 +18,11 @@ import re
 from pathlib import Path
 from typing import Dict, List
 
+from src.core.cache_manager import CacheManager
+
 # Root directory for knowledge base artefacts
 KB_ROOT = Path("data/knowledge_base")
+cache = CacheManager()
 
 
 def _split_chapters(text: str) -> Dict[str, str]:
@@ -76,6 +79,11 @@ def analyze_book(file_path: str) -> Dict[str, Dict[str, str]]:
     path = Path(file_path)
     if not path.exists():
         raise FileNotFoundError(f"Book file not found: {file_path}")
+    mtime = path.stat().st_mtime
+    cache_key = f"analyze_book:{path}"
+    cached = cache.get(cache_key)
+    if cached and cached.get("mtime") == mtime:
+        return cached["data"]
     try:
         text = path.read_text(encoding="utf-8")
     except Exception as exc:
@@ -129,12 +137,14 @@ def analyze_book(file_path: str) -> Dict[str, Dict[str, str]]:
         encoding="utf-8",
     )
 
-    return {
+    data = {
         "characters": characters,
         "locations": locations,
         "style_examples": style_examples,
         "index": index,
     }
+    cache.set(cache_key, {"mtime": mtime, "data": data})
+    return data
 
 
 __all__ = ["analyze_book"]


### PR DESCRIPTION
## Summary
- add CacheManager with JSON file-backed cache and invalidation
- cache book loading, analysis and scene generation
- document cache invalidation rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890fe01e51c8323af01a104b2b5ec7f