### PR TITLE
feat: parse parameters for block tags

### DIFF
--- a/src/tags/enhanced_parser.py
+++ b/src/tags/enhanced_parser.py
@@ -1,7 +1,7 @@
 """Enhanced tag parser with support for inline and block patterns."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Dict, List
 
@@ -17,6 +17,7 @@ class Tag:
     content: str
     position: tuple
     priority: int = 1
+    params: Dict[str, str] = field(default_factory=dict)
 
 
 class EnhancedTagParser:
@@ -33,7 +34,10 @@ class EnhancedTagParser:
 
     #: block patterns like ``[Пример стиля автора, X]\n...\n[Пример окончен]``
     BLOCK_PATTERNS: Dict[str, str] = {
-        "style_example": r"\[Пример стиля автора,.*?\](.*?)\[Пример окончен\]",
+        "style_example": r"\[Пример стиля автора,\s*(?P<author>[^\]]+)\]\s*(?P<content>.*?)\s*\[Пример окончен\]",
+        "world_rule": r"\[Правило мира,\s*(?P<name>[^\]]+)\]\s*(?P<content>.*?)\s*\[Правило окончено\]",
+        "character_reminder": r"\[Напоминание персонажа,\s*(?P<name>[^\]]+)\]\s*(?P<content>.*?)\s*\[Напоминание окончено\]",
+        "generate_content": r"\[Сгенерируй,\s*(?P<topic>[^\]]+)\]\s*(?P<content>.*?)\s*\[Генерация окончена\]",
     }
 
     def __init__(self) -> None:
@@ -47,22 +51,30 @@ class EnhancedTagParser:
 
         for tag_type, pattern in self.INLINE_PATTERNS.items():
             for match in re.finditer(pattern, text, re.IGNORECASE | re.DOTALL):
+                groups = match.groupdict()
+                content = groups.pop("content", match.group(1)).strip()
+                params = {k: v.strip() for k, v in groups.items()}
                 tags.append(
                     Tag(
                         type=tag_type,
-                        content=match.group(1).strip(),
+                        content=content,
                         position=match.span(),
+                        params=params,
                     )
                 )
 
         for tag_type, pattern in self.BLOCK_PATTERNS.items():
             block_re = re.compile(pattern, re.IGNORECASE | re.DOTALL)
             for match in block_re.finditer(text):
+                groups = match.groupdict()
+                content = groups.pop("content", match.group(1) if match.groups() else "").strip()
+                params = {k: v.strip() for k, v in groups.items()}
                 tags.append(
                     Tag(
                         type=tag_type,
-                        content=match.group(1).strip(),
+                        content=content,
                         position=match.span(),
+                        params=params,
                     )
                 )
 

--- a/tests/test_tags/test_tag_parser.py
+++ b/tests/test_tags/test_tag_parser.py
@@ -30,3 +30,34 @@ def test_parser_handles_style_example_block() -> None:
     assert len(tags) == 1
     assert tags[0].type == 'style_example'
     assert tags[0].content == 'Тишина.'
+    assert tags[0].params.get('author') == 'Имя'
+
+
+def test_parser_handles_world_rule_block() -> None:
+    parser = EnhancedTagParser()
+    text = "[Правило мира, Магия]\nНе использовать магию.\n[Правило окончено]"
+    tags = parser.parse_user_input(text)
+    assert len(tags) == 1
+    assert tags[0].type == 'world_rule'
+    assert tags[0].content == 'Не использовать магию.'
+    assert tags[0].params.get('name') == 'Магия'
+
+
+def test_parser_handles_character_reminder_block() -> None:
+    parser = EnhancedTagParser()
+    text = "[Напоминание персонажа, Лили]\nОна любит приключения.\n[Напоминание окончено]"
+    tags = parser.parse_user_input(text)
+    assert len(tags) == 1
+    assert tags[0].type == 'character_reminder'
+    assert tags[0].content == 'Она любит приключения.'
+    assert tags[0].params.get('name') == 'Лили'
+
+
+def test_parser_handles_generate_content_block() -> None:
+    parser = EnhancedTagParser()
+    text = "[Сгенерируй, стих]\nО лесах.\n[Генерация окончена]"
+    tags = parser.parse_user_input(text)
+    assert len(tags) == 1
+    assert tags[0].type == 'generate_content'
+    assert tags[0].content == 'О лесах.'
+    assert tags[0].params.get('topic') == 'стих'


### PR DESCRIPTION
## Summary
- capture parameters from block tags via named regex groups
- add block tag support for world_rule, character_reminder, and generate_content
- expose parsed parameters on Tag dataclass and update tests

## Testing
- `python -m pytest tests/test_tags/test_tag_parser.py -q`
- `pytest -q` *(fails: TagProcessor entity parsing and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68913c4637648323bd32cc66d78c7423