### PR TITLE
feat: add lazy Mistral loading and configurable generation

### DIFF
--- a/src/llm/base_llm.py
+++ b/src/llm/base_llm.py
@@ -14,11 +14,15 @@ class BaseLLM(ABC):
         """Generate text based on ``prompt``."""
         raise NotImplementedError
 
-    @classmethod
     @abstractmethod
-    def is_available(cls) -> bool:
-        """Return ``True`` if the backend dependencies are installed."""
+    def is_available(self) -> bool:
+        """Return ``True`` if the model has been loaded successfully."""
         raise NotImplementedError
+
+    @classmethod
+    def is_backend_available(cls) -> bool:  # pragma: no cover - simple availability check
+        """Return ``True`` if the backend dependencies are installed."""
+        return True
 
 
 class LLMFactory:
@@ -37,6 +41,6 @@ class LLMFactory:
         llm_cls = cls._registry.get(model_type)
         if llm_cls is None:
             raise ValueError(f"Unknown model_type: {model_type}")
-        if not llm_cls.is_available():
+        if not llm_cls.is_backend_available():
             raise RuntimeError(f"{llm_cls.model_name} is not available")
         return llm_cls(**kwargs)

--- a/src/llm/mistral_interface.py
+++ b/src/llm/mistral_interface.py
@@ -1,6 +1,9 @@
 """Mistral LLM interface using llama-cpp-python."""
 from __future__ import annotations
 
+import logging
+from typing import Iterable, Optional
+
 from .base_llm import BaseLLM, LLMFactory
 
 # The real implementation relies on ``llama_cpp`` which may not be available
@@ -14,32 +17,108 @@ except ModuleNotFoundError:  # pragma: no cover
     Llama = None  # type: ignore
 
 
+logger = logging.getLogger(__name__)
+
+
 class MistralLLM(BaseLLM):
     """Wrapper around a local Mistral GGUF model."""
 
     model_name = "mistral"
 
-    def __init__(self, model_path: str) -> None:
-        if Llama is None:
-            raise RuntimeError("llama_cpp is required to use MistralLLM")
-        self.model = Llama(
-            model_path=model_path,
-            n_ctx=2048,
-            n_gpu_layers=32,  # Можно уменьшить до 20–24 при нехватке памяти
-            n_threads=6,
-            use_mlock=True,
-            verbose=False,
-        )
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        n_gpu_layers: int = 0,
+        n_ctx: int = 2048,
+        n_batch: int = 512,
+        use_mmap: bool = True,
+        use_mlock: bool = False,
+        seed: int = 0,
+    ) -> None:
+        """Store configuration for later lazy loading.
 
-    def generate(self, prompt: str, max_tokens: int = 512) -> str:
-        """Generate text from the given prompt."""
+        Parameters mirror those of :class:`llama_cpp.Llama` so that tests can
+        verify we pass the expected values even though the heavy dependency is
+        not actually loaded in the test environment.
+        """
+
+        self.model_path = model_path
+        self.n_gpu_layers = n_gpu_layers
+        self.n_ctx = n_ctx
+        self.n_batch = n_batch
+        self.use_mmap = use_mmap
+        self.use_mlock = use_mlock
+        self.seed = seed
+
+        self.model: Optional["Llama"] = None
+        self._load_error: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    def _load_model(self) -> None:
+        """Load the underlying ``Llama`` model if it hasn't been loaded yet."""
+
+        if self.model is not None:
+            return
         if Llama is None:
-            raise RuntimeError("llama_cpp is required to use MistralLLM")
-        result = self.model(prompt, max_tokens=max_tokens, stop=["</s>"])
+            self._load_error = "llama_cpp is required to use MistralLLM"
+            logger.error(self._load_error)
+            return
+
+        try:
+            logger.info("Loading Mistral model from %s", self.model_path)
+            self.model = Llama(
+                model_path=self.model_path,
+                n_gpu_layers=self.n_gpu_layers,
+                n_ctx=self.n_ctx,
+                n_batch=self.n_batch,
+                use_mmap=self.use_mmap,
+                use_mlock=self.use_mlock,
+                seed=self.seed,
+                verbose=False,
+            )
+            logger.info("Mistral model loaded successfully")
+            self._load_error = None
+        except Exception as exc:  # pragma: no cover - error handling
+            self._load_error = str(exc)
+            logger.exception("Failed to load Mistral model: %s", exc)
+            self.model = None
+
+    def is_available(self) -> bool:
+        """Return ``True`` if the model has been loaded successfully."""
+
+        return self.model is not None and self._load_error is None
+
+    # ------------------------------------------------------------------
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 512,
+        temperature: float = 0.8,
+        top_p: float = 0.95,
+        repeat_penalty: float = 1.1,
+        stop: Optional[Iterable[str]] = None,
+    ) -> str:
+        """Generate text from the given ``prompt`` using the loaded model."""
+
+        self._load_model()
+        if not self.is_available():
+            raise RuntimeError(self._load_error or "model failed to load")
+
+        result = self.model(  # type: ignore[call-arg]
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            repeat_penalty=repeat_penalty,
+            stop=stop or ["</s>"],
+        )
         return result["choices"][0]["text"].strip()
 
+    # ------------------------------------------------------------------
     @classmethod
-    def is_available(cls) -> bool:  # pragma: no cover - simple availability check
+    def is_backend_available(cls) -> bool:  # pragma: no cover - simple availability check
         return Llama is not None
 
 

--- a/tests/test_llm_mistral.py
+++ b/tests/test_llm_mistral.py
@@ -1,0 +1,70 @@
+"""Tests for :mod:`src.llm.mistral_interface`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from src.llm import mistral_interface as mi
+
+
+def test_lazy_loading_and_generation(monkeypatch) -> None:
+    """The model should load lazily and honour generation parameters."""
+
+    calls: Dict[str, Dict[str, Any]] = {}
+
+    class DummyLlama:
+        def __init__(self, **kwargs: Any) -> None:  # pragma: no cover - simple dummy
+            calls["init"] = kwargs
+
+        def __call__(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+            calls["call"] = {"prompt": prompt, **kwargs}
+            return {"choices": [{"text": "response"}]}
+
+    monkeypatch.setattr(mi, "Llama", DummyLlama)
+
+    llm = mi.MistralLLM(
+        "model.gguf",
+        n_gpu_layers=1,
+        n_ctx=256,
+        n_batch=8,
+        use_mmap=False,
+        use_mlock=True,
+        seed=123,
+    )
+
+    assert not llm.is_available()
+
+    text = llm.generate(
+        "Hello",
+        max_tokens=5,
+        temperature=0.6,
+        top_p=0.7,
+        repeat_penalty=1.2,
+        stop=["END"],
+    )
+
+    assert text == "response"
+    assert llm.is_available()
+
+    # Ensure correct initialisation parameters were passed to Llama
+    assert calls["init"] == {
+        "model_path": "model.gguf",
+        "n_gpu_layers": 1,
+        "n_ctx": 256,
+        "n_batch": 8,
+        "use_mmap": False,
+        "use_mlock": True,
+        "seed": 123,
+        "verbose": False,
+    }
+
+    # And generation parameters were forwarded correctly
+    assert calls["call"] == {
+        "prompt": "Hello",
+        "max_tokens": 5,
+        "temperature": 0.6,
+        "top_p": 0.7,
+        "repeat_penalty": 1.2,
+        "stop": ["END"],
+    }
+


### PR DESCRIPTION
## Summary
- refactor MistralLLM to lazily load models with GPU-related settings and robust error handling
- allow dynamic generation controls like temperature, top_p, repeat_penalty, and custom stop tokens
- update base LLM interface and factory to support instance availability checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911ca70b1c8323aa42543918ff1ad0