### PR TITLE
Persist style and character updates

### DIFF
--- a/src/tags/command_executor.py
+++ b/src/tags/command_executor.py
@@ -347,6 +347,33 @@ class CommandExecutor:
                 [t.strip() for t in traits.split(",") if t.strip()]
             )
 
+        emotional = params.get("emotional_moment") or params.get("emotion")
+        if emotional:
+            character.emotional_moments.extend(
+                [e.strip() for e in str(emotional).split(",") if e.strip()]
+            )
+
+        relationships = params.get("relationships")
+        if relationships:
+            if isinstance(relationships, dict):
+                character.relationships.update(relationships)
+            else:
+                for rel in str(relationships).split(","):
+                    if ":" in rel:
+                        other, kind = rel.split(":", 1)
+                        character.relationships[other.strip()] = kind.strip()
+
+        growth = params.get("growth_arc")
+        if growth:
+            if isinstance(growth, list):
+                character.growth_arc.extend(growth)
+            else:
+                character.growth_arc.append(str(growth))
+
+        first_mention = params.get("first_mention")
+        if first_mention is not None:
+            character.first_mention = bool(first_mention)
+
         char_mem.add(character)
         char_mem.save()
         return f"🔔 Помню о персонаже: {name}"

--- a/tests/test_tags/test_command_executor.py
+++ b/tests/test_tags/test_command_executor.py
@@ -85,12 +85,24 @@ def test_character_reminder_handler_updates_memory(tmp_path):
         type='character_reminder',
         content='',
         position=(0, 0),
-        params={'name': 'Лили', 'appearance': 'светлые волосы', 'traits': 'добрая'}
+        params={
+            'name': 'Лили',
+            'appearance': 'светлые волосы',
+            'traits': 'добрая',
+            'emotional_moment': 'радость',
+            'relationships': 'Боб:друг',
+            'growth_arc': 'обрела смелость',
+            'first_mention': True,
+        }
     )
     executor.execute_command(tag)
     data = json.loads((tmp_path / "chars.json").read_text(encoding="utf-8"))
     assert data['Лили']['appearance'] == 'светлые волосы'
     assert 'добрая' in data['Лили']['personality_traits']
+    assert 'радость' in data['Лили']['emotional_moments']
+    assert data['Лили']['relationships']['Боб'] == 'друг'
+    assert 'обрела смелость' in data['Лили']['growth_arc']
+    assert data['Лили']['first_mention'] is True
 
 
 def test_generate_content_handler_without_llm():


### PR DESCRIPTION
## Summary
- Save style examples through `neyra_brain.style_memory` when present, ensuring persistence
- Update character reminders with appearance, traits, emotional moments, relationships, growth arcs and first mention, saving to memory
- Extend tests to cover new character reminder fields and style example persistence

## Testing
- `pytest tests/test_tags/test_command_executor.py::test_style_example_handler_persists_example tests/test_tags/test_command_executor.py::test_character_reminder_handler_updates_memory -q`
- `pytest -q` *(fails: TagProcessor parsing and integration test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6891552e69508323bc5cb19898005de9