### PR TITLE
Handle missing chardet gracefully in encoding detector

### DIFF
--- a/src/utils/encoding_detector.py
+++ b/src/utils/encoding_detector.py
@@ -22,7 +22,7 @@ from typing import Iterable, Tuple
 
 try:  # pragma: no-cover - ``chardet`` might not be installed
     import chardet  # type: ignore
-except Exception:  # pragma: no-cover
+except ImportError:  # pragma: no-cover
     chardet = None  # type: ignore
 
 # Encodings we officially support and their canonical return names.

--- a/tests/test_utils/test_encoding_detector.py
+++ b/tests/test_utils/test_encoding_detector.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+import builtins
+import importlib
+import sys
 
-from src.utils.encoding_detector import detect_encoding
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import src.utils.encoding_detector as encoding_detector
 
 
 def _write_text(path: Path, text: str, encoding: str) -> None:
@@ -23,4 +30,28 @@ def test_detect_encoding_handles_common_encodings(tmp_path: Path) -> None:
     for enc, expected in cases.items():
         file = tmp_path / f"sample_{enc}.txt"
         _write_text(file, sample, enc)
-        assert detect_encoding(file) == expected
+        assert encoding_detector.detect_encoding(file) == expected
+
+
+def test_detect_encoding_without_chardet(monkeypatch, tmp_path: Path) -> None:
+    """Detection should fall back gracefully when ``chardet`` is missing."""
+    sample = "Привет, Нейра!"
+    file = tmp_path / "sample_cp1251.txt"
+    _write_text(file, sample, "cp1251")
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "chardet":
+            raise ImportError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "chardet", raising=False)
+
+    module = importlib.reload(encoding_detector)
+    assert module.chardet is None
+    assert module.detect_encoding(file) == "windows-1251"
+
+    monkeypatch.setattr(builtins, "__import__", original_import)
+    importlib.reload(encoding_detector)


### PR DESCRIPTION
## Summary
- Narrow exception around optional chardet import to ImportError and keep fallback assignment
- Add tests verifying heuristic detection when chardet is absent

## Testing
- `pytest tests/test_utils/test_encoding_detector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e7eb8bc88323ab65b6acb8747cbd