### PR TITLE
Add LLM manager with model selection and ensemble

### DIFF
--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -2,5 +2,12 @@
 
 from .base_llm import BaseLLM, LLMFactory
 from .mistral_interface import MistralLLM
+from .manager import LLMManager, ModelSpec
 
-__all__ = ["BaseLLM", "LLMFactory", "MistralLLM"]
+__all__ = [
+    "BaseLLM",
+    "LLMFactory",
+    "MistralLLM",
+    "LLMManager",
+    "ModelSpec",
+]

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+"""Management utilities for multiple LLM backends.
+
+This module provides :class:`LLMManager` which keeps track of registered
+models, their characteristics and performs model selection and simple
+ensemble aggregation.  The manager can also forward interaction results to
+:class:`~src.learning.learning_system.LearningSystem` for adaptive feedback.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+from .base_llm import BaseLLM
+from src.learning.learning_system import LearningSystem
+
+
+@dataclass
+class ModelSpec:
+    """Container describing a registered model and its meta data."""
+
+    llm: BaseLLM
+    speed: float
+    cost: float
+    accuracy: float
+    prompt_adapter: Optional[Callable[[str], str]] = None
+
+    def adapt_prompt(self, prompt: str) -> str:
+        """Apply the optional ``prompt_adapter`` to ``prompt``."""
+
+        if self.prompt_adapter is None:
+            return prompt
+        return self.prompt_adapter(prompt)
+
+
+class LLMManager:
+    """Manage multiple language models and route requests accordingly."""
+
+    def __init__(self, learning_system: Optional[LearningSystem] = None) -> None:
+        self.models: Dict[str, ModelSpec] = {}
+        self.learning_system = learning_system or LearningSystem()
+
+    # ------------------------------------------------------------------
+    def register_model(
+        self,
+        name: str,
+        llm: BaseLLM,
+        *,
+        speed: float,
+        cost: float,
+        accuracy: float,
+        prompt_adapter: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        """Register an ``llm`` with its performance characteristics."""
+
+        self.models[name] = ModelSpec(
+            llm=llm,
+            speed=speed,
+            cost=cost,
+            accuracy=accuracy,
+            prompt_adapter=prompt_adapter,
+        )
+
+    # ------------------------------------------------------------------
+    def select_model(
+        self, prompt: str, *, request_type: str = "general"
+    ) -> Tuple[str, BaseLLM, str]:
+        """Return the model best suited for ``prompt``.
+
+        The choice considers ``request_type`` (e.g. ``"fast"`` or ``"cheap"``),
+        the length of ``prompt`` and the availability of registered models.
+        The returned tuple contains the model name, the model instance and the
+        adapted prompt for that model.
+        """
+
+        available = [
+            (name, spec)
+            for name, spec in self.models.items()
+            if spec.llm.is_available()
+        ]
+        if not available:
+            raise RuntimeError("No available models")
+
+        length = len(prompt)
+
+        if request_type == "fast":
+            name, spec = max(available, key=lambda item: item[1].speed)
+        elif request_type == "cheap":
+            name, spec = min(available, key=lambda item: item[1].cost)
+        else:
+            if length > 100:
+                name, spec = max(available, key=lambda item: item[1].speed)
+            else:
+                name, spec = max(available, key=lambda item: item[1].accuracy)
+
+        adapted_prompt = spec.adapt_prompt(prompt)
+        return name, spec.llm, adapted_prompt
+
+    # ------------------------------------------------------------------
+    def generate(
+        self,
+        prompt: str,
+        *,
+        request_type: str = "general",
+        ensemble: bool = False,
+        **kwargs,
+    ) -> str:
+        """Generate a response for ``prompt`` using the selected model.
+
+        When ``ensemble`` is ``True`` all available models are invoked and the
+        result from the most accurate one is returned.
+        """
+
+        if ensemble:
+            outputs: Dict[str, str] = {}
+            for name, spec in self.models.items():
+                if not spec.llm.is_available():
+                    continue
+                adapted = spec.adapt_prompt(prompt)
+                outputs[name] = spec.llm.generate(adapted, **kwargs)
+            if not outputs:
+                raise RuntimeError("No available models")
+            best_name = max(outputs, key=lambda n: self.models[n].accuracy)
+            result = outputs[best_name]
+            self._record_interaction(prompt, result, best_name)
+            return result
+
+        name, model, adapted = self.select_model(prompt, request_type=request_type)
+        result = model.generate(adapted, **kwargs)
+        self._record_interaction(prompt, result, name)
+        return result
+
+    # ------------------------------------------------------------------
+    def _record_interaction(self, prompt: str, response: str, model_name: str) -> None:
+        """Forward evaluation information to the learning system."""
+
+        rating = int(self.models[model_name].accuracy * 100)
+        context = {"model": model_name}
+        self.learning_system.learn_from_interaction(
+            prompt, response, rating, context=context
+        )
+
+
+__all__ = ["ModelSpec", "LLMManager"]

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Tests for :mod:`src.llm.manager`."""
+
+from src.llm.manager import LLMManager
+from src.llm.base_llm import BaseLLM
+
+
+class DummyLLM(BaseLLM):
+    model_name = "dummy"
+
+    def __init__(self, response: str, available: bool = True) -> None:
+        self.response = response
+        self.available = available
+
+    def generate(self, prompt: str, max_tokens: int = 512) -> str:  # pragma: no cover - simple dummy
+        return f"{self.response}:{prompt}"
+
+    def is_available(self) -> bool:
+        return self.available
+
+
+def test_selection_and_prompt_adaptation() -> None:
+    manager = LLMManager()
+    fast = DummyLLM("fast")
+    accurate = DummyLLM("accurate")
+
+    manager.register_model("fast", fast, speed=10, cost=1, accuracy=0.5)
+    manager.register_model(
+        "accurate", accurate, speed=1, cost=2, accuracy=0.9, prompt_adapter=str.upper
+    )
+
+    # Request explicitly asking for speed selects fast model
+    name, model, adapted = manager.select_model("hi", request_type="fast")
+    assert name == "fast"
+    assert model is fast
+    assert adapted == "hi"
+
+    # General request prefers accuracy and applies adapter
+    name, model, adapted = manager.select_model("hello", request_type="general")
+    assert name == "accurate"
+    assert adapted == "HELLO"
+
+    # Long prompt should favour speed
+    long_prompt = "x" * 101
+    name, _, _ = manager.select_model(long_prompt)
+    assert name == "fast"
+
+    # If fast becomes unavailable, accurate is chosen
+    fast.available = False
+    name, _, _ = manager.select_model("short")
+    assert name == "accurate"
+
+
+def test_ensemble_and_learning_integration() -> None:
+    manager = LLMManager()
+    fast = DummyLLM("fast")
+    accurate = DummyLLM("accurate")
+
+    manager.register_model("fast", fast, speed=10, cost=1, accuracy=0.5)
+    manager.register_model("accurate", accurate, speed=1, cost=2, accuracy=0.9)
+
+    result = manager.generate("prompt", ensemble=True)
+    assert result == "accurate:prompt"
+    assert manager.learning_system.experience_buffer  # interaction recorded
+    interaction = manager.learning_system.experience_buffer[0]
+    assert interaction["context"]["model"] == "accurate"
+    assert interaction["response"] == "accurate:prompt"


### PR DESCRIPTION
## Summary
- add `LLMManager` for registering LLMs with speed, cost and accuracy metadata
- support task-aware model selection, prompt adaptation and ensemble aggregation
- integrate learning system feedback and provide tests

## Testing
- `pytest tests/test_llm_manager.py -q`
- `pytest tests/test_llm_mistral.py -q`
- `pytest` *(fails: ebooklib, python-docx, PyPDF2 missing; TagProcessor tests)*

------
https://chatgpt.com/codex/tasks/task_e_68932831d68c8323b1e716550d344fdf