### PR TITLE
Add enhanced tag parser and new command handlers

### DIFF
--- a/scripts/test_all_features.py
+++ b/scripts/test_all_features.py
@@ -20,7 +20,7 @@ if str(ROOT) not in sys.path:
 from src.llm import MistralLLM  # noqa: E402
 from src.memory import CharacterMemory  # noqa: E402
 from src.models import Character  # noqa: E402
-from src.tags.tag_parser import TagParser  # noqa: E402
+from src.tags.enhanced_parser import EnhancedTagParser as TagParser  # noqa: E402
 from src.tags.command_executor import CommandExecutor  # noqa: E402
 
 

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -6,7 +6,7 @@ import logging
 from typing import List, Dict, Any
 from pathlib import Path
 
-from src.tags.tag_parser import TagParser, Tag
+from src.tags.enhanced_parser import EnhancedTagParser as TagParser, Tag
 from src.tags.command_executor import CommandExecutor
 from src.core.neyra_config import NEYRA_GREETING, NeyraPersonality
 from src.utils.encoding_detector import detect_encoding

--- a/src/tags/command_executor.py
+++ b/src/tags/command_executor.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import random
 from typing import Any, Callable, Dict, List, Optional
 
-from src.tags.tag_parser import Tag
+from src.tags.enhanced_parser import Tag
 from src.tags.manager import (
     available_tags as manager_available_tags,
     get_handler as manager_get_handler,
@@ -69,6 +69,9 @@ class CommandExecutor:
         manager_register_handler("scene_build", self._build_scene)
         manager_register_handler("description_write", self._write_description)
         manager_register_handler("consistency_check", self._check_consistency)
+        manager_register_handler("style_example", self._handle_style_example)
+        manager_register_handler("character_reminder", self._handle_character_reminder)
+        manager_register_handler("generate_content", self._handle_generate_content)
 
     def register_handler(
         self, tag_type: str, handler: Callable[[str, Dict[str, Any]], str]
@@ -279,3 +282,20 @@ class CommandExecutor:
 
     def _continue_story(self, instruction: str, context: Dict[str, Any]) -> str:
         return f"📖 Продолжаю историю: {instruction}. Соблюдаю логику повествования и характеры персонажей..."
+
+    # ------------------------------------------------------------------
+    # Дополнительные обработчики
+    def _handle_style_example(self, example: str, context: Dict[str, Any]) -> str:
+        examples: List[str] = context.setdefault("style_examples", [])
+        examples.append(example)
+        return f"📝 Сохраняю пример стиля ({len(example)} символов)"
+
+    def _handle_character_reminder(self, name: str, context: Dict[str, Any]) -> str:
+        return f"🔔 Помню о персонаже: {name}"
+
+    def _handle_generate_content(self, prompt: str, context: Dict[str, Any]) -> str:
+        llm = getattr(self.neyra_brain, "llm", None) if self.neyra_brain else None
+        max_tokens = getattr(self.neyra_brain, "llm_max_tokens", 512)
+        if llm is not None:
+            return llm.generate(prompt, max_tokens=max_tokens)
+        return f"✨ Генерирую контент: {prompt}"

--- a/src/tags/enhanced_parser.py
+++ b/src/tags/enhanced_parser.py
@@ -1,0 +1,78 @@
+"""Enhanced tag parser with support for inline and block patterns."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Dict, List
+
+from src.core.neyra_config import TagSystemConfig
+from src.tags.manager import register_pattern
+
+
+@dataclass
+class Tag:
+    """A single parsed tag command."""
+
+    type: str
+    content: str
+    position: tuple
+    priority: int = 1
+
+
+class EnhancedTagParser:
+    """Parse user text for inline ``@tag: value@`` and block tags."""
+
+    #: inline patterns available by default (``@Тег: значение@``)
+    INLINE_PATTERNS: Dict[str, str] = {
+        **TagSystemConfig.CORE_TAGS,
+        **TagSystemConfig.EXTENDED_TAGS,
+        # Additional inline commands
+        "character_reminder": r"@Напомни:\s*([^@]+)@",
+        "generate_content": r"@Сгенерируй:\s*([^@]+)@",
+    }
+
+    #: block patterns like ``[Пример стиля автора, X]\n...\n[Пример окончен]``
+    BLOCK_PATTERNS: Dict[str, str] = {
+        "style_example": r"\[Пример стиля автора,.*?\](.*?)\[Пример окончен\]",
+    }
+
+    def __init__(self) -> None:
+        for tag, pattern in {**self.INLINE_PATTERNS}.items():
+            register_pattern(tag, pattern)
+        for tag, pattern in self.BLOCK_PATTERNS.items():
+            register_pattern(tag, pattern)
+
+    def parse_user_input(self, text: str) -> List[Tag]:
+        tags: List[Tag] = []
+
+        for tag_type, pattern in self.INLINE_PATTERNS.items():
+            for match in re.finditer(pattern, text, re.IGNORECASE | re.DOTALL):
+                tags.append(
+                    Tag(
+                        type=tag_type,
+                        content=match.group(1).strip(),
+                        position=match.span(),
+                    )
+                )
+
+        for tag_type, pattern in self.BLOCK_PATTERNS.items():
+            block_re = re.compile(pattern, re.IGNORECASE | re.DOTALL)
+            for match in block_re.finditer(text):
+                tags.append(
+                    Tag(
+                        type=tag_type,
+                        content=match.group(1).strip(),
+                        position=match.span(),
+                    )
+                )
+
+        return sorted(tags, key=lambda t: t.position[0])
+
+    def suggest_tags(self, context: str) -> List[str]:
+        suggestions: List[str] = []
+        if any(word.istitle() for word in context.split()):
+            suggestions.append("@Персонаж: имя - действие@")
+        emotion_words = ["грустно", "радостно", "страшно", "весело"]
+        if any(word in context.lower() for word in emotion_words):
+            suggestions.append("@Эмоция: чувство@")
+        return suggestions

--- a/tests/test_tags/test_command_executor.py
+++ b/tests/test_tags/test_command_executor.py
@@ -1,8 +1,9 @@
 import pytest
 from unittest.mock import patch
+from typing import Any, Dict
 
 from src.tags.command_executor import CommandExecutor
-from src.tags.tag_parser import Tag
+from src.tags.enhanced_parser import Tag
 
 
 def test_unknown_tag_returns_message():
@@ -54,3 +55,26 @@ def test_create_smart_dialogue_without_llm_selects_default_template():
     assert "Слушай" in result
     assert "Точно!" in result
     assert "Стиль: дружеский" in result
+
+
+def test_style_example_handler_appends_to_context():
+    executor = CommandExecutor()
+    tag = Tag(type='style_example', content='пример', position=(0, 0))
+    ctx: Dict[str, Any] = {}
+    result = executor.execute_command(tag, ctx)
+    assert 'пример' in ctx.get('style_examples', [])
+    assert 'пример' in result
+
+
+def test_character_reminder_handler():
+    executor = CommandExecutor()
+    tag = Tag(type='character_reminder', content='Лили', position=(0, 0))
+    result = executor.execute_command(tag)
+    assert 'Лили' in result
+
+
+def test_generate_content_handler_without_llm():
+    executor = CommandExecutor()
+    tag = Tag(type='generate_content', content='история', position=(0, 0))
+    result = executor.execute_command(tag)
+    assert 'история' in result

--- a/tests/test_tags/test_tag_parser.py
+++ b/tests/test_tags/test_tag_parser.py
@@ -1,11 +1,11 @@
 """Проверяю, понимает ли Нейра команды через теги"""
 
-from src.tags.tag_parser import TagParser
+from src.tags.enhanced_parser import EnhancedTagParser
 
 
 def test_Нейра_понимает_основные_теги() -> None:
     """Нейра должна понимать свой язык тегов"""
-    parser = TagParser()
+    parser = EnhancedTagParser()
     
     text = "@Нейра: Создай сцену@ @Эмоция: радость@"
     tags = parser.parse_user_input(text)
@@ -16,8 +16,17 @@ def test_Нейра_понимает_основные_теги() -> None:
 
 
 def test_parser_understands_description_tag() -> None:
-    parser = TagParser()
+    parser = EnhancedTagParser()
     text = "@Описание: закат над морем@"
     tags = parser.parse_user_input(text)
     assert len(tags) == 1
     assert tags[0].type == 'description_write'
+
+
+def test_parser_handles_style_example_block() -> None:
+    parser = EnhancedTagParser()
+    text = "[Пример стиля автора, Имя]\nТишина.\n[Пример окончен]"
+    tags = parser.parse_user_input(text)
+    assert len(tags) == 1
+    assert tags[0].type == 'style_example'
+    assert tags[0].content == 'Тишина.'


### PR DESCRIPTION
## Summary
- add EnhancedTagParser supporting block `[Пример стиля автора,…][Пример окончен]` and new inline tags
- implement style example, character reminder and content generation handlers
- switch core and tests to the enhanced parser

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891241460b48323b3e73c2a97526e78