### PR TITLE
Add scripts for model loading and feature demos

### DIFF
--- a/config/llm_config.json
+++ b/config/llm_config.json
@@ -1,4 +1,4 @@
 {
-  "model_path": "models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf",
+  "model_path": "models/qwen/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
   "max_tokens": 512
 }

--- a/scripts/download_qwen.py
+++ b/scripts/download_qwen.py
@@ -1,0 +1,76 @@
+
+"""Download the Qwen‑2.5 GGUF model and update configuration.
+
+The script fetches a lightweight variant of the Qwen‑2.5 Instruct model in
+GGUF format and stores it under ``models/qwen``. After a successful download
+``config/llm_config.json`` is updated so that subsequent runs of Neyra use the
+new model.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import requests
+from tqdm import tqdm
+
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_URL = (
+    "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/"
+    "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+)
+MODEL_DIR = ROOT / "models" / "qwen"
+MODEL_PATH = MODEL_DIR / "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf"
+CONFIG_PATH = ROOT / "config" / "llm_config.json"
+
+
+def download() -> None:
+    """Download the GGUF model if it is not already present."""
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    if MODEL_PATH.exists():
+        print(f"Model already exists at {MODEL_PATH}")
+        return
+
+    with requests.get(MODEL_URL, stream=True) as r:
+        r.raise_for_status()
+        total = int(r.headers.get("content-length", 0))
+        with open(MODEL_PATH, "wb") as f, tqdm(
+            total=total, unit="B", unit_scale=True, desc="Downloading"
+        ) as pbar:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+                    pbar.update(len(chunk))
+
+    print("Download complete.")
+
+
+def update_config() -> None:
+    """Point ``llm_config.json`` to the downloaded model."""
+
+    if not CONFIG_PATH.exists():
+        print(f"Config file {CONFIG_PATH} not found")
+        return
+
+    cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    cfg["model_path"] = str(MODEL_PATH)
+    CONFIG_PATH.write_text(
+        json.dumps(cfg, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"Updated config to use {MODEL_PATH}")
+
+
+def main() -> None:
+    download()
+    update_config()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    sys.exit(main())
+

--- a/scripts/test_all_features.py
+++ b/scripts/test_all_features.py
@@ -1,0 +1,80 @@
+
+"""Run a small showcase of Neyra's capabilities.
+
+The script exercises the local LLM, persistent memory, the tagging system and
+action oriented features such as dialogue and scene generation. It is meant as
+an integration smoke test and a usage example for developers.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from src.llm import MistralLLM  # noqa: E402
+from src.memory import CharacterMemory  # noqa: E402
+from src.models import Character  # noqa: E402
+from src.tags.tag_parser import TagParser  # noqa: E402
+from src.tags.command_executor import CommandExecutor  # noqa: E402
+
+
+class Brain:
+    """Minimal container replicating parts of Neyra's brain."""
+
+    def __init__(self, llm: MistralLLM, max_tokens: int) -> None:
+        self.llm = llm
+        self.llm_max_tokens = max_tokens
+        self.characters_memory = CharacterMemory()
+        self.emotional_state = "нейтральная"
+
+
+def main() -> None:
+    config = json.loads((ROOT / "config" / "llm_config.json").read_text(encoding="utf-8"))
+    model_path = config.get("model_path")
+    max_tokens = int(config.get("max_tokens", 256))
+
+    llm = MistralLLM(model_path)
+    brain = Brain(llm, max_tokens)
+
+    # 1) LLM usage ------------------------------------------------------------
+    try:
+        greeting = llm.generate("Скажи краткое приветствие.", max_tokens=32)
+        print(f"LLM: {greeting}")
+    except Exception as exc:  # pragma: no cover - depends on heavy model
+        print(f"LLM unavailable: {exc}")
+        brain.llm = None  # ensure fallbacks are used
+
+    # 2) Memory subsystem -----------------------------------------------------
+    alice = Character(name="Алиса", personality_traits=["смелая"])
+    brain.characters_memory.add(alice)
+    brain.characters_memory.save()
+    print("Memory stored:", brain.characters_memory.get("Алиса"))
+
+    # 3) Tagging and command execution --------------------------------------
+    parser = TagParser()
+    executor = CommandExecutor(brain)
+    user_text = (
+        "@Персонаж: Алиса - смелая@ "
+        "@Эмоция: радость@ "
+        "@Диалог: Привет, как дела?@ "
+        "@Сцена: солнечный день в парке@"
+    )
+    tags = parser.parse_user_input(user_text)
+
+    context: dict[str, str] = {}
+    for tag in tags:
+        result = executor.execute_command(tag, context)
+        print(f"{tag.type}: {result}")
+        if tag.type == "emotion_paint":
+            context["emotion"] = tag.content
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    main()
+

--- a/scripts/test_model.py
+++ b/scripts/test_model.py
@@ -1,0 +1,47 @@
+"""Quick check for the local LLM configuration.
+
+This script reads ``config/llm_config.json``, instantiates
+``MistralLLM`` with the configured model and runs a tiny test prompt.
+It gracefully handles environments where the heavyweight dependencies
+are not installed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+# Ensure the project root is on ``sys.path`` so that ``src`` can be imported
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from src.llm import MistralLLM  # noqa: E402  (import after sys.path tweak)
+
+
+def main() -> None:
+    """Load configuration and run a sample prompt."""
+
+    config_path = ROOT / "config" / "llm_config.json"
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    model_path = cfg.get("model_path")
+    max_tokens = int(cfg.get("max_tokens", 128))
+
+    llm = MistralLLM(model_path)
+    prompt = "Привет! Расскажи что-нибудь интересное."
+
+    try:
+        response = llm.generate(prompt, max_tokens=max_tokens)
+    except Exception as exc:  # pragma: no cover - depends on external model
+        print(f"LLM is not available: {exc}")
+        return
+
+    print("Model response:")
+    print(response)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    main()
+


### PR DESCRIPTION
## Summary
- point config to Qwen 2.5 GGUF
- add script to test configured LLM
- add Qwen downloader that updates config
- showcase script exercising LLM, memory, and tags

## Testing
- `pytest`
- `python scripts/test_model.py`
- `python scripts/test_all_features.py`


------
https://chatgpt.com/codex/tasks/task_e_6891204306c483239a1dcd52c61ee76d