### PR TITLE
docs: document model installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,31 +105,69 @@ python main.py
 
 ## 🔗 Подключение языковой модели (ВАЖНО)
 
-Нейра умеет работать с локальной моделью **Mistral 7B Instruct Q6_K** в формате GGUF.
+Нейра может работать с несколькими локальными моделями в формате GGUF. Ниже
+представлены способы установки для **Mistral 7B** и **Qwen‑2.5**.
 
-### Вариант 1. Ручная настройка
+### Mistral 7B Instruct Q6_K
+
+#### Ручная установка
 1. Скачайте файл [`mistral-7b-instruct-v0.1.Q6_K.gguf`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF).
-2. Создайте папку `models/mistral/` и поместите модель по пути `models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf`.
-3. Убедитесь, что в `requirements.txt` есть строка `llama-cpp-python>=0.2.56` и установите зависимости:
+2. Создайте папку `models/mistral/` и поместите модель по пути
+   `models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf`.
+3. Убедитесь, что в `requirements.txt` есть строка `llama-cpp-python>=0.2.56`
+   и установите зависимости:
    ```bash
    pip install -r requirements.txt
    ```
-4. Проверьте или создайте файл `config/llm_config.json` со следующим содержимым:
-   ```json
-   {
-     "model_path": "models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf",
-     "max_tokens": 512
-   }
-   ```
-5. Запустите `python main.py` и общайтесь с Нейрой как обычно.
+4. Обновите файл `config/llm_config.json`, указав путь к модели (пример ниже).
+5. Запустите `python main.py` и общайтесь с Нейрой.
 
-### Вариант 2. Быстрый старт через терминал
+#### Скрипт загрузки
 ```bash
-mkdir -p models/mistral
-wget -O models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q6_K.gguf"
-pip install -r requirements.txt
-python main.py
+python scripts/download_mistral.py
 ```
+Скрипт скачает модель в `models/mistral/` и автоматически обновит
+`config/llm_config.json`.
+
+### Qwen‑2.5 Instruct Q4_K_M
+
+#### Ручная установка
+1. Скачайте файл [`Qwen2.5-0.5B-Instruct-Q4_K_M.gguf`](https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF).
+2. Создайте папку `models/qwen/` и поместите модель по пути
+   `models/qwen/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf`.
+3. Установите зависимости:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Обновите `config/llm_config.json`, указав путь к модели.
+
+#### Скрипт загрузки
+```bash
+python scripts/download_qwen.py
+```
+Скрипт скачает модель и укажет её в `config/llm_config.json`.
+
+### Пример `config/llm_config.json`
+```json
+{
+  "model_path": "models/mistral/mistral-7b-instruct-v0.1.Q6_K.gguf",
+  "max_tokens": 512
+}
+```
+
+### Устранение проблем с `llama-cpp`
+* **CPU:** обычной установки `pip install llama-cpp-python` достаточно. При
+  ошибках компиляции убедитесь, что установлены инструменты сборки
+  (gcc, make).
+* **GPU (CUDA):** перед установкой задайте переменную
+  `CMAKE_ARGS="-DLLAMA_CUBLAS=on"`:
+  ```bash
+  CMAKE_ARGS="-DLLAMA_CUBLAS=on" pip install --force-reinstall llama-cpp-python
+  ```
+  Если GPU недоступен, библиотека автоматически переключится на CPU.
+* Если при запуске появляется сообщение `libllama.so: cannot open shared
+  object file`, переустановите пакет с ключами `--force-reinstall
+  --no-cache-dir`.
 
 ### Веб-интерфейс Streamlit
 

--- a/scripts/download_mistral.py
+++ b/scripts/download_mistral.py
@@ -1,0 +1,74 @@
+"""Download the Mistral 7B Instruct GGUF model and update configuration.
+
+The script fetches the Q6_K quantized variant of Mistral 7B Instruct in GGUF
+format and stores it under ``models/mistral``. After a successful download
+``config/llm_config.json`` is updated so that subsequent runs of Neyra use the
+new model.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import requests
+from tqdm import tqdm
+
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+ROOT = Path(__file__).resolve().parents[1]
+MODEL_URL = (
+    "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/"
+    "mistral-7b-instruct-v0.1.Q6_K.gguf"
+)
+MODEL_DIR = ROOT / "models" / "mistral"
+MODEL_PATH = MODEL_DIR / "mistral-7b-instruct-v0.1.Q6_K.gguf"
+CONFIG_PATH = ROOT / "config" / "llm_config.json"
+
+
+def download() -> None:
+    """Download the GGUF model if it is not already present."""
+
+    MODEL_DIR.mkdir(parents=True, exist_ok=True)
+    if MODEL_PATH.exists():
+        print(f"Model already exists at {MODEL_PATH}")
+        return
+
+    with requests.get(MODEL_URL, stream=True) as r:
+        r.raise_for_status()
+        total = int(r.headers.get("content-length", 0))
+        with open(MODEL_PATH, "wb") as f, tqdm(
+            total=total, unit="B", unit_scale=True, desc="Downloading"
+        ) as pbar:
+            for chunk in r.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f.write(chunk)
+                    pbar.update(len(chunk))
+
+    print("Download complete.")
+
+
+def update_config() -> None:
+    """Point ``llm_config.json`` to the downloaded model."""
+
+    if not CONFIG_PATH.exists():
+        print(f"Config file {CONFIG_PATH} not found")
+        return
+
+    cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    cfg["model_path"] = str(MODEL_PATH)
+    CONFIG_PATH.write_text(
+        json.dumps(cfg, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"Updated config to use {MODEL_PATH}")
+
+
+def main() -> None:
+    download()
+    update_config()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add script to download and configure Mistral 7B model
- document manual and scripted installation for Mistral and Qwen models
- include example `llm_config.json` and llama-cpp troubleshooting notes

## Testing
- `pytest -q` *(fails: TagProcessor parsing and Neyra recall tests)*

------
https://chatgpt.com/codex/tasks/task_e_68912ca5771c8323aff7d28d00fddb0e