### PR TITLE
Add narrative weaving with conflict resolution and tests

### DIFF
--- a/src/action/story_weaver.py
+++ b/src/action/story_weaver.py
@@ -2,6 +2,79 @@
 Ткач историй - переплетаю сюжетные линии.
 """
 
+from __future__ import annotations
+
+import re
+from typing import List
+
+
 class StoryWeaver:
     """Сплетаю отдельные сцены в цельное повествование."""
-    pass
+
+    _transitions: List[str] = ["Then", "Next", "Afterward", "Meanwhile"]
+
+    def weave(self, scenes: List[str]) -> str:
+        """Комбинировать фрагменты сцен в единый рассказ.
+
+        Метод добавляет переходы между сценами и пытается устранить
+        противоречия простым анализом состояний персонажей.
+
+        Args:
+            scenes: Список фрагментов сцен.
+
+        Returns:
+            str: Сложенное повествование.
+        """
+
+        cleaned = [s.strip() for s in scenes if s and s.strip()]
+        if not cleaned:
+            return ""
+
+        narrative: List[str] = []
+        last_fragment = ""
+        trans_idx = 0
+        states: dict[str, str] = {}
+        pattern = re.compile(
+            r"^(?P<subject>\w+) is (?P<state>\w+)([.!?])?", re.IGNORECASE
+        )
+
+        for fragment in cleaned:
+            if last_fragment and fragment.lower() == last_fragment.lower():
+                # Повторяющиеся сцены удаляются
+                continue
+
+            prefix = ""
+            match = pattern.match(fragment)
+            if match:
+                subject = match.group("subject")
+                state = match.group("state")
+                prev = states.get(subject)
+                if prev and prev != state:
+                    prefix = "However, "
+                elif prev == state:
+                    # состояние не изменилось - сцена избыточна
+                    continue
+                states[subject] = state
+
+            if not prefix and narrative:
+                prefix = self._transitions[trans_idx % len(self._transitions)] + ", "
+                trans_idx += 1
+            elif prefix and narrative:
+                trans_idx += 1
+
+            # Обеспечить корректное окончание сцены
+            if fragment[-1] not in ".!?":
+                fragment += "."
+
+            if prefix.endswith(", "):
+                base = prefix[:-2]
+                if base in self._transitions:
+                    first_word = fragment.split()[0]
+                    pronouns = {"he", "she", "it", "they", "we", "i", "you"}
+                    if first_word.lower() in pronouns:
+                        fragment = first_word.lower() + fragment[len(first_word) :]
+
+            narrative.append(prefix + fragment)
+            last_fragment = fragment
+
+        return " ".join(narrative)

--- a/tests/test_action/test_story_weaver.py
+++ b/tests/test_action/test_story_weaver.py
@@ -1,0 +1,47 @@
+"""Tests for the StoryWeaver action."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path for src layout
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.action.story_weaver import StoryWeaver
+
+
+def test_weaves_with_transitions() -> None:
+    weaver = StoryWeaver()
+    scenes = [
+        "Alice enters the room.",
+        "She looks around.",
+        "Bob waves.",
+    ]
+
+    narrative = weaver.weave(scenes)
+    assert (
+        narrative == "Alice enters the room. Then, she looks around. Next, Bob waves."
+    )
+
+
+def test_resolves_conflicting_states() -> None:
+    weaver = StoryWeaver()
+    scenes = [
+        "Alice is happy.",
+        "Alice is sad.",
+        "Bob smiles.",
+    ]
+
+    narrative = weaver.weave(scenes)
+    assert narrative == "Alice is happy. However, Alice is sad. Next, Bob smiles."
+
+
+def test_removes_duplicate_scenes() -> None:
+    weaver = StoryWeaver()
+    scenes = [
+        "Bob laughs.",
+        "Bob laughs.",
+        "Bob cries.",
+    ]
+
+    narrative = weaver.weave(scenes)
+    assert narrative == "Bob laughs. Then, Bob cries."


### PR DESCRIPTION
## Summary
- implement `StoryWeaver.weave` to merge scene fragments with transitions, duplicate filtering, and simple state-based conflict handling
- add unit tests covering transitions, conflict resolution, and duplicate removal

## Testing
- `python -m pytest tests/test_action/test_story_weaver.py -q`
- `python -m pytest -q` *(fails: TagProcessor parsing & Neyra integration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891d59a5dc8832381c9e88c25d35e32