### PR TITLE
Add role-based personality classes

### DIFF
--- a/personalities/AGENTS.md
+++ b/personalities/AGENTS.md
@@ -1,0 +1,6 @@
+# Personalities Package Instructions
+
+- Ensure every class and public method has a descriptive docstring.
+- Use type hints for all function parameters and return values.
+- Keep lines under 100 characters.
+- After modifying files in this directory, run `pytest` from the repository root.

--- a/personalities/README.md
+++ b/personalities/README.md
@@ -1,0 +1,7 @@
+# Neira Personality Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| curiosity_level | 0.7 | Tendency to explore new ideas. |
+| empathy_level | 0.8 | Capacity to understand others. |
+| creativity_level | 0.6 | Ability to generate novel solutions. |

--- a/personalities/__init__.py
+++ b/personalities/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for role-based AI personalities."""
+
+from .master import MasterPersonality
+from .player import PlayerPersonality
+
+__all__ = ["MasterPersonality", "PlayerPersonality"]

--- a/personalities/default_traits.json
+++ b/personalities/default_traits.json
@@ -1,0 +1,5 @@
+{
+  "curiosity_level": 0.7,
+  "empathy_level": 0.8,
+  "creativity_level": 0.6
+}

--- a/personalities/master.py
+++ b/personalities/master.py
@@ -1,0 +1,50 @@
+"""Master personality definitions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Dict, List
+
+from src.core.ai_personality import AIPersonality
+
+TRAITS_PATH = Path(__file__).with_name("default_traits.json")
+DEFAULT_TRAITS: Dict[str, float] = json.loads(TRAITS_PATH.read_text())
+
+
+@dataclass
+class MasterPersonality(AIPersonality):
+    """AI personality for game masters with narrative abilities."""
+
+    traits: Dict[str, float] = field(default_factory=lambda: DEFAULT_TRAITS.copy())
+
+    specializations: ClassVar[Dict[str, Dict[str, List[str]]]] = {
+        "lorekeeper": {
+            "knowledge_focus": ["history", "mythology"],
+            "personality_traits": ["wise"],
+            "decision_style": "narrative",
+        },
+        "tactician": {
+            "knowledge_focus": ["strategy"],
+            "personality_traits": ["calculating"],
+            "decision_style": "analytical",
+        },
+    }
+
+    def __init__(self, name: str, specialization: str = "lorekeeper") -> None:
+        preset = self.specializations.get(specialization, {})
+        super().__init__(
+            name=name,
+            role="master",
+            knowledge_focus=preset.get("knowledge_focus", []),
+            personality_traits=preset.get("personality_traits", []),
+            current_character="Game Master",
+            decision_style=preset.get("decision_style", "balanced"),
+            communication_style=preset.get("communication_style", "narrative"),
+        )
+        self.traits = DEFAULT_TRAITS.copy()
+
+    def describe_scene(self, elements: List[str]) -> str:
+        """Return a narrative description of the given ``elements``."""
+        return f"As the master, {self.name} sees " + ", ".join(elements) + "."

--- a/personalities/player.py
+++ b/personalities/player.py
@@ -1,0 +1,52 @@
+"""Player personality definitions."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Dict, List
+
+from src.core.ai_personality import AIPersonality
+
+TRAITS_PATH = Path(__file__).with_name("default_traits.json")
+DEFAULT_TRAITS: Dict[str, float] = json.loads(TRAITS_PATH.read_text())
+
+
+@dataclass
+class PlayerPersonality(AIPersonality):
+    """AI personality for players with action choices."""
+
+    traits: Dict[str, float] = field(default_factory=lambda: DEFAULT_TRAITS.copy())
+
+    archetypes: ClassVar[Dict[str, Dict[str, List[str]]]] = {
+        "warrior": {
+            "knowledge_focus": ["combat"],
+            "personality_traits": ["brave", "resilient"],
+            "decision_style": "bold",
+        },
+        "scholar": {
+            "knowledge_focus": ["arcana", "history"],
+            "personality_traits": ["curious"],
+            "decision_style": "thoughtful",
+        },
+    }
+
+    def __init__(self, name: str, archetype: str = "warrior") -> None:
+        preset = self.archetypes.get(archetype, {})
+        super().__init__(
+            name=name,
+            role="player",
+            knowledge_focus=preset.get("knowledge_focus", []),
+            personality_traits=preset.get("personality_traits", []),
+            current_character=archetype.capitalize(),
+            decision_style=preset.get("decision_style", "balanced"),
+            communication_style=preset.get("communication_style", "conversational"),
+        )
+        self.traits = DEFAULT_TRAITS.copy()
+
+    def choose_action(self, situation: str, options: List[str]) -> str:
+        """Select an action from ``options`` given the ``situation``."""
+        if not options:
+            return "wait"
+        return options[0]


### PR DESCRIPTION
## Summary
- add personalities package with default trait config
- implement MasterPersonality and PlayerPersonality subclasses
- document personality parameters for Neira

## Testing
- `pytest` *(fails: TagProcessor tests and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6891b8e88368832389446c0d0bd83622