### PR TITLE
Refactor MemoryNeuron to use MemoryIndex with bounded caches

### DIFF
--- a/src/neurons/memory.py
+++ b/src/neurons/memory.py
@@ -3,21 +3,40 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, List
+from typing import Any
 
 from .base import Neuron
+from ..memory import MemoryIndex
 
 
 @dataclass
 class MemoryNeuron(Neuron):
-    """Neuron specialised in storing information."""
+    """Neuron specialised in storing information via a :class:`MemoryIndex`."""
 
     type: str = "memory"
-    memory: List[Any] = field(default_factory=list)
+    hot_limit: int = 128
+    warm_limit: int = 256
+    index: MemoryIndex = field(init=False)
 
     # ------------------------------------------------------------------
-    def process(self, data: Any) -> None:
-        """Store incoming data to internal memory."""
+    def __post_init__(self) -> None:  # pragma: no cover - simple wiring
+        self.index = MemoryIndex(hot_limit=self.hot_limit, warm_limit=self.warm_limit)
+
+    # ------------------------------------------------------------------
+    def process(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key`` in the internal index."""
 
         self.activate()
-        self.memory.append(data)
+        self.index.set(key, value)
+
+    # ------------------------------------------------------------------
+    def query(self, key: str) -> Any:
+        """Retrieve a value by ``key`` from the index."""
+
+        return self.index.get(key)
+
+    # ------------------------------------------------------------------
+    def purge_cold_storage(self) -> None:
+        """Remove all records from cold storage."""
+
+        self.index.cold_storage.clear()

--- a/src/neurons/patterns.py
+++ b/src/neurons/patterns.py
@@ -49,7 +49,7 @@ class BehaviorPattern:
 
         # Memory activation stage
         for neuron in self.memory_neurons:
-            neuron.process(data)
+            neuron.process(str(data), data)
 
         # Analysis stage
         analysis_results: List[Any] = []

--- a/tests/test_neurons/test_basic.py
+++ b/tests/test_neurons/test_basic.py
@@ -28,9 +28,20 @@ def test_activation_updates_strength_and_count() -> None:
 
 def test_memory_neuron_process() -> None:
     neuron = MemoryNeuron(id="m1")
-    neuron.process("remember this")
-    assert neuron.memory == ["remember this"]
+    neuron.process("key1", "remember this")
+    assert neuron.query("key1") == "remember this"
     assert neuron.activation_count == 1
+
+
+def test_memory_neuron_bounded_storage() -> None:
+    neuron = MemoryNeuron(id="m2", hot_limit=2, warm_limit=3)
+    for i in range(6):
+        neuron.process(f"k{i}", f"v{i}")
+    assert len(neuron.index.hot_cache) <= 2
+    assert len(neuron.index.warm_cache) <= 3
+    assert len(neuron.index.cold_storage) >= 1
+    neuron.purge_cold_storage()
+    assert neuron.index.cold_storage == {}
 
 
 def test_analysis_neuron_process() -> None:

--- a/tests/test_neurons/test_patterns.py
+++ b/tests/test_neurons/test_patterns.py
@@ -23,8 +23,8 @@ def test_behavior_pattern_execute_and_strength() -> None:
 
     result = pattern.execute("hello world")
 
-    # Memory neuron should store the data
-    assert memory.memory == ["hello world"]
+    # Memory neuron should store the data under its key
+    assert memory.query("hello world") == "hello world"
 
     # Action stage should be executed based on analysis results
     assert result == ["action:{'length': 11, 'words': 2}"]


### PR DESCRIPTION
## Summary
- Replace raw list storage in `MemoryNeuron` with a `MemoryIndex` supporting hot/warm cache limits
- Allow querying and purging memory entries and update `BehaviorPattern` to supply keys
- Add tests ensuring memory bounds are enforced

## Testing
- `pytest tests/test_neurons/test_basic.py tests/test_neurons/test_patterns.py`
- `pytest` *(fails: reportlab required for PDF handler; TagProcessor tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6892cf6d9fcc8323bcddbacab3a18ca3