### PR TITLE
feat: add RPG character model with serialization

### DIFF
--- a/characters/__init__.py
+++ b/characters/__init__.py
@@ -1,0 +1,5 @@
+"""Character models for RPG scenarios."""
+
+from .rpg_character import RPGCharacter
+
+__all__ = ["RPGCharacter"]

--- a/characters/rpg_character.py
+++ b/characters/rpg_character.py
@@ -1,0 +1,50 @@
+"""RPG character model with serialization helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class RPGCharacter:
+    """Representation of a role-playing game character."""
+
+    name: str
+    attributes: Dict[str, Any] = field(default_factory=dict)
+    skills: List[str] = field(default_factory=list)
+    equipment: List[str] = field(default_factory=list)
+    status_effects: List[str] = field(default_factory=list)
+    ai_personality_type: str = ""
+    decision_patterns: List[str] = field(default_factory=list)
+    roleplay_style: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the character to a JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "attributes": dict(self.attributes),
+            "skills": list(self.skills),
+            "equipment": list(self.equipment),
+            "status_effects": list(self.status_effects),
+            "ai_personality_type": self.ai_personality_type,
+            "decision_patterns": list(self.decision_patterns),
+            "roleplay_style": self.roleplay_style,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RPGCharacter":
+        """Deserialize an :class:`RPGCharacter` from a dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            attributes=dict(data.get("attributes", {})),
+            skills=list(data.get("skills", [])),
+            equipment=list(data.get("equipment", [])),
+            status_effects=list(data.get("status_effects", [])),
+            ai_personality_type=data.get("ai_personality_type", ""),
+            decision_patterns=list(data.get("decision_patterns", [])),
+            roleplay_style=data.get("roleplay_style", ""),
+        )
+
+
+__all__ = ["RPGCharacter"]

--- a/tests/test_characters/test_rpg_character.py
+++ b/tests/test_characters/test_rpg_character.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from characters.rpg_character import RPGCharacter
+
+
+def test_serialization_roundtrip():
+    original = RPGCharacter(
+        name="Hero",
+        attributes={"strength": 10, "agility": 8},
+        skills=["swordsmanship", "archery"],
+        equipment=["sword", "bow"],
+        status_effects=["poisoned"],
+        ai_personality_type="aggressive",
+        decision_patterns=["attack", "defend"],
+        roleplay_style="heroic",
+    )
+
+    data = original.to_dict()
+    recreated = RPGCharacter.from_dict(data)
+
+    assert recreated == original


### PR DESCRIPTION
## Summary
- add `RPGCharacter` dataclass with gameplay fields
- include helpers to serialize and deserialize characters
- add test covering round-trip serialization

## Testing
- `pytest -q`
- `pytest tests/test_characters/test_rpg_character.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891be7f12b88323a91ebe36298f18e0