### PR TITLE
Add RPG learning and game balancing utilities

### DIFF
--- a/src/learning/rpg_learning.py
+++ b/src/learning/rpg_learning.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Simple adaptive learning helpers for game masters."""
+
+from collections import Counter
+from typing import Dict, List, Mapping, Sequence
+
+
+class RPGLearningSystem:
+    """Lightweight system that learns from game sessions.
+
+    The class keeps track of the master's skills, personality adjustments
+    and notable successful scenarios. It exposes small utility methods
+    that operate on basic Python data structures so they can be easily
+    tested and integrated.
+    """
+
+    def __init__(self) -> None:
+        self.skill_ratings: Dict[str, int] = {}
+        self.personality_traits: Dict[str, float] = {}
+        self.successful_scenarios: List[str] = []
+
+    def analyze_player_reactions(self, reactions: Sequence[str]) -> Dict[str, int]:
+        """Count occurrences of each reaction in ``reactions``.
+
+        Parameters
+        ----------
+        reactions:
+            Collection of player reaction labels.
+
+        Returns
+        -------
+        dict
+            Mapping of reaction label to number of times it appeared.
+        """
+
+        return dict(Counter(reactions))
+
+    def improve_master_skills(self, feedback: Mapping[str, int]) -> Dict[str, int]:
+        """Update internal skill ratings using ``feedback`` increments."""
+
+        for skill, delta in feedback.items():
+            self.skill_ratings[skill] = self.skill_ratings.get(skill, 0) + int(delta)
+        return dict(self.skill_ratings)
+
+    def adapt_personality_behaviors(
+        self, adjustments: Mapping[str, float]
+    ) -> Dict[str, float]:
+        """Apply ``adjustments`` to personality traits, clamped to [-1.0, 1.0]."""
+
+        for trait, delta in adjustments.items():
+            value = self.personality_traits.get(trait, 0.0) + float(delta)
+            self.personality_traits[trait] = max(-1.0, min(1.0, value))
+        return dict(self.personality_traits)
+
+    def learn_from_successful_scenarios(self, scenarios: Sequence[str]) -> List[str]:
+        """Record unique ``scenarios`` that yielded positive results."""
+
+        for scenario in scenarios:
+            if scenario not in self.successful_scenarios:
+                self.successful_scenarios.append(scenario)
+        return list(self.successful_scenarios)

--- a/src/mechanics/balancer.py
+++ b/src/mechanics/balancer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Utilities for keeping game encounters balanced."""
+
+from typing import Dict, List, Sequence
+
+
+class GameBalancer:
+    """Track encounter difficulty and spotlight distribution."""
+
+    def __init__(self) -> None:
+        self.difficulties: List[int] = []
+        self.challenge_level: float = 0.0
+        self.participation: Dict[str, int] = {}
+
+    def monitor_encounter_difficulty(self, difficulty: int) -> float:
+        """Record *difficulty* and return the rolling average."""
+
+        self.difficulties.append(int(difficulty))
+        return sum(self.difficulties) / len(self.difficulties)
+
+    def adjust_challenge_level(self, target_average: float) -> float:
+        """Adjust ``challenge_level`` toward ``target_average`` and return it."""
+
+        if not self.difficulties:
+            self.challenge_level = float(target_average)
+        else:
+            current = sum(self.difficulties) / len(self.difficulties)
+            self.challenge_level += target_average - current
+        return self.challenge_level
+
+    def ensure_spotlight_distribution(self, actors: Sequence[str]) -> bool:
+        """Track *actors* participation and ensure it stays roughly even.
+
+        Returns ``True`` if the difference between the most and least active
+        actors is at most one; otherwise ``False``.
+        """
+
+        for actor in actors:
+            self.participation[actor] = self.participation.get(actor, 0) + 1
+        counts = list(self.participation.values())
+        return max(counts) - min(counts) <= 1 if counts else True

--- a/tests/test_learning/test_rpg_learning.py
+++ b/tests/test_learning/test_rpg_learning.py
@@ -1,0 +1,33 @@
+"""Tests for the RPGLearningSystem."""
+
+from __future__ import annotations
+
+from src.learning.rpg_learning import RPGLearningSystem
+
+
+def test_analyze_player_reactions_counts_labels() -> None:
+    system = RPGLearningSystem()
+    reactions = ["happy", "sad", "happy"]
+    assert system.analyze_player_reactions(reactions) == {"happy": 2, "sad": 1}
+
+
+def test_improve_master_skills_accumulates_feedback() -> None:
+    system = RPGLearningSystem()
+    system.improve_master_skills({"craft": 2})
+    updated = system.improve_master_skills({"craft": 3, "magic": 1})
+    assert updated == {"craft": 5, "magic": 1}
+
+
+def test_adapt_personality_behaviors_clamps_values() -> None:
+    system = RPGLearningSystem()
+    system.personality_traits = {"bold": 0.9}
+    traits = system.adapt_personality_behaviors({"bold": 0.5, "cautious": -0.2})
+    assert traits["bold"] == 1.0
+    assert traits["cautious"] == -0.2
+
+
+def test_learn_from_successful_scenarios_records_unique() -> None:
+    system = RPGLearningSystem()
+    system.learn_from_successful_scenarios(["quest1", "quest2"])
+    scenarios = system.learn_from_successful_scenarios(["quest2", "quest3"])
+    assert scenarios == ["quest1", "quest2", "quest3"]

--- a/tests/test_mechanics/test_balancer.py
+++ b/tests/test_mechanics/test_balancer.py
@@ -1,0 +1,27 @@
+"""Tests for the GameBalancer."""
+
+from __future__ import annotations
+
+from src.mechanics.balancer import GameBalancer
+
+
+def test_monitor_encounter_difficulty_returns_average() -> None:
+    balancer = GameBalancer()
+    assert balancer.monitor_encounter_difficulty(5) == 5
+    assert balancer.monitor_encounter_difficulty(7) == 6
+
+
+def test_adjust_challenge_level_moves_toward_target() -> None:
+    balancer = GameBalancer()
+    balancer.monitor_encounter_difficulty(5)
+    balancer.monitor_encounter_difficulty(7)
+    level = balancer.adjust_challenge_level(8)
+    assert level == 2
+    assert balancer.adjust_challenge_level(5) == 1
+
+
+def test_ensure_spotlight_distribution_checks_balance() -> None:
+    balancer = GameBalancer()
+    assert balancer.ensure_spotlight_distribution(["Alice", "Bob"])
+    assert balancer.ensure_spotlight_distribution(["Alice"])
+    assert not balancer.ensure_spotlight_distribution(["Alice"])


### PR DESCRIPTION
## Summary
- introduce `RPGLearningSystem` for reaction analysis, skill and personality adaptation, and scenario tracking
- add `GameBalancer` to monitor difficulty, adjust challenge level, and balance spotlight among actors

## Testing
- `pytest` (fails: TagProcessor and Neyra integration tests)


------
https://chatgpt.com/codex/tasks/task_e_6891c4ad7654832398dbc18ad6116ec6