### PR TITLE
Add weighted memory with decay scheduling

### DIFF
--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -7,6 +7,7 @@ from .world_atlas import WorldAtlas
 from .world_memory import WorldMemory
 from .style_memory import StyleMemory
 from .index import MemoryIndex
+from .weighted import WeightedMemory
 
 __all__ = [
     "CharacterMemory",
@@ -16,5 +17,6 @@ __all__ = [
     "WorldMemory",
     "StyleMemory",
     "MemoryIndex",
+    "WeightedMemory",
 ]
 

--- a/src/memory/weighted.py
+++ b/src/memory/weighted.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Weighted memory storage.
+
+This module provides a simple in-memory structure that associates arbitrary
+pieces of information with weights.  Weights decay over time which makes the
+structure suitable for implementing short‑term memory like behaviour where
+items gradually become less important unless reinforced.
+
+The class offers helper methods for adding memories, decaying their weights and
+strengthening them when they are accessed.  Additionally a light-weight
+scheduler based on :class:`threading.Timer` can periodically trigger weight
+updates so that applications may keep the memory fresh without manual
+intervention.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List
+import threading
+
+
+@dataclass
+class WeightedMemory:
+    """Store memories with associated weights that decay over time."""
+
+    decay_rate: float = 0.9
+    memories: List[Any] = field(default_factory=list)
+    weights: List[float] = field(default_factory=list)
+    _timer: threading.Timer | None = field(default=None, init=False, repr=False)
+
+    # ------------------------------------------------------------------
+    def add_memory(self, memory: Any, weight: float = 1.0) -> None:
+        """Add a new memory with an optional initial weight."""
+        self.memories.append(memory)
+        self.weights.append(weight)
+
+    # ------------------------------------------------------------------
+    def decay_memories(self) -> None:
+        """Apply exponential decay to all memory weights."""
+        self.weights = [w * self.decay_rate for w in self.weights]
+
+    # ------------------------------------------------------------------
+    def strengthen_memory(self, memory: Any, amount: float = 1.0) -> None:
+        """Increase the weight of a memory when it is accessed."""
+        if memory in self.memories:
+            idx = self.memories.index(memory)
+            self.weights[idx] += amount
+
+    # ------------------------------------------------------------------
+    def start_auto_decay(self, interval: float) -> None:
+        """Start a background timer that periodically decays memories."""
+        if self._timer:
+            self._timer.cancel()
+
+        def _tick() -> None:
+            self.decay_memories()
+            self.start_auto_decay(interval)
+
+        self._timer = threading.Timer(interval, _tick)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def stop_auto_decay(self) -> None:
+        """Stop the background decay timer if it is running."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+
+
+__all__ = ["WeightedMemory"]

--- a/tests/test_memory/test_weighted_memory.py
+++ b/tests/test_memory/test_weighted_memory.py
@@ -1,0 +1,29 @@
+"""Tests for the WeightedMemory class."""
+
+from __future__ import annotations
+
+import time
+
+from src.memory.weighted import WeightedMemory
+
+
+def test_add_strengthen_and_decay() -> None:
+    wm = WeightedMemory(decay_rate=0.5)
+    wm.add_memory("test", 2.0)
+    assert wm.memories == ["test"]
+    assert wm.weights == [2.0]
+
+    wm.strengthen_memory("test", amount=1.0)
+    assert wm.weights[0] == 3.0
+
+    wm.decay_memories()
+    assert wm.weights[0] == 1.5
+
+
+def test_auto_decay_scheduler() -> None:
+    wm = WeightedMemory(decay_rate=0.5)
+    wm.add_memory("auto", 4.0)
+    wm.start_auto_decay(0.1)
+    time.sleep(0.25)  # allow at least one decay cycle
+    wm.stop_auto_decay()
+    assert wm.weights[0] < 4.0


### PR DESCRIPTION
## Summary
- add `WeightedMemory` class to manage memories with weights that decay over time
- expose the new memory helper through the memory package
- test weighted memory operations and automatic decay scheduling

## Testing
- `pytest tests/test_memory/test_weighted_memory.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prompt_toolkit')*


------
https://chatgpt.com/codex/tasks/task_e_68920f03d36883239e6fa863f0edc5a7