### PR TITLE
Add book setting extractor and RPG adapter utilities

### DIFF
--- a/integration/__init__.py
+++ b/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration package for various utilities."""

--- a/integration/books/__init__.py
+++ b/integration/books/__init__.py
@@ -1,0 +1,1 @@
+"""Book-related integration utilities."""

--- a/integration/books/adapter.py
+++ b/integration/books/adapter.py
@@ -1,0 +1,56 @@
+"""Adapter utilities for turning books into RPG material."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from .extractor import SettingExtractor
+
+
+class BookToRPGAdapter:
+    """Convert book information into RPG-friendly structures."""
+
+    def __init__(self, extractor: SettingExtractor | None = None) -> None:
+        self.extractor = extractor or SettingExtractor()
+
+    def create_campaign_from_book(self, book: Dict[str, Any], target_system: str) -> Dict[str, Any]:
+        """Create a campaign dictionary from book data."""
+        content = book.get("content", "")
+        characters = book.get("characters", [])
+        campaign = {
+            "system": target_system,
+            "title": book.get("title", "Untitled"),
+            "world_rules": self.extractor.extract_world_rules(content),
+            "npcs": self.extractor.create_npcs_from_characters(characters),
+            "locations": self.extractor.generate_locations(content),
+            "plot_hooks": self.extractor.extract_plot_hooks(content),
+        }
+        return campaign
+
+    def balance_characters_for_game(
+        self, characters: Iterable[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Balance character levels by setting them to the average."""
+        characters = list(characters)
+        if not characters:
+            return []
+        average = sum(c.get("level", 1) for c in characters) / len(characters)
+        balanced: List[Dict[str, Any]] = []
+        for character in characters:
+            new_char = dict(character)
+            new_char["level"] = int(average)
+            balanced.append(new_char)
+        return balanced
+
+    def generate_adventures(self, plot_elements: Iterable[str]) -> List[Dict[str, str]]:
+        """Generate simple adventure descriptions from plot elements."""
+        adventures = []
+        for element in plot_elements:
+            adventures.append(
+                {
+                    "title": element[:50],
+                    "summary": element,
+                    "encounters": [f"Encounter: {element}"],
+                }
+            )
+        return adventures

--- a/integration/books/extractor.py
+++ b/integration/books/extractor.py
@@ -1,0 +1,67 @@
+"""Utilities for extracting RPG settings from book content."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List
+
+
+class SettingExtractor:
+    """Extract setting information from books for RPG usage."""
+
+    _RULE_KEYWORDS = ("must", "shall", "never", "always", "law")
+    _PLOT_HOOK_KEYWORDS = (
+        "mysterious",
+        "quest",
+        "secret",
+        "threat",
+        "danger",
+        "murder",
+        "prophecy",
+        "legend",
+    )
+    _LOCATION_PATTERNS = re.compile(
+        r"\b(?:city|town|village|forest|castle|kingdom|mountain|lake|sea|desert|island)\s+([A-Z][a-zA-Z]+)"
+    )
+
+    def extract_world_rules(self, book_content: str) -> List[str]:
+        """Return sentences that describe world rules.
+
+        Sentences containing certain keywords are considered rules.
+        """
+        sentences = re.split(r"[.!?]", book_content)
+        rules = [
+            sentence.strip()
+            for sentence in sentences
+            if any(key in sentence.lower() for key in self._RULE_KEYWORDS)
+        ]
+        return [rule for rule in rules if rule]
+
+    def create_npcs_from_characters(
+        self, characters: Iterable[Any]
+    ) -> List[Dict[str, Any]]:
+        """Convert character representations into NPC dictionaries."""
+        npcs: List[Dict[str, Any]] = []
+        for character in characters:
+            if isinstance(character, dict):
+                npc = {"name": character.get("name", "Unnamed"), "role": "npc"}
+                if "traits" in character:
+                    npc["traits"] = list(character["traits"])
+            else:
+                npc = {"name": str(character), "role": "npc"}
+            npcs.append(npc)
+        return npcs
+
+    def generate_locations(self, book_content: str) -> List[str]:
+        """Identify location names from the content."""
+        return list(set(self._LOCATION_PATTERNS.findall(book_content)))
+
+    def extract_plot_hooks(self, book_content: str) -> List[str]:
+        """Find sentences that could serve as plot hooks."""
+        sentences = re.split(r"[.!?]", book_content)
+        hooks = [
+            sentence.strip()
+            for sentence in sentences
+            if any(key in sentence.lower() for key in self._PLOT_HOOK_KEYWORDS)
+        ]
+        return [hook for hook in hooks if hook]

--- a/tests/test_book_adapter.py
+++ b/tests/test_book_adapter.py
@@ -1,0 +1,59 @@
+# tests/test_book_adapter.py
+"""Tests for book extraction and adaptation utilities."""
+
+from integration.books.extractor import SettingExtractor
+from integration.books.adapter import BookToRPGAdapter
+
+
+def test_setting_extractor_basic_functions():
+    content = (
+        "The city Neverwinter must remain hidden. "
+        "Knights shall protect the realm. "
+        "A mysterious quest awaits in the forest Greenwood. "
+        "There is a secret threat rising."
+    )
+    characters = [{"name": "Alice", "traits": ["brave"]}, "Bob"]
+
+    extractor = SettingExtractor()
+
+    rules = extractor.extract_world_rules(content)
+    assert "The city Neverwinter must remain hidden" in rules
+    assert "Knights shall protect the realm" in rules
+
+    npcs = extractor.create_npcs_from_characters(characters)
+    assert any(npc["name"] == "Alice" for npc in npcs)
+    assert any(npc["name"] == "Bob" for npc in npcs)
+
+    locations = extractor.generate_locations(content)
+    assert "Neverwinter" in locations
+    assert "Greenwood" in locations
+
+    hooks = extractor.extract_plot_hooks(content)
+    assert any("mysterious quest" in hook for hook in hooks)
+    assert any("secret threat" in hook for hook in hooks)
+
+
+def test_book_to_rpg_adapter_workflow():
+    content = (
+        "The city Neverwinter must remain hidden. "
+        "A mysterious quest awaits in the forest Greenwood."
+    )
+    book = {
+        "title": "Mystery of Neverwinter",
+        "content": content,
+        "characters": [{"name": "Alice", "level": 2}, {"name": "Bob", "level": 4}],
+    }
+    adapter = BookToRPGAdapter()
+    campaign = adapter.create_campaign_from_book(book, "DND")
+
+    assert campaign["title"] == "Mystery of Neverwinter"
+    assert campaign["system"] == "DND"
+    assert "Neverwinter" in campaign["locations"]
+    assert campaign["npcs"][0]["name"] == "Alice"
+
+    balanced = adapter.balance_characters_for_game(book["characters"])
+    assert all(char["level"] == 3 for char in balanced)
+
+    adventures = adapter.generate_adventures(campaign["plot_hooks"])
+    assert adventures
+    assert adventures[0]["summary"] in campaign["plot_hooks"]


### PR DESCRIPTION
## Summary
- add `SettingExtractor` to pull rules, locations, NPCs, and plot hooks from book text
- add `BookToRPGAdapter` to build campaigns, balance characters, and generate adventures
- cover new functionality with unit tests

## Testing
- `pytest tests/test_book_adapter.py -q`
- `pytest -q` *(fails: TagProcessor expected behavior and Neyra integration)*

------
https://chatgpt.com/codex/tasks/task_e_6891c125b2f48323873b3e5061044c82