### PR TITLE
Add serialization helpers for UI components

### DIFF
--- a/tests/test_ui_serialization.py
+++ b/tests/test_ui_serialization.py
@@ -1,0 +1,28 @@
+"""Tests for simple UI serialization helpers."""
+
+from ui.campaign_interface import CampaignInterface
+from ui.virtual_table import VirtualTable
+from ui.master_screen import MasterScreen
+
+
+class _Dummy:
+    def serialize(self):  # pragma: no cover - trivial
+        return {"foo": "bar"}
+
+
+def test_campaign_interface_serializes_sections() -> None:
+    ci = CampaignInterface()
+    ci.add_section("dummy", _Dummy())
+    assert ci.render() == {"dummy": {"foo": "bar"}}
+
+
+def test_virtual_table_serializes_components() -> None:
+    table = VirtualTable()
+    table.add_component("dummy", _Dummy())
+    assert table.render() == {"dummy": {"foo": "bar"}}
+
+
+def test_master_screen_serializes_tools() -> None:
+    screen = MasterScreen()
+    screen.add_tool("dummy", _Dummy())
+    assert screen.render() == {"dummy": {"foo": "bar"}}

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI layer for web-facing integrations."""

--- a/ui/campaign_interface.py
+++ b/ui/campaign_interface.py
@@ -1,0 +1,47 @@
+"""Campaign interface configuration and serialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class CampaignInterface:
+    """Container for campaign UI sections.
+
+    Parameters
+    ----------
+    sections:
+        Mapping of section name to the object representing that section.
+    """
+
+    sections: Dict[str, Any] = field(default_factory=dict)
+
+    def add_section(self, name: str, section: Any) -> None:
+        """Register a new section under ``name``."""
+        self.sections[name] = section
+
+    # serialization helpers -------------------------------------------------
+    def serialize(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the sections.
+
+        ``section`` values that expose their own ``serialize`` method will be
+        delegated to.  Otherwise the value is used as-is, which means basic
+        Python data structures are passed straight through while complex
+        objects fall back to ``repr``.
+        """
+
+        serialised: Dict[str, Any] = {}
+        for name, section in self.sections.items():
+            if hasattr(section, "serialize"):
+                serialised[name] = section.serialize()  # type: ignore[call-arg]
+            elif isinstance(section, (dict, list, str, int, float, bool)) or section is None:
+                serialised[name] = section
+            else:
+                serialised[name] = repr(section)
+        return serialised
+
+    def render(self) -> Dict[str, Any]:
+        """Expose the interface in a form suitable for front-end rendering."""
+        return self.serialize()

--- a/ui/master_screen.py
+++ b/ui/master_screen.py
@@ -1,0 +1,33 @@
+"""Screen used by the game master to control the session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class MasterScreen:
+    """Collection of tools available to the game master."""
+
+    tools: Dict[str, Any] = field(default_factory=dict)
+
+    def add_tool(self, name: str, tool: Any) -> None:
+        """Register a tool on the master screen."""
+        self.tools[name] = tool
+
+    def serialize(self) -> Dict[str, Any]:
+        """Return a serialisable mapping of the screen's tools."""
+        serialised: Dict[str, Any] = {}
+        for name, tool in self.tools.items():
+            if hasattr(tool, "serialize"):
+                serialised[name] = tool.serialize()  # type: ignore[call-arg]
+            elif isinstance(tool, (dict, list, str, int, float, bool)) or tool is None:
+                serialised[name] = tool
+            else:
+                serialised[name] = repr(tool)
+        return serialised
+
+    def render(self) -> Dict[str, Any]:
+        """Expose the master screen in a form that the front-end can render."""
+        return self.serialize()

--- a/ui/virtual_table.py
+++ b/ui/virtual_table.py
@@ -1,0 +1,33 @@
+"""Abstractions for a virtual tabletop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class VirtualTable:
+    """Representation of a virtual table and its components."""
+
+    components: Dict[str, Any] = field(default_factory=dict)
+
+    def add_component(self, name: str, component: Any) -> None:
+        """Register a component on the table."""
+        self.components[name] = component
+
+    def serialize(self) -> Dict[str, Any]:
+        """Produce a serialisable mapping of the table components."""
+        serialised: Dict[str, Any] = {}
+        for name, component in self.components.items():
+            if hasattr(component, "serialize"):
+                serialised[name] = component.serialize()  # type: ignore[call-arg]
+            elif isinstance(component, (dict, list, str, int, float, bool)) or component is None:
+                serialised[name] = component
+            else:
+                serialised[name] = repr(component)
+        return serialised
+
+    def render(self) -> Dict[str, Any]:
+        """Return data ready for front-end rendering."""
+        return self.serialize()


### PR DESCRIPTION
## Summary
- add CampaignInterface class with serialization helpers
- add VirtualTable and MasterScreen structures with render/serialize methods
- cover new UI structures with simple tests

## Testing
- `pytest` *(fails: TagProcessor tests and Neyra integration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891c30dc3388323a6536c18a8fa59a0