### PR TITLE
Enhance emotion analysis with negation handling

### DIFF
--- a/src/analysis/emotion_reader.py
+++ b/src/analysis/emotion_reader.py
@@ -18,16 +18,33 @@ class EmotionReader:
             "joy": {"happy", "joy", "joyful", "delight", "pleased", "smile"},
             "sadness": {"sad", "unhappy", "sorrow", "cry", "miserable"},
             "anger": {"angry", "mad", "furious", "rage", "irate"},
-            "fear": {"fear", "scared", "terrified", "afraid", "fright"},
+            "fear": {
+                "fear",
+                "scared",
+                "terrified",
+                "afraid",
+                "fright",
+                "nervous",
+                "anxious",
+            },
         }
+        # Негативные частицы для учета отрицаний.
+        self.negations: set[str] = {"not", "no", "never", "n't"}
 
     def analyze_text(self, text: str) -> Dict[str, float]:
-        """Возвращает оценки эмоций в диапазоне [0, 1] для текста."""
+        """Возвращает оценки эмоций в диапазоне [0, 1] для текста.
+
+        Ключевые слова каждой эмоции подсчитываются и нормируются, при
+        этом игнорируются слова, перед которыми стоит отрицание.
+        """
         words = re.findall(r"\b\w+\b", text.lower())
-        raw_scores = {
-            emotion: sum(1 for w in words if w in keywords)
-            for emotion, keywords in self.lexicon.items()
-        }
+        raw_scores: Dict[str, float] = {emotion: 0.0 for emotion in self.lexicon}
+        for idx, word in enumerate(words):
+            if idx > 0 and words[idx - 1] in self.negations:
+                continue
+            for emotion, keywords in self.lexicon.items():
+                if word in keywords:
+                    raw_scores[emotion] += 1
         return self.scale_scores(raw_scores)
 
     @staticmethod

--- a/tests/test_analysis/test_emotion_reader.py
+++ b/tests/test_analysis/test_emotion_reader.py
@@ -28,3 +28,16 @@ def test_detects_anger() -> None:
     scores = reader.analyze_text("He was angry and furious, filled with rage.")
     assert scores["anger"] == 1.0
     assert scores["joy"] < scores["anger"]
+
+
+def test_detects_fear() -> None:
+    reader = EmotionReader()
+    scores = reader.analyze_text("They felt scared and terrified by the dark.")
+    assert scores["fear"] == 1.0
+    assert scores["joy"] < scores["fear"]
+
+
+def test_handles_negation() -> None:
+    reader = EmotionReader()
+    scores = reader.analyze_text("I am not happy about this.")
+    assert scores["joy"] == 0.0


### PR DESCRIPTION
## Summary
- extend emotion lexicon with nervous/anxious and add simple negation handling
- scale emotion scores and allow combining multiple score dictionaries
- add tests for fear detection and negation effects

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*
- `pytest tests/test_analysis/test_emotion_reader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891d5b976c48323aea136cd9a3cf5a7