### PR TITLE
Add feedback interface and preference storage

### DIFF
--- a/src/learning/__init__.py
+++ b/src/learning/__init__.py
@@ -2,5 +2,6 @@
 
 from .learning_system import LearningSystem
 from .error_analysis import classify_error, recommend_action
+from .feedback import FeedbackInterface
 
-__all__ = ["LearningSystem", "classify_error", "recommend_action"]
+__all__ = ["LearningSystem", "classify_error", "recommend_action", "FeedbackInterface"]

--- a/src/learning/feedback.py
+++ b/src/learning/feedback.py
@@ -1,0 +1,42 @@
+"""Interface for recording user feedback during learning."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any, Dict, List
+
+
+class FeedbackInterface:
+    """Simple persistence layer for interaction feedback."""
+
+    storage_path = Path("data/feedback.json")
+    _data: Dict[str, List[Dict[str, Any]]] = {}
+
+    @classmethod
+    def record(cls, user_id: str, interaction: Dict[str, Any]) -> None:
+        """Record ``interaction`` feedback for ``user_id``."""
+        cls._data.setdefault(user_id, []).append(interaction)
+        cls.save()
+
+    @classmethod
+    def save(cls) -> None:
+        """Persist feedback to disk."""
+        cls.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        cls.storage_path.write_text(
+            json.dumps(cls._data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @classmethod
+    def load(cls) -> None:
+        """Load previously stored feedback if available."""
+        if not cls.storage_path.exists():
+            return
+        try:
+            raw = json.loads(cls.storage_path.read_text(encoding="utf-8"))
+        except Exception:
+            raw = {}
+        cls._data = {k: list(v) for k, v in raw.items()}
+
+
+__all__ = ["FeedbackInterface"]

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -9,6 +9,7 @@ from src.neurons import Neuron, NeuronFactory
 from src.neurons.evolution import EvolutionConfig, evolve
 from src.memory import StyleMemory
 from src.learning.error_analysis import classify_error, recommend_action
+from src.learning.feedback import FeedbackInterface
 
 
 @dataclass
@@ -81,14 +82,11 @@ class LearningSystem:
         if rating >= 0:
             self.success_metrics["positive"] += 1
             if context:
-                user_id = context.get("user_id", "default")
+                user_id = context.get("user_id")
                 tone = context.get("tone")
                 examples = context.get("examples", [])
-                if tone or examples:
-                    self.style_memory.add(user_id, "preferred", description=tone)
-                    for ex in examples:
-                        self.style_memory.add_style_example(user_id, "preferred", ex)
-                    self.style_memory.save()
+                if user_id and (tone or examples):
+                    self.style_memory.save_preferences(user_id, tone, examples)
         else:
             self.success_metrics["negative"] += 1
             metrics["error_type"] = classify_error(interaction)
@@ -118,6 +116,9 @@ class LearningSystem:
                     continue
                 weight = self.adaptation_weights[key]
                 self.adaptation_weights[key] = max(1, int(weight * ratio))
+
+        if context and context.get("user_id"):
+            FeedbackInterface.record(context["user_id"], interaction)
 
     # ------------------------------------------------------------------
     def _analyze_failure(self, interaction: Dict[str, Any], error_type: str) -> None:

--- a/src/memory/style_memory.py
+++ b/src/memory/style_memory.py
@@ -81,6 +81,35 @@ class StyleMemory:
         return examples
 
     # ------------------------------------------------------------------
+    def save_preferences(
+        self,
+        user_id: str,
+        tone: str | None = None,
+        examples: List[str] | None = None,
+    ) -> None:
+        """Store user preferences such as ``tone`` and ``examples``.
+
+        Parameters
+        ----------
+        user_id:
+            Identifier of the user whose preferences are being saved.
+        tone:
+            Preferred tone of responses.
+        examples:
+            Example phrases illustrating the desired style.
+        """
+
+        if not tone and not examples:
+            return
+
+        if tone:
+            self.add(user_id, "preferred", description=tone)
+        if examples:
+            for ex in examples:
+                self.add_style_example(user_id, "preferred", ex)
+        self.save()
+
+    # ------------------------------------------------------------------
     def save(self) -> None:
         """Persist memory to disk."""
         serialised = {

--- a/tests/test_learning/test_learning_system.py
+++ b/tests/test_learning/test_learning_system.py
@@ -66,3 +66,22 @@ def test_positive_feedback_saves_user_style(tmp_path) -> None:
     assert pattern.description == "дружелюбный"
     assert "пример" in pattern.examples
 
+
+def test_feedback_interface_called(monkeypatch) -> None:
+    system = LearningSystem()
+    called: dict = {}
+
+    def fake_record(user_id, interaction):
+        called["user_id"] = user_id
+        called["interaction"] = interaction
+
+    monkeypatch.setattr(
+        "src.learning.feedback.FeedbackInterface.record", fake_record
+    )
+
+    context = {"user_id": "u1", "start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("hi", "hello", 1, context)
+
+    assert called["user_id"] == "u1"
+    assert called["interaction"]["request"] == "hi"
+


### PR DESCRIPTION
## Summary
- add `FeedbackInterface` module to persist interaction feedback
- record feedback and save user preferences during learning
- cover feedback recording with a unit test

## Testing
- `pytest` *(fails: RuntimeError: ebooklib is required to handle e-book files, RuntimeError: python-docx is required to handle Office files, RuntimeError: PyPDF2 is required to handle PDF files, AssertionError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68935f0d20dc8323a37caa4783dc0170