### PR TITLE
feat: persist style and character reminders

### DIFF
--- a/src/memory/style_memory.py
+++ b/src/memory/style_memory.py
@@ -34,6 +34,12 @@ class StyleMemory:
         if example:
             entry["examples"].append(example)
 
+    # ------------------------------------------------------------------
+    def add_style_example(self, author: str, example: str) -> None:
+        """Store a writing example linked to a particular author."""
+        entry = self._data.setdefault(author, {"description": "", "examples": []})
+        entry["examples"].append(example)
+
     def get(self, style: str | None = None) -> Dict[str, Any] | Dict[str, Dict[str, Any]]:
         """Retrieve stored style information."""
         if style is None:

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -9,6 +9,7 @@ class Character:
     """Representation of a story character."""
 
     name: str
+    appearance: str = ""
     personality_traits: List[str] = field(default_factory=list)
     emotional_moments: List[str] = field(default_factory=list)
     relationships: Dict[str, str] = field(default_factory=dict)
@@ -19,6 +20,7 @@ class Character:
         """Serialize the character to a JSON-serializable dict."""
         return {
             "name": self.name,
+            "appearance": self.appearance,
             "personality_traits": list(self.personality_traits),
             "emotional_moments": list(self.emotional_moments),
             "relationships": dict(self.relationships),
@@ -31,6 +33,7 @@ class Character:
         """Deserialize a :class:`Character` from a dictionary."""
         return cls(
             name=data.get("name", ""),
+            appearance=data.get("appearance", ""),
             personality_traits=list(data.get("personality_traits", [])),
             emotional_moments=list(data.get("emotional_moments", [])),
             relationships=dict(data.get("relationships", {})),

--- a/src/tags/command_executor.py
+++ b/src/tags/command_executor.py
@@ -31,6 +31,16 @@ class CommandExecutor:
     """
 
     def __init__(self, neyra_brain: Optional[Any] = None) -> None:
+        """Create executor.
+
+        Parameters
+        ----------
+        neyra_brain:
+            Core brain instance.  It is optional for basic command handling
+            but required when commands need to persist information (style and
+            character memories).
+        """
+
         self.neyra_brain = neyra_brain
 
         # Палитры эмоций и стили, которыми я могу пользоваться
@@ -92,7 +102,16 @@ class CommandExecutor:
 
         handler = manager_get_handler(tag.type)
         if handler:
-            return handler(tag.content, context)
+            # Pass tag parameters to handlers via context so that additional
+            # metadata (like author names) can be used while still allowing the
+            # handler to mutate the original context.
+            if tag.params:
+                context["params"] = tag.params
+            try:
+                return handler(tag.content, context)
+            finally:
+                if tag.params:
+                    context.pop("params", None)
         return f"🤔 Команда '{tag.type}' понята, но пока учусь её выполнять..."
 
     def _recall_request(self, query: str, context: Dict[str, Any]) -> str:
@@ -286,11 +305,50 @@ class CommandExecutor:
     # ------------------------------------------------------------------
     # Дополнительные обработчики
     def _handle_style_example(self, example: str, context: Dict[str, Any]) -> str:
-        examples: List[str] = context.setdefault("style_examples", [])
-        examples.append(example)
+        """Store a style example in persistent memory if available."""
+        author = context.get("params", {}).get("author", "неизвестный")
+        if self.neyra_brain and hasattr(self.neyra_brain, "style_memory"):
+            self.neyra_brain.style_memory.add_style_example(author, example)
+            self.neyra_brain.style_memory.save()
+        else:
+            examples: List[str] = context.setdefault("style_examples", [])
+            examples.append(example)
         return f"📝 Сохраняю пример стиля ({len(example)} символов)"
 
-    def _handle_character_reminder(self, name: str, context: Dict[str, Any]) -> str:
+    def _handle_character_reminder(self, content: str, context: Dict[str, Any]) -> str:
+        """Update character information and persist it."""
+        name = context.get("params", {}).get("name", content.strip())
+        if not (self.neyra_brain and hasattr(self.neyra_brain, "characters_memory")):
+            return f"🔔 Помню о персонаже: {name}"
+
+        char_mem = self.neyra_brain.characters_memory
+        character = char_mem.get(name) or Character(name=name)
+
+        params = context.get("params", {})
+
+        appearance = params.get("appearance")
+        if appearance is None:
+            # Allow specifying appearance in the content as ``appearance=...``
+            for part in content.split(";"):
+                if "appearance=" in part:
+                    appearance = part.split("=", 1)[1].strip()
+                    break
+        if appearance:
+            character.appearance = appearance
+
+        traits = params.get("traits")
+        if traits is None:
+            for part in content.split(";"):
+                if "traits=" in part:
+                    traits = part.split("=", 1)[1].strip()
+                    break
+        if traits:
+            character.personality_traits.extend(
+                [t.strip() for t in traits.split(",") if t.strip()]
+            )
+
+        char_mem.add(character)
+        char_mem.save()
         return f"🔔 Помню о персонаже: {name}"
 
     def _handle_generate_content(self, prompt: str, context: Dict[str, Any]) -> str:

--- a/tests/test_tags/test_command_executor.py
+++ b/tests/test_tags/test_command_executor.py
@@ -1,7 +1,8 @@
+import json
 import pytest
 from unittest.mock import patch
-from typing import Any, Dict
 
+from src.memory import CharacterMemory, StyleMemory
 from src.tags.command_executor import CommandExecutor
 from src.tags.enhanced_parser import Tag
 
@@ -24,13 +25,11 @@ def test_register_custom_handler():
     assert executor.execute_command(tag) == "custom:data"
 
 
-def test_emotion_updates_brain():
-    from src.memory import CharacterMemory
-
+def test_emotion_updates_brain(tmp_path):
     class Dummy:
         def __init__(self):
             self.emotional_state = "neutral"
-            self.characters_memory = CharacterMemory()
+            self.characters_memory = CharacterMemory(tmp_path / "chars.json")
 
     brain = Dummy()
     executor = CommandExecutor(brain)
@@ -57,20 +56,41 @@ def test_create_smart_dialogue_without_llm_selects_default_template():
     assert "Стиль: дружеский" in result
 
 
-def test_style_example_handler_appends_to_context():
-    executor = CommandExecutor()
-    tag = Tag(type='style_example', content='пример', position=(0, 0))
-    ctx: Dict[str, Any] = {}
-    result = executor.execute_command(tag, ctx)
-    assert 'пример' in ctx.get('style_examples', [])
-    assert 'пример' in result
+def test_style_example_handler_persists_example(tmp_path):
+    class Dummy:
+        def __init__(self) -> None:
+            self.style_memory = StyleMemory(tmp_path / "styles.json")
+
+    brain = Dummy()
+    executor = CommandExecutor(brain)
+    tag = Tag(
+        type='style_example',
+        content='пример',
+        position=(0, 0),
+        params={'author': 'Автор'}
+    )
+    executor.execute_command(tag)
+    data = json.loads((tmp_path / "styles.json").read_text(encoding="utf-8"))
+    assert 'пример' in data['Автор']['examples']
 
 
-def test_character_reminder_handler():
-    executor = CommandExecutor()
-    tag = Tag(type='character_reminder', content='Лили', position=(0, 0))
-    result = executor.execute_command(tag)
-    assert 'Лили' in result
+def test_character_reminder_handler_updates_memory(tmp_path):
+    class Dummy:
+        def __init__(self) -> None:
+            self.characters_memory = CharacterMemory(tmp_path / "chars.json")
+
+    brain = Dummy()
+    executor = CommandExecutor(brain)
+    tag = Tag(
+        type='character_reminder',
+        content='',
+        position=(0, 0),
+        params={'name': 'Лили', 'appearance': 'светлые волосы', 'traits': 'добрая'}
+    )
+    executor.execute_command(tag)
+    data = json.loads((tmp_path / "chars.json").read_text(encoding="utf-8"))
+    assert data['Лили']['appearance'] == 'светлые волосы'
+    assert 'добрая' in data['Лили']['personality_traits']
 
 
 def test_generate_content_handler_without_llm():


### PR DESCRIPTION
## Summary
- allow tag handlers to access tag parameters via context
- persist style examples to style memory keyed by author
- update character reminder to record appearance and traits in character memory

## Testing
- `pytest tests/test_tags/test_command_executor.py -q`
- `pytest -q` *(fails: TagProcessor parsing expectations and history search join)*

------
https://chatgpt.com/codex/tasks/task_e_68913f66c2308323ad8a345192d406c9