### PR TITLE
Integrate persistent failure knowledge base

### DIFF
--- a/src/learning/__init__.py
+++ b/src/learning/__init__.py
@@ -3,5 +3,12 @@
 from .learning_system import LearningSystem
 from .error_analysis import classify_error, recommend_action
 from .feedback import FeedbackInterface
+from .knowledge_base import KnowledgeBase
 
-__all__ = ["LearningSystem", "classify_error", "recommend_action", "FeedbackInterface"]
+__all__ = [
+    "LearningSystem",
+    "classify_error",
+    "recommend_action",
+    "FeedbackInterface",
+    "KnowledgeBase",
+]

--- a/src/learning/knowledge_base.py
+++ b/src/learning/knowledge_base.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class KnowledgeBase:
+    """Simple JSON-backed storage for failure records."""
+
+    def __init__(self, path: Path | str | None = None) -> None:
+        self.path = Path(path) if path else None
+        self._entries: List[Dict[str, Any]] = []
+        if self.path and self.path.exists():
+            try:
+                self._entries = json.loads(self.path.read_text())
+            except json.JSONDecodeError:
+                self._entries = []
+
+    # ------------------------------------------------------------------
+    def add(self, entry: Dict[str, Any]) -> None:
+        """Add a new failure ``entry`` to the knowledge base."""
+        self._entries.append(entry)
+
+    # ------------------------------------------------------------------
+    def query(self, request: str) -> Optional[Dict[str, Any]]:
+        """Return the first entry matching ``request`` if present."""
+        for item in self._entries:
+            if item.get("request") == request:
+                return item
+        return None
+
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        """Persist entries to disk when a path is configured."""
+        if not self.path:
+            return
+        self.path.write_text(json.dumps(self._entries))
+
+
+__all__ = ["KnowledgeBase"]

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -10,6 +10,7 @@ from src.neurons.evolution import EvolutionConfig, evolve
 from src.memory import StyleMemory
 from src.learning.error_analysis import classify_error, recommend_action
 from src.learning.feedback import FeedbackInterface
+from src.learning.knowledge_base import KnowledgeBase
 
 
 @dataclass
@@ -39,6 +40,7 @@ class LearningSystem:
     )
     style_memory: StyleMemory = field(default_factory=StyleMemory)
     response_cache: Dict[str, str] = field(default_factory=dict)
+    knowledge_base: KnowledgeBase = field(default_factory=KnowledgeBase)
 
     # ------------------------------------------------------------------
     def learn_from_interaction(
@@ -136,11 +138,16 @@ class LearningSystem:
             "error_type": error_type,
         }
         self.failure_analysis.append(entry)
+        self.knowledge_base.add(entry)
+        self.knowledge_base.save()
 
     # ------------------------------------------------------------------
     def check_previous_failures(self, user_request: str) -> Optional[Dict[str, Any]]:
         """Return previous failure entry if the request was seen before."""
 
+        kb_entry = self.knowledge_base.query(user_request)
+        if kb_entry:
+            return kb_entry
         for failure in self.failure_analysis:
             if failure.get("request") == user_request:
                 return failure

--- a/tests/test_learning/test_knowledge_base.py
+++ b/tests/test_learning/test_knowledge_base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from src.learning import KnowledgeBase, LearningSystem
+
+
+def test_knowledge_base_add_query_save(tmp_path) -> None:
+    path = tmp_path / "kb.json"
+    kb = KnowledgeBase(path)
+    entry = {"request": "hi", "description": "logical"}
+    kb.add(entry)
+    kb.save()
+
+    loaded = KnowledgeBase(path)
+    assert loaded.query("hi") == entry
+
+
+def test_learning_system_persists_failures(tmp_path) -> None:
+    path = tmp_path / "kb.json"
+    system = LearningSystem()
+    system.knowledge_base = KnowledgeBase(path)
+    ctx = {"start_time": 0.0, "end_time": 1.0}
+    system.learn_from_interaction("hi", "oops", -1, ctx)
+
+    other = LearningSystem()
+    other.knowledge_base = KnowledgeBase(path)
+    failure = other.check_previous_failures("hi")
+    assert failure is not None
+    assert failure["request"] == "hi"


### PR DESCRIPTION
## Summary
- add JSON-backed `KnowledgeBase` with `add`, `query`, and `save`
- track failures in `LearningSystem` using the shared knowledge base
- test persistence and retrieval of failures

## Testing
- `python -m pytest tests/test_learning/test_knowledge_base.py tests/test_learning/test_learning_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893750b88288323b4c7dac749e6b4ef