### PR TITLE
Add ebook, PDF, and office file handlers with tests

### DIFF
--- a/src/file_handlers/ebook_handler.py
+++ b/src/file_handlers/ebook_handler.py
@@ -1,15 +1,27 @@
-"""Placeholder handler for electronic book formats."""
+"""Handler for electronic book formats using :mod:`ebooklib`."""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Dict
 
 from .base_handler import BaseFileHandler
 
+try:  # pragma: no-cover - optional dependency
+    from ebooklib import epub, ITEM_DOCUMENT
+except Exception:  # pragma: no-cover
+    epub = None  # type: ignore
+    ITEM_DOCUMENT = None  # type: ignore
+
 
 class EbookHandler(BaseFileHandler):
-    """Handle ``.epub``, ``.fb2`` and ``.mobi`` files."""
+    """Handle ``.epub`` files.
+
+    The handler currently supports reading and writing ``.epub`` documents.  The
+    ``.fb2`` and ``.mobi`` formats are recognised but will raise a
+    ``RuntimeError`` when used.
+    """
 
     _extensions = {".epub", ".fb2", ".mobi"}
 
@@ -17,10 +29,61 @@ class EbookHandler(BaseFileHandler):
         """See base class."""
         return Path(file_path).suffix.lower() in self._extensions
 
+    def _require_epub(self) -> None:
+        if epub is None:  # pragma: no cover - happens when dependency missing
+            raise RuntimeError("ebooklib is required to handle e-book files")
+
     def read_file(self, file_path: str) -> Dict[str, Any]:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("E-book support is not implemented")
+        path = Path(file_path)
+        ext = path.suffix.lower()
+        if ext != ".epub":
+            raise RuntimeError(f"Unsupported e-book format: {ext}")
+        self._require_epub()
+        try:
+            book = epub.read_epub(str(path))
+        except Exception as exc:  # pragma: no cover - corrupted file
+            raise RuntimeError(f"Failed to read e-book: {exc}") from exc
+        texts = []
+        for item in book.get_items_of_type(ITEM_DOCUMENT):
+            try:
+                raw = item.get_content().decode("utf-8", errors="ignore")
+            except Exception:  # pragma: no cover - safety
+                continue
+            texts.append(re.sub(r"<[^>]+>", "", raw))
+        metadata = {k: v for k, v in book.metadata.items()}
+        return {
+            "title": book.get_metadata("DC", "title")[0][0]
+            if book.get_metadata("DC", "title")
+            else path.stem,
+            "content": "\n".join(texts),
+            "metadata": metadata,
+            "structure": {"chapters": len(texts)},
+            "encoding": "utf-8",
+            "format": ext.lstrip("."),
+        }
 
     def save_file(self, file_path: str, data: Dict[str, Any]) -> bool:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("E-book support is not implemented")
+        path = Path(file_path)
+        ext = path.suffix.lower()
+        if ext != ".epub":
+            raise RuntimeError(f"Unsupported e-book format: {ext}")
+        self._require_epub()
+        try:
+            book = epub.EpubBook()
+            title = data.get("title", path.stem)
+            book.set_title(title)
+            chapter = epub.EpubHtml(
+                title="chapter1",
+                file_name="chap_1.xhtml",
+                content=f"<p>{data.get('content', '')}</p>",
+            )
+            book.add_item(chapter)
+            book.add_item(epub.EpubNcx())
+            book.add_item(epub.EpubNav())
+            book.spine = ["nav", chapter]
+            epub.write_epub(str(path), book)
+        except Exception as exc:  # pragma: no cover - disk issues etc.
+            raise RuntimeError(f"Failed to write e-book: {exc}") from exc
+        return True

--- a/src/file_handlers/office_handler.py
+++ b/src/file_handlers/office_handler.py
@@ -1,4 +1,4 @@
-"""Placeholder handlers for office document formats."""
+"""Handlers for office document formats using :mod:`python-docx`."""
 
 from __future__ import annotations
 
@@ -7,13 +7,17 @@ from typing import Any, Dict
 
 from .base_handler import BaseFileHandler
 
+try:  # pragma: no-cover - optional dependency
+    from docx import Document
+except Exception:  # pragma: no-cover
+    Document = None  # type: ignore
+
 
 class OfficeHandler(BaseFileHandler):
-    """Handle ``.doc``, ``.docx`` and ``.odt`` files.
+    """Handle ``.docx`` files.
 
-    The implementation is intentionally minimal and only validates support for
-    a given file extension.  Actual reading and writing will be implemented in
-    future iterations.
+    The ``.doc`` and ``.odt`` extensions are recognised but not currently
+    implemented and will raise a ``RuntimeError`` when used.
     """
 
     _extensions = {".doc", ".docx", ".odt"}
@@ -22,10 +26,49 @@ class OfficeHandler(BaseFileHandler):
         """See base class."""
         return Path(file_path).suffix.lower() in self._extensions
 
+    def _require_docx(self) -> None:
+        if Document is None:  # pragma: no cover
+            raise RuntimeError("python-docx is required to handle Office files")
+
     def read_file(self, file_path: str) -> Dict[str, Any]:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("Office document support is not implemented")
+        path = Path(file_path)
+        ext = path.suffix.lower()
+        if ext != ".docx":
+            raise RuntimeError(f"Unsupported office format: {ext}")
+        self._require_docx()
+        try:
+            doc = Document(str(path))
+        except Exception as exc:  # pragma: no cover - corrupted file
+            raise RuntimeError(f"Failed to read document: {exc}") from exc
+        paragraphs = [p.text for p in doc.paragraphs]
+        metadata = {
+            "author": doc.core_properties.author,
+            "created": doc.core_properties.created.isoformat()
+            if doc.core_properties.created
+            else None,
+        }
+        return {
+            "title": path.stem,
+            "content": "\n".join(paragraphs),
+            "metadata": metadata,
+            "structure": {"paragraphs": len(paragraphs)},
+            "encoding": "utf-8",
+            "format": ext.lstrip("."),
+        }
 
     def save_file(self, file_path: str, data: Dict[str, Any]) -> bool:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("Office document support is not implemented")
+        path = Path(file_path)
+        ext = path.suffix.lower()
+        if ext != ".docx":
+            raise RuntimeError(f"Unsupported office format: {ext}")
+        self._require_docx()
+        try:
+            doc = Document()
+            for line in data.get("content", "").splitlines():
+                doc.add_paragraph(line)
+            doc.save(str(path))
+        except Exception as exc:  # pragma: no cover - disk issues etc.
+            raise RuntimeError(f"Failed to write document: {exc}") from exc
+        return True

--- a/src/file_handlers/pdf_handler.py
+++ b/src/file_handlers/pdf_handler.py
@@ -1,4 +1,4 @@
-"""Placeholder handler for PDF documents."""
+"""PDF document handler using :mod:`PyPDF2`."""
 
 from __future__ import annotations
 
@@ -6,6 +6,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .base_handler import BaseFileHandler
+
+try:  # pragma: no-cover - optional dependency
+    from PyPDF2 import PdfReader, PdfWriter
+except Exception:  # pragma: no-cover
+    PdfReader = None  # type: ignore
+    PdfWriter = None  # type: ignore
 
 
 class PDFHandler(BaseFileHandler):
@@ -17,10 +23,60 @@ class PDFHandler(BaseFileHandler):
         """See base class."""
         return Path(file_path).suffix.lower() in self._extensions
 
+    def _require_pypdf(self) -> None:
+        if PdfReader is None or PdfWriter is None:  # pragma: no cover
+            raise RuntimeError("PyPDF2 is required to handle PDF files")
+
     def read_file(self, file_path: str) -> Dict[str, Any]:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("PDF support is not implemented")
+        self._require_pypdf()
+        path = Path(file_path)
+        try:
+            reader = PdfReader(str(path))
+        except Exception as exc:  # pragma: no cover - corrupted file
+            raise RuntimeError(f"Failed to read PDF: {exc}") from exc
+        texts = []
+        for page in reader.pages:
+            text = page.extract_text() or ""
+            if text:
+                texts.append(text)
+        metadata = {k[1:]: v for k, v in (reader.metadata or {}).items()}
+        return {
+            "title": path.stem,
+            "content": "\n".join(texts),
+            "metadata": metadata,
+            "structure": {"pages": len(reader.pages)},
+            "encoding": "utf-8",
+            "format": "pdf",
+        }
 
     def save_file(self, file_path: str, data: Dict[str, Any]) -> bool:  # noqa: D401
         """See base class."""
-        raise NotImplementedError("PDF support is not implemented")
+        self._require_pypdf()
+        path = Path(file_path)
+        content = data.get("content", "")
+        try:
+            try:  # pragma: no cover - reportlab may not be installed
+                from reportlab.pdfgen import canvas
+            except Exception as exc:  # pragma: no cover
+                raise RuntimeError("reportlab is required to save PDF files") from exc
+
+            # First create a simple PDF with ReportLab
+            c = canvas.Canvas(str(path))
+            textobject = c.beginText(40, 800)
+            for line in content.splitlines():
+                textobject.textLine(line)
+            c.drawText(textobject)
+            c.save()
+
+            # Attach any metadata using PyPDF2
+            reader = PdfReader(str(path))
+            writer = PdfWriter()
+            writer.clone_document_from_reader(reader)
+            if meta := data.get("metadata"):
+                writer.add_metadata({f"/{k}": v for k, v in meta.items()})
+            with open(path, "wb") as fh:
+                writer.write(fh)
+        except Exception as exc:  # pragma: no cover - disk issues etc.
+            raise RuntimeError(f"Failed to write PDF: {exc}") from exc
+        return True

--- a/tests/test_file_handlers/test_ebook_handler.py
+++ b/tests/test_file_handlers/test_ebook_handler.py
@@ -1,0 +1,21 @@
+"""Tests for the :class:`EbookHandler`."""
+
+from src.file_handlers.ebook_handler import EbookHandler
+
+
+def test_epub_roundtrip(tmp_path):
+    handler = EbookHandler()
+    data = {
+        "title": "sample",
+        "content": "Hello EPUB",
+        "metadata": {},
+        "structure": {},
+        "encoding": "utf-8",
+        "format": "epub",
+    }
+
+    file_path = tmp_path / "sample.epub"
+    assert handler.save_file(str(file_path), data)
+
+    read_back = handler.read_file(str(file_path))
+    assert "Hello EPUB" in read_back["content"]

--- a/tests/test_file_handlers/test_office_handler.py
+++ b/tests/test_file_handlers/test_office_handler.py
@@ -1,0 +1,21 @@
+"""Tests for the :class:`OfficeHandler`."""
+
+from src.file_handlers.office_handler import OfficeHandler
+
+
+def test_docx_roundtrip(tmp_path):
+    handler = OfficeHandler()
+    data = {
+        "title": "sample",
+        "content": "Hello DOCX",
+        "metadata": {},
+        "structure": {},
+        "encoding": "utf-8",
+        "format": "docx",
+    }
+
+    file_path = tmp_path / "sample.docx"
+    assert handler.save_file(str(file_path), data)
+
+    read_back = handler.read_file(str(file_path))
+    assert read_back["content"].strip() == "Hello DOCX"

--- a/tests/test_file_handlers/test_pdf_handler.py
+++ b/tests/test_file_handlers/test_pdf_handler.py
@@ -1,0 +1,21 @@
+"""Tests for the :class:`PDFHandler`."""
+
+from src.file_handlers.pdf_handler import PDFHandler
+
+
+def test_pdf_roundtrip(tmp_path):
+    handler = PDFHandler()
+    data = {
+        "title": "sample",
+        "content": "Hello PDF world",
+        "metadata": {},
+        "structure": {},
+        "encoding": "utf-8",
+        "format": "pdf",
+    }
+
+    file_path = tmp_path / "sample.pdf"
+    assert handler.save_file(str(file_path), data)
+
+    read_back = handler.read_file(str(file_path))
+    assert "Hello PDF world" in read_back["content"]


### PR DESCRIPTION
## Summary
- implement ebook handler using ebooklib with read and write support
- integrate PyPDF2 with ReportLab to read/write PDFs
- add docx handler with python-docx
- test round-trip loading/saving for epub, pdf, and docx formats

## Testing
- `pytest tests/test_file_handlers/test_pdf_handler.py tests/test_file_handlers/test_office_handler.py tests/test_file_handlers/test_ebook_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d4eb1a808323a3cd5026d4c04738