### PR TITLE
Add LLM base class and factory

### DIFF
--- a/src/action/base_generator.py
+++ b/src/action/base_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from src.llm.mistral_interface import MistralLLM
+from src.llm import BaseLLM
 
 
 class BaseGenerator:
@@ -14,7 +14,7 @@ class BaseGenerator:
     fallback when the LLM is not available.
     """
 
-    def __init__(self, llm: Optional[MistralLLM], template: str) -> None:
+    def __init__(self, llm: Optional[BaseLLM], template: str) -> None:
         self.llm = llm
         self.template = template
 

--- a/src/action/description_writer.py
+++ b/src/action/description_writer.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from src.llm.mistral_interface import MistralLLM
+from src.llm import BaseLLM
 from .base_generator import BaseGenerator
 
 
 class DescriptionWriter(BaseGenerator):
     """Создает повествовательные описания с помощью LLM."""
 
-    def __init__(self, llm: Optional[MistralLLM]) -> None:
+    def __init__(self, llm: Optional[BaseLLM]) -> None:
         super().__init__(llm, template="Опиши: {prompt}")
 
     def write(self, description: str, max_tokens: int = 512) -> str:

--- a/src/action/dialogue_master.py
+++ b/src/action/dialogue_master.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from src.llm.mistral_interface import MistralLLM
+from src.llm import BaseLLM
 from .base_generator import BaseGenerator
 
 
 class DialogueMaster(BaseGenerator):
     """Помогаю героям говорить живо."""
 
-    def __init__(self, llm: Optional[MistralLLM]) -> None:
+    def __init__(self, llm: Optional[BaseLLM]) -> None:
         super().__init__(llm, template="Сгенерируй диалог: {prompt}")
 
     def create(self, command: str, max_tokens: int = 512) -> str:

--- a/src/action/scene_painter.py
+++ b/src/action/scene_painter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from src.llm.mistral_interface import MistralLLM
+from src.llm import BaseLLM
 from src.models import Scene
 from .base_generator import BaseGenerator
 
@@ -12,7 +12,7 @@ from .base_generator import BaseGenerator
 class ScenePainter(BaseGenerator):
     """Создаю яркие описания сцен."""
 
-    def __init__(self, llm: Optional[MistralLLM]) -> None:
+    def __init__(self, llm: Optional[BaseLLM]) -> None:
         super().__init__(llm, template="Опиши сцену: {prompt}")
 
     def paint(self, description: str, max_tokens: int = 512) -> Scene:

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -10,7 +10,7 @@ from src.tags.tag_parser import TagParser, Tag
 from src.tags.command_executor import CommandExecutor
 from src.core.neyra_config import NEYRA_GREETING, NeyraPersonality
 from src.utils.encoding_detector import detect_encoding
-from src.llm.mistral_interface import MistralLLM
+from src.llm import BaseLLM, LLMFactory
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory
 from src.models import Character
@@ -36,16 +36,17 @@ class Neyra:
 
         self.logger.info("Нейра проснулась! ✨")
 
-    def _load_llm(self) -> MistralLLM | None:
+    def _load_llm(self) -> BaseLLM | None:
         """Загружаю локальную LLM при наличии конфига."""
         config_path = Path("config/llm_config.json")
         if not config_path.exists():
             return None
         try:
             cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            model_type = cfg.get("model_type", "mistral")
             model_path = cfg.get("model_path")
             self.llm_max_tokens = int(cfg.get("max_tokens", 512))
-            return MistralLLM(model_path)
+            return LLMFactory.create(model_type, model_path=model_path)
         except Exception as e:  # pragma: no cover
             self.logger.error(f"Ошибка загрузки LLM: {e}")
             return None

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,5 +1,6 @@
 """LLM interfaces for Neyra."""
 
+from .base_llm import BaseLLM, LLMFactory
 from .mistral_interface import MistralLLM
 
-__all__ = ["MistralLLM"]
+__all__ = ["BaseLLM", "LLMFactory", "MistralLLM"]

--- a/src/llm/base_llm.py
+++ b/src/llm/base_llm.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Type
+
+
+class BaseLLM(ABC):
+    """Abstract base class for all LLM implementations."""
+
+    model_name: str
+
+    @abstractmethod
+    def generate(self, prompt: str, max_tokens: int = 512) -> str:
+        """Generate text based on ``prompt``."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def is_available(cls) -> bool:
+        """Return ``True`` if the backend dependencies are installed."""
+        raise NotImplementedError
+
+
+class LLMFactory:
+    """Factory for creating LLM instances by ``model_type``."""
+
+    _registry: Dict[str, Type[BaseLLM]] = {}
+
+    @classmethod
+    def register(cls, model_type: str, llm_cls: Type[BaseLLM]) -> None:
+        """Register an ``llm_cls`` under ``model_type``."""
+        cls._registry[model_type] = llm_cls
+
+    @classmethod
+    def create(cls, model_type: str, **kwargs: Any) -> BaseLLM:
+        """Instantiate the LLM associated with ``model_type``."""
+        llm_cls = cls._registry.get(model_type)
+        if llm_cls is None:
+            raise ValueError(f"Unknown model_type: {model_type}")
+        if not llm_cls.is_available():
+            raise RuntimeError(f"{llm_cls.model_name} is not available")
+        return llm_cls(**kwargs)

--- a/src/llm/mistral_interface.py
+++ b/src/llm/mistral_interface.py
@@ -1,6 +1,8 @@
 """Mistral LLM interface using llama-cpp-python."""
 from __future__ import annotations
 
+from .base_llm import BaseLLM, LLMFactory
+
 # The real implementation relies on ``llama_cpp`` which may not be available
 # in lightweight environments (like the test environment for this kata).
 # Import the class lazily and provide a helpful fallback so that the module can
@@ -12,8 +14,10 @@ except ModuleNotFoundError:  # pragma: no cover
     Llama = None  # type: ignore
 
 
-class MistralLLM:
+class MistralLLM(BaseLLM):
     """Wrapper around a local Mistral GGUF model."""
+
+    model_name = "mistral"
 
     def __init__(self, model_path: str) -> None:
         if Llama is None:
@@ -33,3 +37,11 @@ class MistralLLM:
             raise RuntimeError("llama_cpp is required to use MistralLLM")
         result = self.model(prompt, max_tokens=max_tokens, stop=["</s>"])
         return result["choices"][0]["text"].strip()
+
+    @classmethod
+    def is_available(cls) -> bool:  # pragma: no cover - simple availability check
+        return Llama is not None
+
+
+# Register the implementation in the factory
+LLMFactory.register("mistral", MistralLLM)


### PR DESCRIPTION
## Summary
- introduce `BaseLLM` abstract class and `LLMFactory` for modular language model loading
- export new interfaces and refactor generators to consume generic `BaseLLM`
- load models through `LLMFactory` in `Neyra` brain

## Testing
- `pip install rich -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911a4938dc83238d06d7f0cb01fa9c