### PR TITLE
feat: enhance learning system with metrics and caching

### DIFF
--- a/src/interaction/chat_session.py
+++ b/src/interaction/chat_session.py
@@ -13,6 +13,7 @@ adds a convenience layer around it.
 from dataclasses import dataclass
 import re
 from typing import List, Optional
+import time
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
@@ -77,17 +78,29 @@ class ChatSession:
         """Send ``message`` to Neyra, request rating and return her response."""
 
         setattr(self.neyra, "current_user_id", user_id)
-        try:
-            prepared = self._prepare_message(message)
-            result = handle_command(self.neyra, prepared, self.processor)
-        except Exception as exc:  # pragma: no cover - defensive
-            self.console.print(Panel(f"[red]{exc}[/]", title="Error"))
-            return ""
+        start_time = time.perf_counter()
+        prepared = self._prepare_message(message)
+
+        cached = self.learning.get_cached_response(message)
+        if cached is not None:
+            result_text = cached
+        else:
+            try:
+                result = handle_command(self.neyra, prepared, self.processor)
+                result_text = result.text
+            except Exception as exc:  # pragma: no cover - defensive
+                self.console.print(Panel(f"[red]{exc}[/]", title="Error"))
+                return ""
+
+        end_time = time.perf_counter()
 
         # Track conversation history
         self.history.append(ChatEntry("user", message))
-        self.history.append(ChatEntry("neyra", result.text))
+        self.history.append(ChatEntry("neyra", result_text))
         self._trim_history()
+
+        # Ensure response cached for future use
+        self.learning.response_cache[message] = result_text
 
         # Update context based on tags in the prepared message
         tags = self.processor.parse(prepared)
@@ -111,15 +124,17 @@ class ChatSession:
                 context = {
                     "user_id": user_id,
                     "tone": getattr(self.neyra, "current_style", None),
-                    "examples": [result.text],
+                    "examples": [result_text],
+                    "start_time": start_time,
+                    "end_time": end_time,
                 }
                 self.learning.learn_from_interaction(
-                    message, result.text, rating, context
+                    message, result_text, rating, context
                 )
             except Exception:  # pragma: no cover - best effort
                 pass
 
-        return result.text
+        return result_text
 
     def chat_loop(self) -> None:  # pragma: no cover - interactive
         """Run an interactive loop until the user enters ``/exit``."""

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -34,6 +34,7 @@ class LearningSystem:
     failure_analysis: List[Dict[str, Any]] = field(default_factory=list)
     adaptation_weights: Dict[str, int] = field(default_factory=dict)
     style_memory: StyleMemory = field(default_factory=StyleMemory)
+    response_cache: Dict[str, str] = field(default_factory=dict)
 
     # ------------------------------------------------------------------
     def learn_from_interaction(
@@ -64,6 +65,12 @@ class LearningSystem:
             "context": context or {},
         }
 
+        metrics = {
+            "success": rating >= 0,
+            "reaction_time": None,
+            "error_type": None,
+        }
+
         prev_failure = self.check_previous_failures(user_request)
         if prev_failure:
             interaction["context"]["warning"] = prev_failure.get("recommendation")
@@ -84,13 +91,37 @@ class LearningSystem:
                     self.style_memory.save()
         else:
             self.success_metrics["negative"] += 1
-            self._analyze_failure(interaction)
+            metrics["error_type"] = classify_error(interaction)
+            self._analyze_failure(interaction, metrics["error_type"])
+
+        # Capture reaction time if provided
+        if context:
+            start = context.get("start_time")
+            end = context.get("end_time")
+            if start is not None and end is not None:
+                metrics["reaction_time"] = end - start
+
+        interaction["metrics"] = metrics
+
+        # Cache the response for future lookups
+        self.response_cache[user_request] = response
+
+        # Update adaptation weights based on success ratio
+        total_pos = self.success_metrics["positive"]
+        total_neg = self.success_metrics["negative"]
+        total = total_pos + total_neg
+        if total:
+            ratio = total_pos / total
+            self.adaptation_weights["success_rate"] = ratio
+            for key in list(self.adaptation_weights.keys()):
+                if key == "success_rate":
+                    continue
+                weight = self.adaptation_weights[key]
+                self.adaptation_weights[key] = max(1, int(weight * ratio))
 
     # ------------------------------------------------------------------
-    def _analyze_failure(self, interaction: Dict[str, Any]) -> None:
+    def _analyze_failure(self, interaction: Dict[str, Any], error_type: str) -> None:
         """Record failure details and recommended actions."""
-
-        error_type = classify_error(interaction)
         entry = {
             "request": interaction.get("request"),
             "response": interaction.get("response"),
@@ -110,6 +141,21 @@ class LearningSystem:
             if failure.get("request") == user_request:
                 return failure
         return None
+
+    # ------------------------------------------------------------------
+    def get_cached_response(self, user_request: str) -> Optional[str]:
+        """Return cached response for ``user_request`` if available.
+
+        The method also checks past failures and prints a warning when a
+        matching failure is found.
+        """
+
+        prev_failure = self.check_previous_failures(user_request)
+        if prev_failure:
+            print(
+                f"Warning: previous failure detected. {prev_failure.get('recommendation')}"
+            )
+        return self.response_cache.get(user_request)
 
     # ------------------------------------------------------------------
     def create_new_neuron_type(self) -> Optional[str]:

--- a/tests/test_learning/test_learning_system.py
+++ b/tests/test_learning/test_learning_system.py
@@ -5,17 +5,34 @@ from src.neurons import NeuronFactory
 from src.memory import StyleMemory
 
 
-def test_learn_from_interaction_updates_metrics() -> None:
+def test_learn_from_interaction_records_metrics() -> None:
     system = LearningSystem()
-    system.learn_from_interaction("hi", "hello", -1, {"topic": "combat"})
-    assert len(system.experience_buffer) == 1
-    assert system.success_metrics["negative"] == 1
-    assert system.failure_analysis["combat"] == 1
+    ctx = {"start_time": 0.0, "end_time": 1.5}
+    system.learn_from_interaction("hi", "hello", -1, ctx)
+
+    interaction = system.experience_buffer[0]
+    metrics = interaction["metrics"]
+    assert metrics["success"] is False
+    assert metrics["reaction_time"] == 1.5
+    assert metrics["error_type"] is not None
+
+
+def test_request_cache_and_success_rate() -> None:
+    system = LearningSystem()
+    ctx = {"start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("good", "yes", 1, ctx)
+    system.learn_from_interaction("bad", "no", -1, ctx)
+
+    assert system.adaptation_weights["success_rate"] == 0.5
+
+    system.response_cache["cached"] = "stored"
+    assert system.get_cached_response("cached") == "stored"
 
 
 def test_create_new_neuron_type_registers() -> None:
     system = LearningSystem()
-    system.learn_from_interaction("hi", "hello", -1, {"topic": "magic"})
+    ctx = {"start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("hi", "hello", -1, ctx)
     neuron_type = system.create_new_neuron_type()
     neuron = NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
     assert neuron.type == neuron_type
@@ -23,7 +40,8 @@ def test_create_new_neuron_type_registers() -> None:
 
 def test_save_and_load_state_roundtrip(tmp_path) -> None:
     system = LearningSystem()
-    system.learn_from_interaction("hi", "hello", 1, {"topic": "lore"})
+    ctx = {"start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("hi", "hello", 1, ctx)
     path = tmp_path / "state.json"
     system.save_state(path)
     loaded = LearningSystem.load_state(path)
@@ -35,9 +53,16 @@ def test_save_and_load_state_roundtrip(tmp_path) -> None:
 def test_positive_feedback_saves_user_style(tmp_path) -> None:
     system = LearningSystem()
     system.style_memory = StyleMemory(tmp_path / "styles.json")
-    context = {"user_id": "u1", "tone": "дружелюбный", "examples": ["пример"]}
+    context = {
+        "user_id": "u1",
+        "tone": "дружелюбный",
+        "examples": ["пример"],
+        "start_time": 0.0,
+        "end_time": 1.0,
+    }
     system.learn_from_interaction("hi", "hello", 1, context)
     pattern = system.style_memory.get_style("u1", "preferred")
     assert pattern is not None
     assert pattern.description == "дружелюбный"
     assert "пример" in pattern.examples
+


### PR DESCRIPTION
## Summary
- track success, reaction time, and error type in learning system
- cache responses with failure checks before answering
- adjust adaptation weights based on success ratio and add tests

## Testing
- `pytest -q` *(fails: TagProcessor parsing and integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689355fa2b2c83238440200d06deb969