### PR TITLE
feat: add memory index caching layers

### DIFF
--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -6,6 +6,7 @@ from .story_timeline import StoryTimeline
 from .world_atlas import WorldAtlas
 from .world_memory import WorldMemory
 from .style_memory import StyleMemory
+from .index import MemoryIndex
 
 __all__ = [
     "CharacterMemory",
@@ -14,5 +15,6 @@ __all__ = [
     "WorldAtlas",
     "WorldMemory",
     "StyleMemory",
+    "MemoryIndex",
 ]
 

--- a/src/memory/index.py
+++ b/src/memory/index.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Three-level caching index for memory records."""
+
+from typing import Any, Dict
+
+
+class MemoryIndex:
+    """Manage data between hot, warm and cold storage levels.
+
+    The index keeps track of how often each entry is accessed via
+    ``usage_stats``. Frequently used entries migrate upwards through the
+    caching tiers:
+
+    * Cold storage – baseline persistence for rarely used data.
+    * Warm cache   – items accessed occasionally.
+    * Hot cache    – frequently accessed items.
+
+    Periodic checks promote lightly used cold entries to the warm cache and
+    heavily used warm entries to the hot cache.
+    """
+
+    def __init__(self, hot_threshold: int = 5, warm_threshold: int = 2) -> None:
+        self.hot_cache: Dict[str, Any] = {}
+        self.warm_cache: Dict[str, Any] = {}
+        self.cold_storage: Dict[str, Any] = {}
+        self.usage_stats: Dict[str, int] = {}
+        self.hot_threshold = hot_threshold
+        self.warm_threshold = warm_threshold
+
+    def set(self, key: str, value: Any) -> None:
+        """Store a new entry in cold storage."""
+        self.cold_storage[key] = value
+
+    def get(self, key: str) -> Any:
+        """Retrieve an entry from the index."""
+        if key in self.hot_cache:
+            self._increment_usage(key)
+            return self.hot_cache[key]
+        if key in self.warm_cache:
+            self._increment_usage(key)
+            self._promote_to_hot(key)
+            if key in self.hot_cache:
+                return self.hot_cache[key]
+            return self.warm_cache[key]
+        value = self._search_cold_storage(key)
+        if value is not None:
+            self._increment_usage(key)
+        self._periodic_check()
+        return value
+
+    def _increment_usage(self, key: str) -> None:
+        self.usage_stats[key] = self.usage_stats.get(key, 0) + 1
+
+    def _promote_to_hot(self, key: str) -> None:
+        """Move an entry from the warm cache to the hot cache."""
+        if (
+            key in self.warm_cache
+            and self.usage_stats.get(key, 0) >= self.hot_threshold
+        ):
+            self.hot_cache[key] = self.warm_cache.pop(key)
+
+    def _add_to_warm(self, key: str, value: Any) -> None:
+        """Insert an entry into the warm cache removing it from cold storage."""
+        self.warm_cache[key] = value
+        self.cold_storage.pop(key, None)
+
+    def _search_cold_storage(self, key: str) -> Any:
+        """Look up an entry in cold storage."""
+        return self.cold_storage.get(key)
+
+    def _periodic_check(self) -> None:
+        """Promote lightly used cold entries to the warm cache."""
+        for key in list(self.cold_storage.keys()):
+            if self.usage_stats.get(key, 0) >= self.warm_threshold:
+                value = self.cold_storage[key]
+                self._add_to_warm(key, value)
+
+
+__all__ = ["MemoryIndex"]

--- a/tests/test_memory/test_memory_index.py
+++ b/tests/test_memory/test_memory_index.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from src.memory.index import MemoryIndex
+
+
+def test_promotes_cold_to_warm() -> None:
+    index = MemoryIndex(hot_threshold=10, warm_threshold=2)
+    index.set("alpha", 1)
+
+    assert index.get("alpha") == 1  # first access, stays in cold
+    assert "alpha" in index.cold_storage
+
+    # Second access triggers promotion to warm cache
+    index.get("alpha")
+    assert "alpha" in index.warm_cache
+    assert "alpha" not in index.cold_storage
+    assert index.usage_stats["alpha"] == 2
+
+
+def test_promotes_warm_to_hot() -> None:
+    index = MemoryIndex(hot_threshold=3, warm_threshold=1)
+    index.set("beta", 2)
+
+    # First access moves beta to warm cache
+    index.get("beta")
+    assert "beta" in index.warm_cache
+
+    # Further accesses promote beta to hot cache
+    index.get("beta")
+    index.get("beta")
+    assert "beta" in index.hot_cache
+    assert "beta" not in index.warm_cache
+    assert index.usage_stats["beta"] == 3
+
+
+def test_search_cold_storage() -> None:
+    index = MemoryIndex()
+    index.set("gamma", 3)
+    assert index._search_cold_storage("gamma") == 3


### PR DESCRIPTION
## Summary
- add MemoryIndex class with hot, warm and cold caching tiers and usage-based promotion
- expose MemoryIndex from memory package
- test cache promotion logic and cold storage search

## Testing
- `pytest tests/test_memory -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f4822a78832391b2883becf4d3af