### PR TITLE
Add compact character model with template expansion

### DIFF
--- a/characters/__init__.py
+++ b/characters/__init__.py
@@ -1,5 +1,6 @@
 """Character models for RPG scenarios."""
 
 from .rpg_character import RPGCharacter
+from .compact import CompactCharacter
 
-__all__ = ["RPGCharacter"]
+__all__ = ["RPGCharacter", "CompactCharacter"]

--- a/characters/compact.py
+++ b/characters/compact.py
@@ -1,0 +1,126 @@
+"""Compact character model with limited information storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+import json
+
+
+@dataclass
+class CompactCharacter:
+    """Representation of a character with compressed trait data.
+
+    Only a limited number of ``core_traits`` and ``story_moments`` are stored
+    to keep the object lightweight. The class provides helpers for expanding
+    the compact data using templates and for extracting new traits from a
+    textual context while respecting the size limits.
+    """
+
+    name: str
+    core_traits: List[str] = field(default_factory=list)
+    story_moments: List[str] = field(default_factory=list)
+
+    #: Maximum number of stored core traits.
+    MAX_CORE_TRAITS: int = 5
+    #: Maximum number of stored story moments.
+    MAX_STORY_MOMENTS: int = 10
+
+    def _trim_lists(self) -> None:
+        """Ensure internal lists do not exceed the configured limits."""
+        if len(self.core_traits) > self.MAX_CORE_TRAITS:
+            self.core_traits[:] = self.core_traits[-self.MAX_CORE_TRAITS :]
+        if len(self.story_moments) > self.MAX_STORY_MOMENTS:
+            self.story_moments[:] = self.story_moments[-self.MAX_STORY_MOMENTS :]
+
+    def _expand_from_templates(
+        self,
+        trait_templates: Dict[str, str],
+        moment_templates: Dict[str, str],
+    ) -> Dict[str, List[str]]:
+        """Expand compact data using template mappings.
+
+        Parameters
+        ----------
+        trait_templates:
+            Mapping of trait identifiers to their detailed descriptions.
+        moment_templates:
+            Mapping of moment identifiers to their detailed descriptions.
+
+        Returns
+        -------
+        Dict[str, List[str]]
+            Expanded ``core_traits`` and ``story_moments`` lists.
+        """
+
+        expanded_traits = [
+            trait_templates.get(trait, trait) for trait in self.core_traits
+        ]
+        expanded_moments = [
+            moment_templates.get(moment, moment) for moment in self.story_moments
+        ]
+        return {
+            "core_traits": expanded_traits,
+            "story_moments": expanded_moments,
+        }
+
+    def _extract_new_traits(
+        self, context: str, trait_patterns: Dict[str, str]
+    ) -> List[str]:
+        """Extract new traits from a context string.
+
+        The ``trait_patterns`` mapping relates trait names to simple substrings
+        that, if present in ``context``, indicate that the trait should be
+        attached to the character. Newly discovered traits are appended and
+        the lists are trimmed to respect the maximum sizes.
+
+        Parameters
+        ----------
+        context:
+            Textual context to search for traits.
+        trait_patterns:
+            Mapping of trait names to search substrings.
+
+        Returns
+        -------
+        List[str]
+            The updated list of ``core_traits``.
+        """
+
+        for trait, pattern in trait_patterns.items():
+            if pattern in context and trait not in self.core_traits:
+                self.core_traits.append(trait)
+                self._trim_lists()
+        return self.core_traits
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the character to a JSON-serializable dict."""
+        return {
+            "name": self.name,
+            "core_traits": list(self.core_traits),
+            "story_moments": list(self.story_moments),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CompactCharacter":
+        """Deserialize a :class:`CompactCharacter` from a dictionary."""
+        return cls(
+            name=data.get("name", ""),
+            core_traits=list(data.get("core_traits", [])),
+            story_moments=list(data.get("story_moments", [])),
+        )
+
+    def to_json(self) -> str:
+        """Serialize the character to a JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, data: str) -> "CompactCharacter":
+        """Deserialize a :class:`CompactCharacter` from JSON string."""
+        return cls.from_dict(json.loads(data))
+
+
+__all__ = ["CompactCharacter"]

--- a/tests/test_characters/test_compact_character.py
+++ b/tests/test_characters/test_compact_character.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from characters.compact import CompactCharacter
+
+
+def test_serialization_roundtrip():
+    original = CompactCharacter(
+        name="Hero",
+        core_traits=["brave", "cunning"],
+        story_moments=["battle_of_hill"],
+    )
+
+    json_data = original.to_json()
+    recreated = CompactCharacter.from_json(json_data)
+
+    assert recreated == original
+
+
+def test_extract_new_traits_with_limit():
+    char = CompactCharacter(
+        name="LimitTester",
+        core_traits=["a", "b", "c", "d", "e"],
+    )
+    context = "f g h"
+    patterns = {"f": "f", "g": "g", "h": "h"}
+
+    updated = char._extract_new_traits(context, patterns)
+
+    assert updated == ["d", "e", "f", "g", "h"]
+    assert len(updated) == char.MAX_CORE_TRAITS
+
+
+def test_expand_from_templates():
+    char = CompactCharacter(
+        name="TemplateTester",
+        core_traits=["brave"],
+        story_moments=["battle"],
+    )
+
+    expanded = char._expand_from_templates(
+        trait_templates={"brave": "Shows bravery"},
+        moment_templates={"battle": "Fought a great battle"},
+    )
+
+    assert expanded["core_traits"] == ["Shows bravery"]
+    assert expanded["story_moments"] == ["Fought a great battle"]


### PR DESCRIPTION
## Summary
- implement CompactCharacter with limited trait and moment storage
- expand compact data from templates and extract traits from context
- add JSON serialization and tests

## Testing
- `python -m pytest tests/test_characters/test_compact_character.py`

------
https://chatgpt.com/codex/tasks/task_e_689200ece5888323972a6f4a6ffe9959