### PR TITLE
Add priority-based processing queue

### DIFF
--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -1,0 +1,4 @@
+from .queue import ProcessingQueue
+from .types import Task, Priority
+
+__all__ = ["ProcessingQueue", "Task", "Priority"]

--- a/src/processing/queue.py
+++ b/src/processing/queue.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Optional, Any
+
+from .types import Priority, Task
+
+
+class ProcessingQueue:
+    """A queue managing tasks with different priorities."""
+
+    def __init__(self) -> None:
+        self.high: Deque[Task] = deque()
+        self.medium: Deque[Task] = deque()
+        self.low: Deque[Task] = deque()
+
+    def add_task(self, task: Task, priority: Priority = Priority.MEDIUM) -> None:
+        """Add a task to the queue based on its priority."""
+
+        if priority is Priority.HIGH:
+            self.high.append(task)
+        elif priority is Priority.MEDIUM:
+            self.medium.append(task)
+        else:
+            self.low.append(task)
+
+    def process_next(self) -> Optional[Any]:
+        """Process the next task based on priority.
+
+        Returns the result of the task execution, or ``None`` if no tasks remain.
+        """
+
+        if self.high:
+            task = self.high.popleft()
+        elif self.medium:
+            task = self.medium.popleft()
+        elif self.low:
+            task = self.low.popleft()
+        else:
+            return None
+        return task.run()

--- a/src/processing/types.py
+++ b/src/processing/types.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Callable, Tuple, Dict
+
+
+class Priority(Enum):
+    """Priority levels for tasks."""
+
+    HIGH = auto()
+    MEDIUM = auto()
+    LOW = auto()
+
+
+@dataclass
+class Task:
+    """A unit of work to be processed."""
+
+    func: Callable[..., Any]
+    args: Tuple[Any, ...] = field(default_factory=tuple)
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def run(self) -> Any:
+        """Execute the task and return the result."""
+
+        return self.func(*self.args, **self.kwargs)

--- a/tests/test_processing_queue.py
+++ b/tests/test_processing_queue.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for src layout
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.processing.queue import ProcessingQueue
+from src.processing.types import Task, Priority
+
+
+def make_task(name: str) -> Task:
+    return Task(func=lambda: name)
+
+
+def test_processing_queue_runs_tasks_by_priority():
+    queue = ProcessingQueue()
+
+    queue.add_task(make_task("low"), Priority.LOW)
+    queue.add_task(make_task("high1"), Priority.HIGH)
+    queue.add_task(make_task("medium"), Priority.MEDIUM)
+    queue.add_task(make_task("high2"), Priority.HIGH)
+
+    results = []
+    while True:
+        result = queue.process_next()
+        if result is None:
+            break
+        results.append(result)
+
+    assert results == ["high1", "high2", "medium", "low"]


### PR DESCRIPTION
## Summary
- implement Task dataclass and Priority enum
- add ProcessingQueue with high, medium, low queues
- cover queue with priority processing test

## Testing
- `pytest tests/test_processing_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_6892455f21b88323ab6b0096f2a2347a