### PR TITLE
Add adaptive learning system with neuron factory

### DIFF
--- a/src/learning/__init__.py
+++ b/src/learning/__init__.py
@@ -1,0 +1,5 @@
+"""Learning utilities and adaptive systems."""
+
+from .learning_system import LearningSystem
+
+__all__ = ["LearningSystem"]

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type
+
+from src.neurons import Neuron, NeuronFactory
+
+
+@dataclass
+class LearningSystem:
+    """Adaptive learning system for long-term interaction tracking.
+
+    Attributes
+    ----------
+    experience_buffer:
+        List of recorded interaction dictionaries.
+    success_metrics:
+        Mapping of metric name to value (e.g. positive/negative counts).
+    failure_analysis:
+        Counts of failure reasons gathered during analysis.
+    adaptation_weights:
+        Threshold values used to decide when to create new neuron types.
+    """
+
+    experience_buffer: List[Dict[str, Any]] = field(default_factory=list)
+    success_metrics: Dict[str, int] = field(
+        default_factory=lambda: {"positive": 0, "negative": 0}
+    )
+    failure_analysis: Dict[str, int] = field(default_factory=dict)
+    adaptation_weights: Dict[str, int] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    def learn_from_interaction(
+        self,
+        user_request: str,
+        response: str,
+        rating: int,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Process interaction data and update internal state.
+
+        Parameters
+        ----------
+        user_request:
+            Original request from the user.
+        response:
+            System response produced.
+        rating:
+            User-provided rating where negative values indicate failure.
+        context:
+            Optional additional context for the interaction.
+        """
+
+        interaction = {
+            "request": user_request,
+            "response": response,
+            "rating": rating,
+            "context": context or {},
+        }
+        self.experience_buffer.append(interaction)
+
+        if rating >= 0:
+            self.success_metrics["positive"] += 1
+        else:
+            self.success_metrics["negative"] += 1
+            self._analyze_failure(interaction)
+
+    # ------------------------------------------------------------------
+    def _analyze_failure(self, interaction: Dict[str, Any]) -> None:
+        """Record failure reason statistics."""
+
+        reason = interaction["context"].get("topic", "unknown")
+        self.failure_analysis[reason] = self.failure_analysis.get(reason, 0) + 1
+
+    # ------------------------------------------------------------------
+    def create_new_neuron_type(self) -> Optional[str]:
+        """Create and register a new neuron type if needed.
+
+        The decision is based on accumulated ``failure_analysis`` statistics. If
+        a failure reason count exceeds its stored weight, a new neuron type is
+        registered for that reason and its weight updated.
+        """
+
+        for reason, count in self.failure_analysis.items():
+            weight = self.adaptation_weights.get(reason, 0)
+            if count > weight:
+                neuron_type = f"{reason}_neuron"
+
+                def _process(self: Neuron, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - placeholder
+                    return None
+
+                new_cls: Type[Neuron] = type(
+                    neuron_type,
+                    (Neuron,),
+                    {"process": _process},
+                )
+                NeuronFactory.register(neuron_type, new_cls)
+                self.adaptation_weights[reason] = count
+                return neuron_type
+        return None
+
+    # ------------------------------------------------------------------
+    def save_state(self, path: Path | str) -> None:
+        """Serialize the learning state to ``path``."""
+
+        data = {
+            "experience_buffer": self.experience_buffer,
+            "success_metrics": self.success_metrics,
+            "failure_analysis": self.failure_analysis,
+            "adaptation_weights": self.adaptation_weights,
+        }
+        Path(path).write_text(json.dumps(data))
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def load_state(cls, path: Path | str) -> "LearningSystem":
+        """Load learning state from ``path``."""
+
+        data = json.loads(Path(path).read_text())
+        instance = cls()
+        instance.experience_buffer = data.get("experience_buffer", [])
+        instance.success_metrics = data.get("success_metrics", {})
+        instance.failure_analysis = data.get("failure_analysis", {})
+        instance.adaptation_weights = data.get("adaptation_weights", {})
+        return instance
+
+
+__all__ = ["LearningSystem"]
+

--- a/src/neurons/__init__.py
+++ b/src/neurons/__init__.py
@@ -10,6 +10,7 @@ from .analysis import AnalysisNeuron
 from .action import ActionNeuron
 from .patterns import BehaviorPattern
 from .network import NeuronNetwork
+from .factory import NeuronFactory
 
 __all__ = [
     "Neuron",
@@ -18,4 +19,5 @@ __all__ = [
     "ActionNeuron",
     "BehaviorPattern",
     "NeuronNetwork",
+    "NeuronFactory",
 ]

--- a/src/neurons/factory.py
+++ b/src/neurons/factory.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from .base import Neuron
+
+
+class NeuronFactory:
+    """Factory for registering and creating neuron classes."""
+
+    _registry: Dict[str, Type[Neuron]] = {}
+
+    @classmethod
+    def register(cls, neuron_type: str, neuron_cls: Type[Neuron]) -> None:
+        """Register ``neuron_cls`` under ``neuron_type``."""
+
+        cls._registry[neuron_type] = neuron_cls
+
+    @classmethod
+    def create(cls, neuron_type: str, *args: Any, **kwargs: Any) -> Neuron:
+        """Instantiate the neuron associated with ``neuron_type``."""
+
+        neuron_cls = cls._registry.get(neuron_type)
+        if neuron_cls is None:
+            raise ValueError(f"Unknown neuron_type: {neuron_type}")
+        return neuron_cls(*args, **kwargs)
+
+
+__all__ = ["NeuronFactory"]

--- a/tests/test_learning/test_learning_system.py
+++ b/tests/test_learning/test_learning_system.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from src.learning import LearningSystem
+from src.neurons import NeuronFactory
+
+
+def test_learn_from_interaction_updates_metrics() -> None:
+    system = LearningSystem()
+    system.learn_from_interaction("hi", "hello", -1, {"topic": "combat"})
+    assert len(system.experience_buffer) == 1
+    assert system.success_metrics["negative"] == 1
+    assert system.failure_analysis["combat"] == 1
+
+
+def test_create_new_neuron_type_registers() -> None:
+    system = LearningSystem()
+    system.learn_from_interaction("hi", "hello", -1, {"topic": "magic"})
+    neuron_type = system.create_new_neuron_type()
+    neuron = NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
+    assert neuron.type == neuron_type
+
+
+def test_save_and_load_state_roundtrip(tmp_path) -> None:
+    system = LearningSystem()
+    system.learn_from_interaction("hi", "hello", 1, {"topic": "lore"})
+    path = tmp_path / "state.json"
+    system.save_state(path)
+    loaded = LearningSystem.load_state(path)
+    assert loaded.experience_buffer == system.experience_buffer
+    assert loaded.success_metrics == system.success_metrics
+    assert loaded.failure_analysis == system.failure_analysis


### PR DESCRIPTION
## Summary
- implement `LearningSystem` for tracking interactions, analyzing failures, and adapting by registering new neuron types
- provide `NeuronFactory` for neuron registration and instantiation
- support persistence via save/load and add tests for learning system behaviour

## Testing
- `pytest` *(fails: ebooklib is required to handle e-books; python-docx is required to handle DOCX files; PyPDF2 is required to handle PDF files; TagProcessor tests failed; TypeError in Neyra recall history)*
- `PYTHONPATH=. pytest tests/test_learning/test_learning_system.py`


------
https://chatgpt.com/codex/tasks/task_e_68930a6a97248323b5fe403ec10bf286