### PR TITLE
Add error category tracking and planning neuron

### DIFF
--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -34,6 +34,9 @@ class LearningSystem:
     )
     failure_analysis: List[Dict[str, Any]] = field(default_factory=list)
     adaptation_weights: Dict[str, int] = field(default_factory=dict)
+    error_categories: Dict[str, int] = field(
+        default_factory=lambda: {"logical": 0, "linguistic": 0, "system": 0}
+    )
     style_memory: StyleMemory = field(default_factory=StyleMemory)
     response_cache: Dict[str, str] = field(default_factory=dict)
 
@@ -169,10 +172,11 @@ class LearningSystem:
 
         cfg = EvolutionConfig()
 
-        error_counts: Dict[str, int] = {}
+        error_counts: Dict[str, int] = {k: 0 for k in self.error_categories}
         for entry in self.failure_analysis:
             et = entry.get("error_type", "unknown")
             error_counts[et] = error_counts.get(et, 0) + 1
+        self.error_categories.update(error_counts)
 
         for reason, count in error_counts.items():
             weight = self.adaptation_weights.get(reason, 0)

--- a/src/neurons/__init__.py
+++ b/src/neurons/__init__.py
@@ -8,6 +8,7 @@ from .base import Neuron
 from .memory import MemoryNeuron
 from .analysis import AnalysisNeuron
 from .action import ActionNeuron
+from .planning import PlanningNeuron
 from .patterns import BehaviorPattern
 from .network import NeuronNetwork
 from .factory import NeuronFactory
@@ -18,6 +19,7 @@ __all__ = [
     "MemoryNeuron",
     "AnalysisNeuron",
     "ActionNeuron",
+    "PlanningNeuron",
     "BehaviorPattern",
     "NeuronNetwork",
     "NeuronFactory",

--- a/src/neurons/evolution.py
+++ b/src/neurons/evolution.py
@@ -15,6 +15,7 @@ from .base import Neuron
 from .memory import MemoryNeuron
 from .analysis import AnalysisNeuron
 from .action import ActionNeuron
+from .planning import PlanningNeuron
 
 
 @dataclass
@@ -26,7 +27,14 @@ class EvolutionConfig:
     mutation_rate: float = 0.1
 
 
-SPECIALISED = [MemoryNeuron, AnalysisNeuron, ActionNeuron]
+SPECIALISED = [MemoryNeuron, AnalysisNeuron, ActionNeuron, PlanningNeuron]
+
+
+def register_base_class(cls: Type[Neuron]) -> None:
+    """Register an additional base class for evolution."""
+
+    if cls not in SPECIALISED:
+        SPECIALISED.append(cls)
 
 
 def evolve(
@@ -77,4 +85,4 @@ def evolve(
     return neuron_type, neuron_cls
 
 
-__all__ = ["EvolutionConfig", "evolve"]
+__all__ = ["EvolutionConfig", "evolve", "register_base_class"]

--- a/src/neurons/planning.py
+++ b/src/neurons/planning.py
@@ -1,0 +1,21 @@
+"""Planning neuron."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .base import Neuron
+
+
+@dataclass
+class PlanningNeuron(Neuron):
+    """Neuron capable of simple planning tasks."""
+
+    type: str = "planning"
+
+    # ------------------------------------------------------------------
+    def process(self, goal: str) -> str:
+        """Return a placeholder plan for the given goal."""
+
+        self.activate()
+        return f"plan:{goal}"

--- a/tests/test_neurons/test_new_types.py
+++ b/tests/test_neurons/test_new_types.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from src.learning import LearningSystem
+from src.neurons import Neuron, MemoryNeuron, PlanningNeuron
+from src.neurons.evolution import EvolutionConfig, evolve
+
+
+def test_create_new_neuron_type_tracks_categories(monkeypatch) -> None:
+    system = LearningSystem()
+    system.failure_analysis = [
+        {"error_type": "logical"},
+        {"error_type": "linguistic"},
+        {"error_type": "logical"},
+        {"error_type": "system"},
+    ]
+
+    monkeypatch.setattr(
+        "src.learning.learning_system.evolve",
+        lambda source, cfg: ("dummy", MemoryNeuron),
+    )
+
+    neuron_type = system.create_new_neuron_type()
+    assert neuron_type == "dummy"
+    assert system.error_categories == {"logical": 2, "linguistic": 1, "system": 1}
+
+
+def test_evolve_supports_planning_neuron(monkeypatch) -> None:
+    source = Neuron(id="src", type="base", activation_count=3, strength=0.9)
+    cfg = EvolutionConfig(activation_threshold=2, strength_threshold=0.8)
+
+    monkeypatch.setattr(
+        "src.neurons.evolution.random.choice", lambda seq: PlanningNeuron
+    )
+
+    result = evolve(source, cfg)
+    assert result is not None
+    _, neuron_cls = result
+    new_neuron = source.connections[0]
+    assert isinstance(new_neuron, PlanningNeuron)


### PR DESCRIPTION
## Summary
- track logical, linguistic, and system errors when creating new neuron types
- support new PlanningNeuron base class and allow registering extra neuron bases
- test category tracking and PlanningNeuron evolution

## Testing
- `pytest tests/test_neurons -q`


------
https://chatgpt.com/codex/tasks/task_e_6893640fbc7083239fd253af3b0eb7fc