### PR TITLE
feat: add structured world and style memory

### DIFF
--- a/src/memory/style_memory.py
+++ b/src/memory/style_memory.py
@@ -1,9 +1,20 @@
 """Storage for writing style information and examples."""
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass, field
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List, Any
+
+
+@dataclass
+class StylePattern:
+    """Describes a writing style for a particular author."""
+
+    author: str
+    description: str = ""
+    examples: List[str] = field(default_factory=list)
+    characteristics: List[str] = field(default_factory=list)
 
 
 class StyleMemory:
@@ -11,57 +22,65 @@ class StyleMemory:
 
     def __init__(self, storage_path: str | Path | None = None) -> None:
         self.storage_path = Path(storage_path or "data/styles.json")
-        self._data: Dict[str, Dict[str, Any]] = {}
-        self._load()
-
-    def _load(self) -> None:
-        if self.storage_path.exists():
-            try:
-                self._data = json.loads(self.storage_path.read_text(encoding="utf-8"))
-            except Exception:
-                self._data = {}
-
-    def add(
-        self,
-        style: str,
-        example: str | None = None,
-        description: str | None = None,
-    ) -> None:
-        """Add a style description or example."""
-        entry = self._data.setdefault(style, {"description": "", "examples": []})
-        if description:
-            entry["description"] = description
-        if example:
-            entry["examples"].append(example)
+        self._data: Dict[str, StylePattern] = {}
+        self.load()
 
     # ------------------------------------------------------------------
+    def add(
+        self,
+        author: str,
+        example: str | None = None,
+        description: str | None = None,
+        characteristics: List[str] | None = None,
+    ) -> None:
+        """Add or update information about an author's style."""
+        pattern = self._data.setdefault(author, StylePattern(author=author))
+        if description:
+            pattern.description = description
+        if example:
+            pattern.examples.append(example)
+        if characteristics:
+            pattern.characteristics.extend(characteristics)
+
     def add_style_example(self, author: str, example: str) -> None:
         """Store a writing example linked to a particular author."""
-        entry = self._data.setdefault(author, {"description": "", "examples": []})
-        entry["examples"].append(example)
+        self.add(author, example=example)
 
-    def get(self, style: str | None = None) -> Dict[str, Any] | Dict[str, Dict[str, Any]]:
+    def get_style(self, author: str | None = None) -> StylePattern | Dict[str, StylePattern] | None:
         """Retrieve stored style information."""
-        if style is None:
+        if author is None:
             return self._data
-        return self._data.get(style, {"description": "", "examples": []})
+        return self._data.get(author)
 
-    def get_examples(self, style: str | None = None) -> List[str]:
+    def get_examples(self, author: str | None = None) -> List[str]:
         """Return a list of style examples."""
-        if style:
-            return list(self._data.get(style, {}).get("examples", []))
+        if author:
+            pattern = self._data.get(author)
+            return list(pattern.examples) if pattern else []
         examples: List[str] = []
-        for info in self._data.values():
-            examples.extend(info.get("examples", []))
+        for pattern in self._data.values():
+            examples.extend(pattern.examples)
         return examples
 
+    # ------------------------------------------------------------------
     def save(self) -> None:
         """Persist memory to disk."""
+        serialised = {author: asdict(pattern) for author, pattern in self._data.items()}
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
         self.storage_path.write_text(
-            json.dumps(self._data, ensure_ascii=False, indent=2),
+            json.dumps(serialised, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 
+    def load(self) -> None:
+        """Load style information from disk."""
+        if not self.storage_path.exists():
+            return
+        try:
+            raw: Dict[str, Any] = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        except Exception:
+            raw = {}
+        self._data = {author: StylePattern(**info) for author, info in raw.items()}
 
-__all__ = ["StyleMemory"]
+
+__all__ = ["StyleMemory", "StylePattern"]

--- a/src/memory/world_memory.py
+++ b/src/memory/world_memory.py
@@ -1,9 +1,29 @@
 """Storage for information about fictional worlds."""
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass, field
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+
+@dataclass
+class WorldRule:
+    """Rule that defines some aspect of a world."""
+
+    category: str
+    description: str
+    examples: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CulturalInfo:
+    """Information about a culture inside a world."""
+
+    name: str
+    category: str
+    description: str
+    examples: List[str] = field(default_factory=list)
 
 
 class WorldMemory:
@@ -11,33 +31,98 @@ class WorldMemory:
 
     def __init__(self, storage_path: str | Path | None = None) -> None:
         self.storage_path = Path(storage_path or "data/world_memory.json")
-        self._data: Dict[str, Dict[str, Any]] = {}
-        self._load()
+        # Mapping of world name to its rules and cultural information
+        self._data: Dict[str, Dict[str, List[Any]]] = {}
+        self.load()
 
-    def _load(self) -> None:
-        if self.storage_path.exists():
-            try:
-                self._data = json.loads(self.storage_path.read_text(encoding="utf-8"))
-            except Exception:
-                self._data = {}
+    # ------------------------------------------------------------------
+    def add_rule(
+        self,
+        world: str,
+        category: str,
+        description: str,
+        examples: List[str] | None = None,
+    ) -> None:
+        """Add a rule for a specific world."""
+        rule = WorldRule(category=category, description=description, examples=examples or [])
+        world_entry = self._data.setdefault(world, {"rules": [], "cultures": []})
+        world_entry["rules"].append(rule)
 
-    def add(self, name: str, info: Dict[str, Any]) -> None:
-        """Add or update information about a world."""
-        self._data[name] = info
+    def add_culture(
+        self,
+        world: str,
+        name: str,
+        category: str,
+        description: str,
+        examples: List[str] | None = None,
+    ) -> None:
+        """Add cultural information for a world."""
+        culture = CulturalInfo(
+            name=name,
+            category=category,
+            description=description,
+            examples=examples or [],
+        )
+        world_entry = self._data.setdefault(world, {"rules": [], "cultures": []})
+        world_entry["cultures"].append(culture)
 
-    def get(self, name: str | None = None) -> Any:
+    # ------------------------------------------------------------------
+    def get(self, world: str | None = None) -> Any:
         """Retrieve information about a world or all worlds."""
-        if name is None:
-            return self._data
-        return self._data.get(name)
+        if world is None:
+            return {
+                name: {
+                    "rules": [asdict(rule) for rule in data.get("rules", [])],
+                    "cultures": [asdict(c) for c in data.get("cultures", [])],
+                }
+                for name, data in self._data.items()
+            }
+        entry = self._data.get(world)
+        if entry is None:
+            return None
+        return {
+            "rules": [asdict(rule) for rule in entry.get("rules", [])],
+            "cultures": [asdict(c) for c in entry.get("cultures", [])],
+        }
 
+    # ------------------------------------------------------------------
     def save(self) -> None:
         """Persist current memory to the storage file."""
+        serialised = self.get()
         self.storage_path.parent.mkdir(parents=True, exist_ok=True)
         self.storage_path.write_text(
-            json.dumps(self._data, ensure_ascii=False, indent=2),
+            json.dumps(serialised, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
 
+    def load(self) -> None:
+        """Load memory from disk."""
+        if not self.storage_path.exists():
+            return
+        try:
+            raw = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        except Exception:
+            raw = {}
+        self._data = {}
+        for world, info in raw.items():
+            rules = [WorldRule(**r) for r in info.get("rules", [])]
+            cultures = [CulturalInfo(**c) for c in info.get("cultures", [])]
+            self._data[world] = {"rules": rules, "cultures": cultures}
 
-__all__ = ["WorldMemory"]
+    # Compatibility with previous API ---------------------------------
+    def add(self, name: str, info: Dict[str, Any]) -> None:
+        """Add or update information about a world (legacy API)."""
+        world_entry = self._data.setdefault(name, {"rules": [], "cultures": []})
+        for rule in info.get("rules", []):
+            if isinstance(rule, WorldRule):
+                world_entry["rules"].append(rule)
+            else:
+                world_entry["rules"].append(WorldRule(**rule))
+        for culture in info.get("cultures", []):
+            if isinstance(culture, CulturalInfo):
+                world_entry["cultures"].append(culture)
+            else:
+                world_entry["cultures"].append(CulturalInfo(**culture))
+
+
+__all__ = ["WorldMemory", "WorldRule", "CulturalInfo"]


### PR DESCRIPTION
## Summary
- introduce `WorldRule` and `CulturalInfo` dataclasses and migrate `WorldMemory` to structured storage with rule and culture helpers
- add `StylePattern` dataclass and manage style examples via `add_style_example`/`get_style`
- serialize and deserialize dataclass-based memories to JSON

## Testing
- `pytest tests/test_tags/test_command_executor.py::test_style_example_handler_persists_example -q`
- `pytest -q` *(fails: TagProcessor missing features, Neyra recall type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891510f930483239fe782ca93f417bb