### PR TITLE
Add basic neuron framework

### DIFF
--- a/src/neurons/__init__.py
+++ b/src/neurons/__init__.py
@@ -1,0 +1,17 @@
+"""Neuron classes for core processing.
+
+This module exposes base and specialized neuron types used within
+Neira's internal reasoning systems.
+"""
+
+from .base import Neuron
+from .memory import MemoryNeuron
+from .analysis import AnalysisNeuron
+from .action import ActionNeuron
+
+__all__ = [
+    "Neuron",
+    "MemoryNeuron",
+    "AnalysisNeuron",
+    "ActionNeuron",
+]

--- a/src/neurons/action.py
+++ b/src/neurons/action.py
@@ -1,0 +1,21 @@
+"""Action neuron."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Neuron
+
+
+@dataclass
+class ActionNeuron(Neuron):
+    """Neuron capable of triggering actions."""
+
+    type: str = "action"
+
+    # ------------------------------------------------------------------
+    def process(self, action: str) -> str:
+        """Return a textual representation of an action being executed."""
+
+        self.activate()
+        return f"action:{action}"

--- a/src/neurons/analysis.py
+++ b/src/neurons/analysis.py
@@ -1,0 +1,25 @@
+"""Analysis neuron."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from .base import Neuron
+
+
+@dataclass
+class AnalysisNeuron(Neuron):
+    """Perform simple analysis on text input."""
+
+    type: str = "analysis"
+
+    # ------------------------------------------------------------------
+    def process(self, text: str) -> Dict[str, Any]:
+        """Return basic statistics about the given text."""
+
+        self.activate()
+        return {
+            "length": len(text),
+            "words": len(text.split()),
+        }

--- a/src/neurons/base.py
+++ b/src/neurons/base.py
@@ -1,0 +1,75 @@
+"""Base neuron implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Any
+
+
+@dataclass
+class Neuron:
+    """Basic building block for reasoning structures.
+
+    Parameters
+    ----------
+    id:
+        Unique identifier for the neuron.
+    type:
+        Logical type of the neuron (e.g. memory, analysis).
+    connections:
+        Other neurons this neuron is linked to.
+    activation_count:
+        Number of times the neuron has been activated.
+    strength:
+        Relative importance of the neuron. The value is automatically
+        regulated using :pyattr:`activation_count` and last usage time.
+    last_used:
+        Timestamp of the last activation.
+    """
+
+    id: str
+    type: str
+    connections: List["Neuron"] = field(default_factory=list)
+    activation_count: int = 0
+    strength: float = 0.5
+    last_used: datetime = field(default_factory=datetime.utcnow)
+
+    # ------------------------------------------------------------------
+    def connect(self, neuron: "Neuron") -> None:
+        """Connect this neuron to another neuron."""
+
+        if neuron not in self.connections:
+            self.connections.append(neuron)
+
+    # ------------------------------------------------------------------
+    def activate(self) -> None:
+        """Activate the neuron and update its internal statistics."""
+
+        self.activation_count += 1
+        self.update_strength()
+
+    # ------------------------------------------------------------------
+    def update_strength(self) -> None:
+        """Adjust the neuron's strength based on usage.
+
+        The strength increases with every activation with diminishing
+        returns while decaying slowly over time if the neuron is not
+        used. This keeps frequently used neurons more influential while
+        letting rarely used ones fade.
+        """
+
+        now = datetime.utcnow()
+        elapsed = (now - self.last_used).total_seconds()
+        # Decay strength by 1% per minute since last use
+        self.strength *= 0.99 ** (elapsed / 60)
+        # Reinforce based on activation count with diminishing returns
+        self.strength += 1 / (self.activation_count + 1)
+        self.strength = max(0.0, min(self.strength, 1.0))
+        self.last_used = now
+
+    # ------------------------------------------------------------------
+    def process(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - abstract
+        """Placeholder for subclasses to implement their behaviour."""
+
+        raise NotImplementedError

--- a/src/neurons/memory.py
+++ b/src/neurons/memory.py
@@ -1,0 +1,23 @@
+"""Memory related neuron."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+from .base import Neuron
+
+
+@dataclass
+class MemoryNeuron(Neuron):
+    """Neuron specialised in storing information."""
+
+    type: str = "memory"
+    memory: List[Any] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    def process(self, data: Any) -> None:
+        """Store incoming data to internal memory."""
+
+        self.activate()
+        self.memory.append(data)

--- a/tests/test_neurons/test_basic.py
+++ b/tests/test_neurons/test_basic.py
@@ -1,0 +1,48 @@
+"""Tests for neuron classes."""
+
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+# Ensure project root on path for src layout
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.neurons import Neuron, MemoryNeuron, AnalysisNeuron, ActionNeuron
+
+
+def test_activation_updates_strength_and_count() -> None:
+    neuron = Neuron(id="n1", type="generic")
+    start_strength = neuron.strength
+    neuron.activate()
+    assert neuron.activation_count == 1
+    assert neuron.strength > start_strength
+
+    prev_time = neuron.last_used
+    # simulate time passing to trigger decay
+    neuron.last_used -= timedelta(minutes=10)
+    neuron.activate()
+    assert neuron.activation_count == 2
+    assert neuron.last_used > prev_time
+    assert neuron.strength <= 1.0
+
+
+def test_memory_neuron_process() -> None:
+    neuron = MemoryNeuron(id="m1")
+    neuron.process("remember this")
+    assert neuron.memory == ["remember this"]
+    assert neuron.activation_count == 1
+
+
+def test_analysis_neuron_process() -> None:
+    neuron = AnalysisNeuron(id="a1")
+    result = neuron.process("hello world")
+    assert result["length"] == len("hello world")
+    assert result["words"] == 2
+    assert neuron.activation_count == 1
+
+
+def test_action_neuron_process() -> None:
+    neuron = ActionNeuron(id="act1")
+    outcome = neuron.process("jump")
+    assert outcome == "action:jump"
+    assert neuron.activation_count == 1


### PR DESCRIPTION
## Summary
- implement core `Neuron` class with connection, activation and strength management
- add concrete neuron types for memory, analysis and action behaviours
- cover neuron behaviour with basic tests

## Testing
- `pytest tests/test_neurons/test_basic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68924744995483238e59ca555751d101