### PR TITLE
feat: persist session memory to disk

### DIFF
--- a/src/core/session_memory.py
+++ b/src/core/session_memory.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
+from dataclasses import dataclass, asdict, is_dataclass
+from datetime import datetime, timedelta
+import json
+import os
 from typing import Any, Dict, List
 
 
@@ -18,9 +20,17 @@ class SessionRecord:
 class SessionMemory:
     """In-memory storage for session states and character progression."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        storage_path: str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        self.storage_path = storage_path
+        self.ttl_seconds = ttl_seconds
         self._sessions: Dict[str, SessionRecord] = {}
         self._development: Dict[str, List[Dict[str, Any]]] = {}
+        if self.storage_path:
+            self.load_from_disk()
 
     def save_session_state(self, session: Any) -> None:
         """Store ``session`` by its ``id`` attribute."""
@@ -32,11 +42,65 @@ class SessionMemory:
         self._sessions[session_id] = SessionRecord(
             session=session, saved_at=datetime.utcnow()
         )
+        self.save_to_disk()
 
     def load_session_state(self, session_id: str) -> Any | None:
         """Return previously saved session for ``session_id`` if present."""
         record = self._sessions.get(session_id)
         return record.session if record else None
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+
+    def _serialize_session(self, session: Any) -> Any:
+        if hasattr(session, "to_dict") and callable(getattr(session, "to_dict")):
+            return session.to_dict()
+        if is_dataclass(session):
+            return asdict(session)
+        if hasattr(session, "__dict__"):
+            return session.__dict__
+        return session
+
+    def save_to_disk(self) -> None:
+        """Persist ``_sessions`` to ``storage_path`` if configured."""
+        if not self.storage_path:
+            return
+        os.makedirs(os.path.dirname(self.storage_path), exist_ok=True)
+        data = {
+            sid: {
+                "session": self._serialize_session(rec.session),
+                "saved_at": rec.saved_at.isoformat(),
+            }
+            for sid, rec in self._sessions.items()
+        }
+        with open(self.storage_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def load_from_disk(self) -> None:
+        """Load sessions from ``storage_path``, purging entries beyond TTL."""
+        if not self.storage_path or not os.path.exists(self.storage_path):
+            return
+        with open(self.storage_path, "r", encoding="utf-8") as fh:
+            raw: Dict[str, Dict[str, Any]] = json.load(fh)
+        now = datetime.utcnow()
+        ttl = (
+            timedelta(seconds=self.ttl_seconds)
+            if self.ttl_seconds is not None
+            else None
+        )
+        self._sessions = {}
+        changed = False
+        for sid, rec in raw.items():
+            saved_at = datetime.fromisoformat(rec["saved_at"])
+            if ttl and now - saved_at > ttl:
+                changed = True
+                continue
+            self._sessions[sid] = SessionRecord(
+                session=rec["session"],
+                saved_at=saved_at,
+            )
+        if changed:
+            self.save_to_disk()
 
     def track_character_development(self, character: Any) -> List[Dict[str, Any]]:
         """Append a timestamped snapshot of ``character`` state."""

--- a/tests/test_session_memory.py
+++ b/tests/test_session_memory.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+
+from src.core.session_memory import SessionMemory
+
+
+@dataclass
+class DummySession:
+    id: str
+    value: int
+
+
+def test_persistence(tmp_path) -> None:
+    path = tmp_path / "sessions.json"
+    memory = SessionMemory(storage_path=str(path))
+    memory.save_session_state(DummySession(id="s1", value=42))
+
+    assert path.exists()
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert "s1" in data
+    assert "saved_at" in data["s1"]
+
+    reloaded = SessionMemory(storage_path=str(path))
+    loaded = reloaded.load_session_state("s1")
+    assert isinstance(loaded, dict)
+    assert loaded["value"] == 42
+
+
+def test_expiration(tmp_path) -> None:
+    path = tmp_path / "sessions.json"
+    memory = SessionMemory(storage_path=str(path), ttl_seconds=1)
+    memory.save_session_state(DummySession(id="s1", value=42))
+    time.sleep(1.1)
+    reloaded = SessionMemory(storage_path=str(path), ttl_seconds=1)
+    assert reloaded.load_session_state("s1") is None


### PR DESCRIPTION
## Summary
- add optional disk persistence with TTL filtering to SessionMemory
- load and save sessions to JSON file with helper methods
- test session persistence and expiration

## Testing
- `pytest tests/test_session_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d36b0944832396ebfaf3ab8cff22