### PR TITLE
Refactor WeightedMemory with heap-based dict storage

### DIFF
--- a/src/memory/weighted.py
+++ b/src/memory/weighted.py
@@ -15,36 +15,60 @@ intervention.
 """
 
 from dataclasses import dataclass, field
-from typing import Any, List
+from typing import Any, Dict, List, Tuple
 import threading
+import heapq
 
 
 @dataclass
 class WeightedMemory:
-    """Store memories with associated weights that decay over time."""
+    """Store memories with associated weights that decay over time.
+
+    Internally memories are kept in a dictionary mapping the memory item to
+    its current weight.  Two heaps are maintained for efficient retrieval of
+    the highest weighted memory and pruning of the lowest weighted one.
+    """
 
     decay_rate: float = 0.9
-    memories: List[Any] = field(default_factory=list)
-    weights: List[float] = field(default_factory=list)
+    max_size: int | None = None
+    memories: Dict[Any, float] = field(default_factory=dict)
+    _max_heap: List[Tuple[float, Any]] = field(default_factory=list, init=False, repr=False)
+    _min_heap: List[Tuple[float, Any]] = field(default_factory=list, init=False, repr=False)
     _timer: threading.Timer | None = field(default=None, init=False, repr=False)
 
     # ------------------------------------------------------------------
     def add_memory(self, memory: Any, weight: float = 1.0) -> None:
         """Add a new memory with an optional initial weight."""
-        self.memories.append(memory)
-        self.weights.append(weight)
+        self.memories[memory] = weight
+        heapq.heappush(self._max_heap, (-weight, memory))
+        heapq.heappush(self._min_heap, (weight, memory))
+        if self.max_size and len(self.memories) > self.max_size:
+            self._prune_lowest()
 
     # ------------------------------------------------------------------
     def decay_memories(self) -> None:
         """Apply exponential decay to all memory weights."""
-        self.weights = [w * self.decay_rate for w in self.weights]
+        for mem in list(self.memories.keys()):
+            self.memories[mem] *= self.decay_rate
+        self._rebuild_heaps()
 
     # ------------------------------------------------------------------
     def strengthen_memory(self, memory: Any, amount: float = 1.0) -> None:
         """Increase the weight of a memory when it is accessed."""
         if memory in self.memories:
-            idx = self.memories.index(memory)
-            self.weights[idx] += amount
+            self.memories[memory] += amount
+            weight = self.memories[memory]
+            heapq.heappush(self._max_heap, (-weight, memory))
+            heapq.heappush(self._min_heap, (weight, memory))
+
+    # ------------------------------------------------------------------
+    def get_top_memory(self) -> tuple[Any, float] | None:
+        """Return the memory with the highest weight or ``None`` if empty."""
+        self._cleanup_max_heap()
+        if not self._max_heap:
+            return None
+        weight, mem = self._max_heap[0]
+        return mem, -weight
 
     # ------------------------------------------------------------------
     def start_auto_decay(self, interval: float) -> None:
@@ -65,6 +89,37 @@ class WeightedMemory:
         if self._timer:
             self._timer.cancel()
             self._timer = None
+
+    # ------------------------------------------------------------------
+    def _cleanup_max_heap(self) -> None:
+        while self._max_heap:
+            weight, mem = self._max_heap[0]
+            if mem not in self.memories or self.memories[mem] != -weight:
+                heapq.heappop(self._max_heap)
+            else:
+                break
+
+    def _cleanup_min_heap(self) -> None:
+        while self._min_heap:
+            weight, mem = self._min_heap[0]
+            if mem not in self.memories or self.memories[mem] != weight:
+                heapq.heappop(self._min_heap)
+            else:
+                break
+
+    def _prune_lowest(self) -> None:
+        """Remove the memory with the lowest weight."""
+        self._cleanup_min_heap()
+        if self._min_heap:
+            weight, mem = heapq.heappop(self._min_heap)
+            if mem in self.memories and self.memories[mem] == weight:
+                del self.memories[mem]
+
+    def _rebuild_heaps(self) -> None:
+        self._max_heap = [(-w, m) for m, w in self.memories.items()]
+        self._min_heap = [(w, m) for m, w in self.memories.items()]
+        heapq.heapify(self._max_heap)
+        heapq.heapify(self._min_heap)
 
 
 __all__ = ["WeightedMemory"]

--- a/tests/test_memory/test_weighted_memory.py
+++ b/tests/test_memory/test_weighted_memory.py
@@ -10,14 +10,14 @@ from src.memory.weighted import WeightedMemory
 def test_add_strengthen_and_decay() -> None:
     wm = WeightedMemory(decay_rate=0.5)
     wm.add_memory("test", 2.0)
-    assert wm.memories == ["test"]
-    assert wm.weights == [2.0]
+    assert wm.memories["test"] == 2.0
 
     wm.strengthen_memory("test", amount=1.0)
-    assert wm.weights[0] == 3.0
+    assert wm.memories["test"] == 3.0
 
     wm.decay_memories()
-    assert wm.weights[0] == 1.5
+    assert wm.memories["test"] == 1.5
+    assert wm.get_top_memory() == ("test", 1.5)
 
 
 def test_auto_decay_scheduler() -> None:
@@ -26,4 +26,15 @@ def test_auto_decay_scheduler() -> None:
     wm.start_auto_decay(0.1)
     time.sleep(0.25)  # allow at least one decay cycle
     wm.stop_auto_decay()
-    assert wm.weights[0] < 4.0
+    assert wm.memories["auto"] < 4.0
+
+
+def test_max_size_prunes_lowest() -> None:
+    wm = WeightedMemory(max_size=2)
+    wm.add_memory("a", 1.0)
+    wm.add_memory("b", 2.0)
+    wm.add_memory("c", 0.5)  # should be immediately pruned
+    assert set(wm.memories.keys()) == {"a", "b"}
+
+    wm.add_memory("d", 3.0)  # should evict lowest weight 'a'
+    assert set(wm.memories.keys()) == {"b", "d"}


### PR DESCRIPTION
## Summary
- switch WeightedMemory to a dict keyed by memory and backed by max/min heaps for O(log n) updates and fast top lookup
- add optional `max_size` for pruning lowest-weight memories and expose `get_top_memory`
- update tests for new API and heap-backed behaviour

## Testing
- `pytest tests/test_memory/test_weighted_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c59d0bec8323a6b580f5cef6b93f