### PR TITLE
Add personality context and session memory utilities

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,4 +1,11 @@
 from .cache_manager import CacheManager
 from .ai_personality import AIPersonality
+from .personality_context import PersonalityContext
+from .session_memory import SessionMemory
 
-__all__ = ["CacheManager", "AIPersonality"]
+__all__ = [
+    "CacheManager",
+    "AIPersonality",
+    "PersonalityContext",
+    "SessionMemory",
+]

--- a/src/core/personality_context.py
+++ b/src/core/personality_context.py
@@ -1,0 +1,53 @@
+"""Manage multiple AI personalities and their knowledge separation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Set
+
+
+class PersonalityContext:
+    """Store and switch between multiple AI personalities.
+
+    Each personality has an isolated knowledge base but knowledge can be
+    selectively shared with others.
+    """
+
+    def __init__(self) -> None:
+        self._personalities: Dict[str, Dict[str, Any]] = {}
+        self.current: str | None = None
+
+    def switch_to_personality(self, personality_id: str) -> str:
+        """Activate ``personality_id`` and create it if missing."""
+        self.current = personality_id
+        self._personalities.setdefault(personality_id, {"knowledge": set()})
+        return personality_id
+
+    def maintain_separation(self) -> Set[Any]:
+        """Return a snapshot of the current personality's knowledge base."""
+        if self.current is None:
+            return set()
+        knowledge: Set[Any] = self._personalities[self.current]["knowledge"]
+        return set(knowledge)
+
+    def share_knowledge(
+        self,
+        knowledge: Iterable[Any],
+        target_personalities: Iterable[str] | None = None,
+    ) -> None:
+        """Share ``knowledge`` with other personalities.
+
+        ``target_personalities`` specifies which personalities should receive
+        the knowledge.  When ``None`` all personalities except the current one
+        are updated.
+        """
+
+        if self.current is None:
+            return
+        targets = (
+            [pid for pid in self._personalities if pid != self.current]
+            if target_personalities is None
+            else list(target_personalities)
+        )
+        for pid in targets:
+            self._personalities.setdefault(pid, {"knowledge": set()})
+            self._personalities[pid]["knowledge"].update(knowledge)

--- a/src/core/session_memory.py
+++ b/src/core/session_memory.py
@@ -1,0 +1,52 @@
+"""Persist and retrieve session information for the application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+
+@dataclass
+class SessionRecord:
+    """Internal record capturing the session state."""
+
+    session: Any
+    saved_at: datetime
+
+
+class SessionMemory:
+    """In-memory storage for session states and character progression."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, SessionRecord] = {}
+        self._development: Dict[str, List[Dict[str, Any]]] = {}
+
+    def save_session_state(self, session: Any) -> None:
+        """Store ``session`` by its ``id`` attribute."""
+        session_id = getattr(session, "id", None) or getattr(
+            session, "session_id", None
+        )
+        if session_id is None:
+            raise ValueError("session must have an 'id' or 'session_id' attribute")
+        self._sessions[session_id] = SessionRecord(
+            session=session, saved_at=datetime.utcnow()
+        )
+
+    def load_session_state(self, session_id: str) -> Any | None:
+        """Return previously saved session for ``session_id`` if present."""
+        record = self._sessions.get(session_id)
+        return record.session if record else None
+
+    def track_character_development(self, character: Any) -> List[Dict[str, Any]]:
+        """Append a timestamped snapshot of ``character`` state."""
+        character_id = getattr(character, "id", None)
+        if character_id is None:
+            raise ValueError("character must have an 'id' attribute")
+        snapshot = {
+            "timestamp": datetime.utcnow(),
+            "state": getattr(character, "state", None),
+        }
+        history = self._development.setdefault(character_id, [])
+        history.append(snapshot)
+        return list(history)


### PR DESCRIPTION
## Summary
- introduce `PersonalityContext` to manage multiple personalities and share knowledge selectively
- add `SessionMemory` for saving sessions and tracking character development
- expose the new utilities via the core package

## Testing
- `pytest` *(fails: TypeError and various assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_6891c689dcc8832383123b8ab487486b