### PR TITLE
Implement tiered memory cache with LRU demotion

### DIFF
--- a/src/memory/index.py
+++ b/src/memory/index.py
@@ -2,55 +2,115 @@ from __future__ import annotations
 
 """Three-level caching index for memory records."""
 
+from collections import OrderedDict
+import time
 from typing import Any, Dict
 
 
 class MemoryIndex:
     """Manage data between hot, warm and cold storage levels.
 
-    The index keeps track of how often each entry is accessed via
-    ``usage_stats``. Frequently used entries migrate upwards through the
-    caching tiers:
-
-    * Cold storage – baseline persistence for rarely used data.
-    * Warm cache   – items accessed occasionally.
-    * Hot cache    – frequently accessed items.
-
-    Periodic checks promote lightly used cold entries to the warm cache and
-    heavily used warm entries to the hot cache.
+    The index tracks how often and how recently each entry is accessed. Items
+    migrate between ``cold_storage`` (baseline persistence), ``warm_cache`` and
+    ``hot_cache`` based on these usage statistics. Each tier applies an LRU
+    policy with configurable size limits.
     """
 
-    def __init__(self, hot_threshold: int = 5, warm_threshold: int = 2) -> None:
-        self.hot_cache: Dict[str, Any] = {}
-        self.warm_cache: Dict[str, Any] = {}
+    def __init__(
+        self,
+        hot_threshold: int = 5,
+        warm_threshold: int = 2,
+        hot_limit: int = 128,
+        warm_limit: int = 256,
+    ) -> None:
+        self.hot_cache: "OrderedDict[str, Any]" = OrderedDict()
+        self.warm_cache: "OrderedDict[str, Any]" = OrderedDict()
         self.cold_storage: Dict[str, Any] = {}
         self.usage_stats: Dict[str, int] = {}
+        self.access_times: Dict[str, float] = {}
         self.hot_threshold = hot_threshold
         self.warm_threshold = warm_threshold
+        self.hot_limit = hot_limit
+        self.warm_limit = warm_limit
 
+    # ------------------------------------------------------------------
+    # public API
     def set(self, key: str, value: Any) -> None:
-        """Store a new entry in cold storage."""
+        """Store ``key``/``value`` in cold storage."""
         self.cold_storage[key] = value
+        self.usage_stats[key] = 0
+        self.access_times[key] = time.time()
+        self._age_items(key)
+        self._check_demotions()
+        self._enforce_limits()
 
     def get(self, key: str) -> Any:
-        """Retrieve an entry from the index."""
+        """Retrieve ``key`` from whichever tier currently holds it."""
         if key in self.hot_cache:
-            self._increment_usage(key)
+            self._record_access(key, tier="hot")
+            self._check_demotions()
+            self._enforce_limits()
             return self.hot_cache[key]
+
         if key in self.warm_cache:
-            self._increment_usage(key)
+            self._record_access(key, tier="warm")
             self._promote_to_hot(key)
+            self._check_demotions()
+            self._enforce_limits()
             if key in self.hot_cache:
                 return self.hot_cache[key]
             return self.warm_cache[key]
+
         value = self._search_cold_storage(key)
         if value is not None:
-            self._increment_usage(key)
-        self._periodic_check()
+            self._record_access(key, tier="cold")
+            if self.usage_stats.get(key, 0) >= self.warm_threshold:
+                self._add_to_warm(key, value)
+        self._check_demotions()
+        self._enforce_limits()
         return value
 
-    def _increment_usage(self, key: str) -> None:
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _record_access(self, key: str, tier: str) -> None:
+        """Update bookkeeping for ``key`` being accessed."""
+        self._age_items(key)
         self.usage_stats[key] = self.usage_stats.get(key, 0) + 1
+        self.access_times[key] = time.time()
+        if tier == "hot":
+            self.hot_cache.move_to_end(key)
+        elif tier == "warm":
+            self.warm_cache.move_to_end(key)
+
+    def _age_items(self, accessed_key: str) -> None:
+        """Decrement usage counts for items other than ``accessed_key``."""
+        for key in list(self.usage_stats.keys()):
+            if key != accessed_key and self.usage_stats[key] > 0:
+                self.usage_stats[key] -= 1
+
+    def _check_demotions(self) -> None:
+        """Demote entries whose usage falls below the tier thresholds."""
+        for key in list(self.hot_cache.keys()):
+            if self.usage_stats.get(key, 0) < self.hot_threshold:
+                value = self.hot_cache.pop(key)
+                self.warm_cache[key] = value
+                self.usage_stats[key] = self.warm_threshold
+        for key in list(self.warm_cache.keys()):
+            if self.usage_stats.get(key, 0) < self.warm_threshold:
+                value = self.warm_cache.pop(key)
+                self.cold_storage[key] = value
+                self.usage_stats[key] = 0
+
+    def _enforce_limits(self) -> None:
+        """Apply LRU eviction when cache size limits are exceeded."""
+        while len(self.hot_cache) > self.hot_limit:
+            key, value = self.hot_cache.popitem(last=False)
+            self.warm_cache[key] = value
+            self.usage_stats[key] = self.warm_threshold
+        while len(self.warm_cache) > self.warm_limit:
+            key, value = self.warm_cache.popitem(last=False)
+            self.cold_storage[key] = value
+            self.usage_stats[key] = 0
 
     def _promote_to_hot(self, key: str) -> None:
         """Move an entry from the warm cache to the hot cache."""
@@ -59,22 +119,20 @@ class MemoryIndex:
             and self.usage_stats.get(key, 0) >= self.hot_threshold
         ):
             self.hot_cache[key] = self.warm_cache.pop(key)
+            self.usage_stats[key] = self.hot_threshold
+            self.access_times[key] = time.time()
 
     def _add_to_warm(self, key: str, value: Any) -> None:
         """Insert an entry into the warm cache removing it from cold storage."""
         self.warm_cache[key] = value
         self.cold_storage.pop(key, None)
+        self.usage_stats[key] = self.warm_threshold
+        self.access_times[key] = time.time()
 
     def _search_cold_storage(self, key: str) -> Any:
         """Look up an entry in cold storage."""
         return self.cold_storage.get(key)
 
-    def _periodic_check(self) -> None:
-        """Promote lightly used cold entries to the warm cache."""
-        for key in list(self.cold_storage.keys()):
-            if self.usage_stats.get(key, 0) >= self.warm_threshold:
-                value = self.cold_storage[key]
-                self._add_to_warm(key, value)
-
 
 __all__ = ["MemoryIndex"]
+

--- a/tests/test_memory/test_memory_index.py
+++ b/tests/test_memory/test_memory_index.py
@@ -4,7 +4,7 @@ from src.memory.index import MemoryIndex
 
 
 def test_promotes_cold_to_warm() -> None:
-    index = MemoryIndex(hot_threshold=10, warm_threshold=2)
+    index = MemoryIndex(hot_threshold=10, warm_threshold=2, hot_limit=5, warm_limit=5)
     index.set("alpha", 1)
 
     assert index.get("alpha") == 1  # first access, stays in cold
@@ -14,11 +14,10 @@ def test_promotes_cold_to_warm() -> None:
     index.get("alpha")
     assert "alpha" in index.warm_cache
     assert "alpha" not in index.cold_storage
-    assert index.usage_stats["alpha"] == 2
 
 
 def test_promotes_warm_to_hot() -> None:
-    index = MemoryIndex(hot_threshold=3, warm_threshold=1)
+    index = MemoryIndex(hot_threshold=3, warm_threshold=1, hot_limit=5, warm_limit=5)
     index.set("beta", 2)
 
     # First access moves beta to warm cache
@@ -30,7 +29,51 @@ def test_promotes_warm_to_hot() -> None:
     index.get("beta")
     assert "beta" in index.hot_cache
     assert "beta" not in index.warm_cache
-    assert index.usage_stats["beta"] == 3
+
+
+def test_demotes_inactive_items() -> None:
+    index = MemoryIndex(hot_threshold=3, warm_threshold=1, hot_limit=5, warm_limit=5)
+    index.set("alpha", 1)
+    # Promote alpha to hot
+    index.get("alpha")
+    index.get("alpha")
+    index.get("alpha")
+    assert "alpha" in index.hot_cache
+
+    # Use beta repeatedly so that alpha ages out to cold
+    index.set("beta", 2)
+    index.get("beta")
+    index.get("beta")
+    index.get("beta")
+    index.get("beta")
+    assert "alpha" in index.cold_storage
+    assert "alpha" not in index.hot_cache
+    assert "alpha" not in index.warm_cache
+
+
+def test_hot_limit_eviction() -> None:
+    index = MemoryIndex(hot_threshold=1, warm_threshold=0, hot_limit=1, warm_limit=1)
+    index.set("a", 1)
+    index.get("a")
+    index.get("a")  # a promoted to hot
+
+    index.set("b", 2)
+    index.get("b")
+    index.get("b")  # b promoted to hot, a evicted due to LRU
+
+    assert "b" in index.hot_cache
+    assert "a" in index.cold_storage
+
+
+def test_warm_limit_eviction() -> None:
+    index = MemoryIndex(hot_threshold=100, warm_threshold=0, hot_limit=5, warm_limit=1)
+    index.set("a", 1)
+    index.get("a")  # a warmed
+    index.set("b", 2)
+    index.get("b")  # b warmed, a evicted
+
+    assert "b" in index.warm_cache
+    assert "a" in index.cold_storage
 
 
 def test_search_cold_storage() -> None:


### PR DESCRIPTION
## Summary
- add hot and warm cache size limits to `MemoryIndex`
- track access timestamps and demote items based on usage
- test promotion/demotion and LRU eviction across tiers

## Testing
- `pytest tests/test_memory/test_memory_index.py -q`
- `pytest tests/test_memory -q`


------
https://chatgpt.com/codex/tasks/task_e_68926b92d6088323829e56a0d7ddd152