### PR TITLE
feat: collect user feedback in chat sessions

### DIFF
--- a/src/interaction/chat_session.py
+++ b/src/interaction/chat_session.py
@@ -21,6 +21,8 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 
+from src.learning import LearningSystem
+
 from .tag_processor import TagProcessor, handle_command
 
 
@@ -52,6 +54,7 @@ class ChatSession:
         *,
         max_history: int = 50,
         console: Optional[Console] = None,
+        learning_system: Optional[LearningSystem] = None,
     ) -> None:
         self.neyra = neyra
         self.processor = processor or TagProcessor()
@@ -59,9 +62,10 @@ class ChatSession:
         self._last_character: Optional[str] = None
         self.max_history = max_history
         self.console = console or Console()
+        self.learning = learning_system or LearningSystem()
 
         # interactive session with history and command completion
-        commands = ["/help", "/clear", "/status", "/memory", "/exit"]
+        commands = ["/help", "/clear", "/status", "/memory", "/stats", "/exit"]
         self.session = PromptSession(
             history=InMemoryHistory(),
             completer=WordCompleter(commands, ignore_case=True),
@@ -69,8 +73,8 @@ class ChatSession:
 
     # ------------------------------------------------------------------
     # Public API
-    def ask(self, message: str) -> str:
-        """Send ``message`` to Neyra and return her response."""
+    def ask(self, message: str, rating: Optional[int] = None) -> str:
+        """Send ``message`` to Neyra, request rating and return her response."""
 
         try:
             prepared = self._prepare_message(message)
@@ -89,6 +93,23 @@ class ChatSession:
         for tag in tags:
             if tag.type == "character_work" and tag.subject:
                 self._last_character = tag.subject
+
+        # Request rating if not supplied programmatically
+        if rating is None:
+            rating = self._request_rating()
+
+        if rating is not None:
+            # Persist in Neyra's history if available
+            if hasattr(self.neyra, "history"):
+                try:
+                    self.neyra.history.add(message, rating)
+                except Exception:  # pragma: no cover - best effort
+                    pass
+            # Inform learning system
+            try:
+                self.learning.learn_from_interaction(message, result.text, rating)
+            except Exception:  # pragma: no cover - best effort
+                pass
 
         return result.text
 
@@ -158,6 +179,25 @@ class ChatSession:
         if len(self.history) > self.max_history:
             del self.history[: len(self.history) - self.max_history]
 
+    def _request_rating(self) -> Optional[int]:
+        """Interactively ask the user to rate the answer."""
+
+        while True:  # pragma: no cover - simple loop
+            try:
+                raw = self.session.prompt(
+                    "Оцените ответ (1-5) или Enter чтобы пропустить: "
+                )
+            except (KeyboardInterrupt, EOFError):
+                return None
+            raw = raw.strip()
+            if not raw:
+                return None
+            if raw.isdigit():
+                value = int(raw)
+                if 1 <= value <= 5:
+                    return value
+            self.console.print("Введите число от 1 до 5.")
+
     def _handle_service_command(self, command: str) -> Optional[str]:
         """Handle internal service commands.
 
@@ -193,6 +233,10 @@ class ChatSession:
                 return "История пуста"
             lines = [f"{entry.speaker}: {entry.text}" for entry in self.history]
             return "\n".join(lines)
+        if cmd in {"/stats"}:
+            if hasattr(self.neyra, "history") and hasattr(self.neyra.history, "stats"):
+                return self.neyra.history.stats()
+            return "Оценок пока нет"
         return f"Неизвестная команда: {cmd}"
 
 

--- a/src/interaction/request_history.py
+++ b/src/interaction/request_history.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, asdict
 from datetime import datetime
 import json
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -15,6 +15,7 @@ class HistoryEntry:
 
     timestamp: datetime
     text: str
+    rating: Optional[int] = None
 
 
 class RequestHistory:
@@ -35,15 +36,16 @@ class RequestHistory:
                 data = json.loads(self.path.read_text(encoding="utf-8"))
                 for item in data:
                     ts = datetime.fromisoformat(item["timestamp"])
-                    self._entries.append(HistoryEntry(ts, item["text"]))
+                    rating = item.get("rating")
+                    self._entries.append(HistoryEntry(ts, item["text"], rating))
             except Exception:  # pragma: no cover - corrupted history
                 self._entries = []
 
     # ------------------------------------------------------------------
-    def add(self, text: str) -> None:
-        """Add ``text`` to the history and persist it."""
+    def add(self, text: str, rating: Optional[int] = None) -> None:
+        """Add ``text`` (with optional ``rating``) to the history and persist it."""
 
-        entry = HistoryEntry(datetime.now(), text)
+        entry = HistoryEntry(datetime.now(), text, rating)
         self._entries.append(entry)
         self._save()
 
@@ -57,6 +59,17 @@ class RequestHistory:
         """Return the last ``limit`` requests joined by newlines."""
 
         return "\n".join(e.text for e in self._entries[-limit:])
+
+    def stats(self) -> str:
+        """Return basic statistics for stored ratings."""
+
+        ratings = [e.rating for e in self._entries if e.rating is not None]
+        if not ratings:
+            return "Оценок пока нет"
+        total = len(ratings)
+        avg = sum(ratings) / total
+        lines = [f"Всего оценок: {total}", f"Средняя оценка: {avg:.2f}"]
+        return "\n".join(lines)
 
     # ------------------------------------------------------------------
     def _save(self) -> None:

--- a/tests/test_interaction/test_chat_session.py
+++ b/tests/test_interaction/test_chat_session.py
@@ -7,10 +7,10 @@ def test_chat_session_follows_character_context():
     neyra = Neyra()
     chat = ChatSession(neyra)
 
-    first = chat.ask("Расскажи, как выглядел Вилл")
+    first = chat.ask("Расскажи, как выглядел Вилл", rating=5)
     assert "Вилл" in first
 
-    second = chat.ask("А как он говорит?")
+    second = chat.ask("А как он говорит?", rating=4)
     assert "Вилл" in second
     assert any(word in second.lower() for word in ["говор", "реч"])
 
@@ -24,13 +24,16 @@ def test_service_commands_manage_history() -> None:
     neyra = Neyra()
     chat = ChatSession(neyra)
 
-    chat.ask("Расскажи, как выглядел Вилл")
+    chat.ask("Расскажи, как выглядел Вилл", rating=3)
     status = chat._handle_service_command("/status")
     assert "Записей" in status
     assert "Вилл" in status
 
     memory = chat._handle_service_command("/memory")
     assert "Вилл" in memory
+
+    stats = chat._handle_service_command("/stats")
+    assert "Средняя" in stats
 
     chat._handle_service_command("/clear")
     assert chat.history == []


### PR DESCRIPTION
## Summary
- prompt users for 1-5 rating after each answer and send feedback to learning system
- store ratings in request history and expose `/stats` command for aggregated statistics
- adjust chat session tests to provide ratings

## Testing
- `pytest tests/test_interaction/test_chat_session.py::test_chat_session_follows_character_context -q`
- `pytest tests/test_file_handlers/test_ebook_handler.py::test_epub_roundtrip -q` *(fails: RuntimeError: ebooklib is required to handle e-book files)*
- `pytest tests/test_interaction/test_tag_processor.py::test_parse_character_tag -q` *(fails: AssertionError: assert 'Лили — внешность' == 'Лили')*


------
https://chatgpt.com/codex/tasks/task_e_68930dde8ba0832385f837a9f1d88111