### PR TITLE
feat: add simple chat mode with context memory

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 import logging
 from pathlib import Path
 from src.core.neyra_brain import Neyra
-from src.interaction.dialog_controller import DialogController
+from src.interaction import ChatSession
 
 def setup_logging() -> None:
     """Настраиваю систему для записи того, что думает Нейра"""
@@ -58,8 +58,10 @@ def main() -> None:
             print("Добавьте .txt файлы в папку data/books/ и я их изучу!")
             
         print("\n💫 Нейра готова к работе! Используйте теги для общения.")
-        controller = DialogController(neyra)
-        controller.interact()
+        # По умолчанию запускаем интерактивный режим с поддержкой чата.
+        # Диалоговый контроллер оставляем для обратной совместимости.
+        chat = ChatSession(neyra)
+        chat.chat_loop()
         
     except Exception as e:  # pylint: disable=broad-except
         logger.error(f"Ошибка при пробуждении Нейры: {e}")

--- a/src/interaction/__init__.py
+++ b/src/interaction/__init__.py
@@ -4,6 +4,7 @@ from .tag_processor import TagProcessor, ProcessedTag
 from .history import RequestHistory
 from .dialog_controller import DialogController
 from .command_handler import CommandResult, handle_command
+from .chat_session import ChatSession, ChatEntry
 
 __all__ = [
     "TagProcessor",
@@ -12,5 +13,7 @@ __all__ = [
     "DialogController",
     "CommandResult",
     "handle_command",
+    "ChatSession",
+    "ChatEntry",
 ]
 

--- a/src/interaction/chat_session.py
+++ b/src/interaction/chat_session.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Lightweight chat interface with context memory.
+
+This module introduces :class:`ChatSession` which provides a very small
+stateful layer on top of the existing tag based command system.  It allows
+users to talk with Neyra in a conversational manner.  The session keeps track
+of the last referenced character and automatically expands follow‑up questions
+into proper tags.  The classic tag logic remains untouched – the chat simply
+adds a convenience layer around it.
+"""
+
+from dataclasses import dataclass
+import re
+from typing import List, Optional
+
+from .command_handler import handle_command
+from .tag_processor import TagProcessor
+
+
+@dataclass
+class ChatEntry:
+    """Single message in the conversation history."""
+
+    speaker: str
+    text: str
+
+
+class ChatSession:
+    """Interact with Neyra in a dialogue style.
+
+    Parameters
+    ----------
+    neyra:
+        Instance capable of processing commands via ``process_command``.
+    processor:
+        Optional shared :class:`TagProcessor`.  If not supplied, a new instance
+        is created.  Keeping a single processor allows autocompletion data and
+        history to be reused between calls.
+    """
+
+    def __init__(self, neyra, processor: Optional[TagProcessor] = None) -> None:
+        self.neyra = neyra
+        self.processor = processor or TagProcessor()
+        self.history: List[ChatEntry] = []
+        self._last_character: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    def ask(self, message: str) -> str:
+        """Send ``message`` to Neyra and return her response."""
+
+        prepared = self._prepare_message(message)
+        result = handle_command(self.neyra, prepared, self.processor)
+
+        # Track conversation history
+        self.history.append(ChatEntry("user", message))
+        self.history.append(ChatEntry("neyra", result.text))
+
+        # Update context based on tags in the prepared message
+        tags = self.processor.parse(prepared)
+        for tag in tags:
+            if tag.type == "character_work" and tag.subject:
+                self._last_character = tag.subject
+
+        return result.text
+
+    def chat_loop(self, *, input_func=input, output_func=print) -> None:  # pragma: no cover - interactive
+        """Run an interactive loop until the user enters ``/exit``."""
+
+        while True:
+            user_text = input_func("\n> ")
+            if not user_text.strip():
+                continue
+            if user_text.strip() == "/exit":
+                break
+            response = self.ask(user_text)
+            if response:
+                output_func(response)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _prepare_message(self, message: str) -> str:
+        """Return a command string suitable for ``handle_command``.
+
+        The function first checks whether the message already contains tags.  If
+        it does, it is returned as‑is.  Otherwise a few simple heuristics are
+        applied to map natural language questions to tags.  Currently supported
+        patterns are intentionally small but showcase how context can be
+        extended without modifying the underlying tag system.
+        """
+
+        # If message already uses tags – nothing to do
+        if self.processor.parse(message):
+            return message
+
+        # Pattern: "как выглядел <имя>" or "расскажи как выглядит <имя>"
+        m = re.search(r"(?:как\s+)?выглядел[аи]?\s+(?P<name>[\w-]+)", message, re.IGNORECASE)
+        if m:
+            name = m.group("name")
+            self._last_character = name
+            return f"@Персонаж: {name} - внешность@"
+
+        # Follow‑up question about the last character: "как он говорит" etc.
+        if self._last_character is not None:
+            if re.search(r"как\s+он\s+говорит", message, re.IGNORECASE):
+                return f"@Персонаж: {self._last_character} - манера речи@"
+            if re.search(r"как\s+он\s+выгляд", message, re.IGNORECASE):
+                return f"@Персонаж: {self._last_character} - внешность@"
+
+        # Default: treat as a direct command to Neyra
+        return f"@Нейра: {message}@"
+
+
+__all__ = ["ChatSession", "ChatEntry"]

--- a/tests/test_interaction/test_chat_session.py
+++ b/tests/test_interaction/test_chat_session.py
@@ -1,0 +1,18 @@
+from src.core.neyra_brain import Neyra
+from src.interaction import ChatSession
+
+
+def test_chat_session_follows_character_context():
+    """Follow-up questions should reuse last mentioned character."""
+    neyra = Neyra()
+    chat = ChatSession(neyra)
+
+    first = chat.ask("Расскажи, как выглядел Вилл")
+    assert "Вилл" in first
+
+    second = chat.ask("А как он говорит?")
+    assert "Вилл" in second
+    assert any(word in second.lower() for word in ["говор", "реч"])
+
+    # Two user messages and two Neyra responses
+    assert len(chat.history) == 4


### PR DESCRIPTION
## Summary
- introduce ChatSession for conversational interaction with simple context memory
- expose chat utilities and switch main entrypoint to use the chat loop
- cover chat context tracking with tests

## Testing
- `pip install rich`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891099fc628832399d123e5ccb4b852