### PR TITLE
fix: handle missing PyYAML explicitly

### DIFF
--- a/src/mechanics/rules.py
+++ b/src/mechanics/rules.py
@@ -10,7 +10,7 @@ from .dice import DiceResult
 
 try:  # pragma: no cover - optional dependency
     import yaml
-except Exception:  # pragma: no cover - handled gracefully
+except ImportError:  # pragma: no cover - only handle missing PyYAML
     yaml = None
 
 # Directory containing ruleset files


### PR DESCRIPTION
## Summary
- narrow exception handling in rules to only catch missing PyYAML

## Testing
- `python -m pytest tests/ -v` (fails: ebooklib is required to handle e-books; python-docx is required to handle docx; PyPDF2 is required to handle PDF files)
- `python -m pytest tests/test_mechanics/test_rules.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6891e4a172e4832390f0c70b7f0a3d5d