### PR TITLE
feat: track llm metrics and style prompts

### DIFF
--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -2,7 +2,8 @@
 
 from .base_llm import BaseLLM, LLMFactory
 from .mistral_interface import MistralLLM
-from .manager import LLMManager, ModelSpec
+from .manager import LLMManager, ModelSpec, Task
+from .prompts import chat_prompt, apply_user_style
 
 __all__ = [
     "BaseLLM",
@@ -10,4 +11,7 @@ __all__ = [
     "MistralLLM",
     "LLMManager",
     "ModelSpec",
+    "Task",
+    "chat_prompt",
+    "apply_user_style",
 ]

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -9,10 +9,12 @@ ensemble aggregation.  The manager can also forward interaction results to
 """
 
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional, Tuple
+import time
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from .base_llm import BaseLLM
 from src.learning.learning_system import LearningSystem
+from .prompts import chat_prompt
 
 
 @dataclass
@@ -33,12 +35,24 @@ class ModelSpec:
         return self.prompt_adapter(prompt)
 
 
+@dataclass
+class Task:
+    """Describe a generation task and user context."""
+
+    prompt: str
+    user_id: str | None = None
+    request_type: str = "general"
+    context: Dict[str, Any] | None = None
+
+
 class LLMManager:
     """Manage multiple language models and route requests accordingly."""
 
     def __init__(self, learning_system: Optional[LearningSystem] = None) -> None:
         self.models: Dict[str, ModelSpec] = {}
         self.learning_system = learning_system or LearningSystem()
+        # name -> {calls, successes, total_time}
+        self.model_metrics: Dict[str, Dict[str, float]] = {}
 
     # ------------------------------------------------------------------
     def register_model(
@@ -62,15 +76,12 @@ class LLMManager:
         )
 
     # ------------------------------------------------------------------
-    def select_model(
-        self, prompt: str, *, request_type: str = "general"
-    ) -> Tuple[str, BaseLLM, str]:
-        """Return the model best suited for ``prompt``.
+    def select_model(self, task: Task) -> Tuple[str, BaseLLM, str]:
+        """Return the model best suited for ``task``.
 
-        The choice considers ``request_type`` (e.g. ``"fast"`` or ``"cheap"``),
-        the length of ``prompt`` and the availability of registered models.
-        The returned tuple contains the model name, the model instance and the
-        adapted prompt for that model.
+        Selection is based on previously recorded metrics, the requested
+        ``task.request_type`` and any user preferences contained in
+        ``task.context``.
         """
 
         available = [
@@ -81,64 +92,118 @@ class LLMManager:
         if not available:
             raise RuntimeError("No available models")
 
-        length = len(prompt)
+        if task.context and "preferred_model" in task.context:
+            preferred = task.context["preferred_model"]
+            for name, spec in available:
+                if name == preferred:
+                    adapted = spec.adapt_prompt(task.prompt)
+                    return name, spec.llm, adapted
 
-        if request_type == "fast":
-            name, spec = max(available, key=lambda item: item[1].speed)
-        elif request_type == "cheap":
+        def success_rate(model_name: str) -> float:
+            metrics = self.model_metrics.get(model_name, {})
+            calls = metrics.get("calls", 0)
+            if not calls:
+                return self.models[model_name].accuracy
+            return metrics.get("successes", 0) / calls
+
+        def avg_time(model_name: str) -> float:
+            metrics = self.model_metrics.get(model_name, {})
+            calls = metrics.get("calls", 0)
+            if not calls:
+                return 1.0 / self.models[model_name].speed
+            return metrics.get("total_time", 0.0) / calls
+
+        length = len(task.prompt)
+
+        if task.request_type == "fast":
+            name, spec = min(available, key=lambda item: avg_time(item[0]))
+        elif task.request_type == "cheap":
             name, spec = min(available, key=lambda item: item[1].cost)
         else:
             if length > 100:
-                name, spec = max(available, key=lambda item: item[1].speed)
+                name, spec = min(available, key=lambda item: avg_time(item[0]))
             else:
-                name, spec = max(available, key=lambda item: item[1].accuracy)
+                name, spec = max(available, key=lambda item: success_rate(item[0]))
 
-        adapted_prompt = spec.adapt_prompt(prompt)
+        adapted_prompt = spec.adapt_prompt(task.prompt)
         return name, spec.llm, adapted_prompt
 
     # ------------------------------------------------------------------
     def generate(
         self,
-        prompt: str,
+        task: Task,
         *,
-        request_type: str = "general",
         ensemble: bool = False,
+        success: bool = True,
         **kwargs,
     ) -> str:
-        """Generate a response for ``prompt`` using the selected model.
+        """Generate a response for ``task`` using the selected model.
 
         When ``ensemble`` is ``True`` all available models are invoked and the
         result from the most accurate one is returned.
         """
+
+        task.prompt = chat_prompt(
+            task.prompt, user_id=task.user_id, style_memory=self.learning_system.style_memory
+        )
 
         if ensemble:
             outputs: Dict[str, str] = {}
             for name, spec in self.models.items():
                 if not spec.llm.is_available():
                     continue
-                adapted = spec.adapt_prompt(prompt)
+                adapted = spec.adapt_prompt(task.prompt)
+                start = time.perf_counter()
                 outputs[name] = spec.llm.generate(adapted, **kwargs)
+                duration = time.perf_counter() - start
+                self._update_metrics(name, duration, success)
             if not outputs:
                 raise RuntimeError("No available models")
             best_name = max(outputs, key=lambda n: self.models[n].accuracy)
             result = outputs[best_name]
-            self._record_interaction(prompt, result, best_name)
+            self._record_interaction(task.prompt, result, best_name)
             return result
 
-        name, model, adapted = self.select_model(prompt, request_type=request_type)
+        name, model, adapted = self.select_model(task)
+        start = time.perf_counter()
         result = model.generate(adapted, **kwargs)
-        self._record_interaction(prompt, result, name)
+        end = time.perf_counter()
+        self._update_metrics(name, end - start, success)
+        self._record_interaction(
+            task.prompt, result, name, start_time=start, end_time=end
+        )
         return result
 
     # ------------------------------------------------------------------
-    def _record_interaction(self, prompt: str, response: str, model_name: str) -> None:
+    def _record_interaction(
+        self,
+        prompt: str,
+        response: str,
+        model_name: str,
+        *,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> None:
         """Forward evaluation information to the learning system."""
 
         rating = int(self.models[model_name].accuracy * 100)
-        context = {"model": model_name}
+        context: Dict[str, Any] = {"model": model_name}
+        if start_time is not None and end_time is not None:
+            context.update({"start_time": start_time, "end_time": end_time})
         self.learning_system.learn_from_interaction(
             prompt, response, rating, context=context
         )
 
+    def _update_metrics(self, model_name: str, duration: float, success: bool) -> None:
+        """Update usage metrics for ``model_name``."""
 
-__all__ = ["ModelSpec", "LLMManager"]
+        metrics = self.model_metrics.setdefault(
+            model_name, {"calls": 0, "successes": 0, "total_time": 0.0}
+        )
+        metrics["calls"] += 1
+        metrics["total_time"] += duration
+        if success:
+            metrics["successes"] += 1
+
+
+__all__ = ["ModelSpec", "LLMManager", "Task"]

--- a/src/llm/prompts.py
+++ b/src/llm/prompts.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Prompt templates with user style adaptation."""
+
+from src.memory.style_memory import StyleMemory, StylePattern
+
+
+DEFAULT_CHAT_TEMPLATE = "{prompt}"
+
+
+def apply_user_style(
+    prompt: str,
+    *,
+    user_id: str | None = None,
+    style_memory: StyleMemory | None = None,
+) -> str:
+    """Return ``prompt`` adapted according to ``user_id`` style.
+
+    Parameters
+    ----------
+    prompt:
+        Original prompt text.
+    user_id:
+        Identifier of the user whose style should be applied.
+    style_memory:
+        Optional :class:`StyleMemory` used to fetch style information.
+    """
+
+    if user_id is None:
+        return prompt
+    memory = style_memory or StyleMemory()
+    style = memory.get_style(user_id, "preferred")
+    if not isinstance(style, StylePattern):
+        return prompt
+    style_prefix = ""
+    if style.description:
+        style_prefix += f"Тон: {style.description}\n"
+    if style.examples:
+        style_prefix += "Примеры:\n" + "\n".join(style.examples) + "\n"
+    return style_prefix + prompt
+
+
+def chat_prompt(
+    prompt: str,
+    *,
+    user_id: str | None = None,
+    style_memory: StyleMemory | None = None,
+) -> str:
+    """Format a basic chat prompt applying user style if available."""
+
+    base = DEFAULT_CHAT_TEMPLATE.format(prompt=prompt)
+    return apply_user_style(base, user_id=user_id, style_memory=style_memory)
+
+
+__all__ = ["chat_prompt", "apply_user_style", "DEFAULT_CHAT_TEMPLATE"]

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Tests for :mod:`src.llm.manager`."""
 
-from src.llm.manager import LLMManager
+from src.llm.manager import LLMManager, Task
 from src.llm.base_llm import BaseLLM
 
 
@@ -31,24 +31,24 @@ def test_selection_and_prompt_adaptation() -> None:
     )
 
     # Request explicitly asking for speed selects fast model
-    name, model, adapted = manager.select_model("hi", request_type="fast")
+    name, model, adapted = manager.select_model(Task(prompt="hi", request_type="fast"))
     assert name == "fast"
     assert model is fast
     assert adapted == "hi"
 
     # General request prefers accuracy and applies adapter
-    name, model, adapted = manager.select_model("hello", request_type="general")
+    name, model, adapted = manager.select_model(Task(prompt="hello"))
     assert name == "accurate"
     assert adapted == "HELLO"
 
     # Long prompt should favour speed
     long_prompt = "x" * 101
-    name, _, _ = manager.select_model(long_prompt)
+    name, _, _ = manager.select_model(Task(prompt=long_prompt))
     assert name == "fast"
 
     # If fast becomes unavailable, accurate is chosen
     fast.available = False
-    name, _, _ = manager.select_model("short")
+    name, _, _ = manager.select_model(Task(prompt="short"))
     assert name == "accurate"
 
 
@@ -60,7 +60,7 @@ def test_ensemble_and_learning_integration() -> None:
     manager.register_model("fast", fast, speed=10, cost=1, accuracy=0.5)
     manager.register_model("accurate", accurate, speed=1, cost=2, accuracy=0.9)
 
-    result = manager.generate("prompt", ensemble=True)
+    result = manager.generate(Task(prompt="prompt"), ensemble=True)
     assert result == "accurate:prompt"
     assert manager.learning_system.experience_buffer  # interaction recorded
     interaction = manager.learning_system.experience_buffer[0]


### PR DESCRIPTION
## Summary
- track per-model usage metrics and user-aware selection
- add user-style aware prompt helpers
- expose new LLM utilities and update tests

## Testing
- `pytest tests/test_llm_manager.py`
- `pytest` *(fails: test_pdf_roundtrip requires reportlab, multiple TagProcessor tests, neyra_recall_history)*

------
https://chatgpt.com/codex/tasks/task_e_689368fa9f6c8323ba51cf9fc2cd4da8