### PR TITLE
Add claim verification system with source reliability

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,3 +1,9 @@
 from .self_corrector import SelfCorrector, SuggestionChooser
+from .verification_system import VerificationSystem, VerificationResult
 
-__all__ = ["SelfCorrector", "SuggestionChooser"]
+__all__ = [
+    "SelfCorrector",
+    "SuggestionChooser",
+    "VerificationSystem",
+    "VerificationResult",
+]

--- a/src/analysis/verification_system.py
+++ b/src/analysis/verification_system.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Simple claim verification module.
+
+This module provides a tiny framework to verify user claims by consulting
+stored memories and optional external checkers.  It is intentionally minimal
+and designed primarily for unit testing and demonstration purposes.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Tuple
+
+from src.memory import MemoryIndex
+
+
+@dataclass
+class VerificationResult:
+    """Result of a claim verification."""
+
+    claim: str
+    verdict: bool | None
+    confidence: float
+    sources: List[str] = field(default_factory=list)
+
+
+class VerificationSystem:
+    """Verify claims against memory and external services."""
+
+    def __init__(
+        self,
+        memory: MemoryIndex | None = None,
+        external_checkers: List[Callable[[str], Tuple[bool, float]]] | None = None,
+    ) -> None:
+        self.memory = memory or MemoryIndex()
+        # External checkers are callables returning a tuple of (verdict, confidence)
+        self.external_checkers = (
+            external_checkers if external_checkers is not None else [self._stub_check]
+        )
+
+    # ------------------------------------------------------------------
+    def add_external_checker(
+        self, checker: Callable[[str], Tuple[bool, float]]
+    ) -> None:
+        """Register an additional external checker."""
+
+        self.external_checkers.append(checker)
+
+    # ------------------------------------------------------------------
+    def verify_claim(self, claim: str) -> VerificationResult:
+        """Verify ``claim`` using memory and external checkers."""
+
+        sources: List[str] = []
+        verdict: bool | None = None
+        confidence = 0.0
+
+        memory_value = self.memory.get(claim)
+        if memory_value is not None:
+            verdict = bool(memory_value)
+            confidence = self.memory.source_reliability.get(claim, 0.0)
+            sources.append("memory")
+
+        for checker in self.external_checkers:
+            try:
+                result, ext_conf = checker(claim)
+            except Exception:  # pragma: no cover - defensive, external code
+                continue
+            sources.append(checker.__name__)
+            if verdict is None:
+                verdict = result
+            elif verdict != result:
+                # Conflicting results lower the confidence significantly
+                confidence = min(confidence, ext_conf) / 2
+                verdict = result
+                continue
+            confidence = (confidence + ext_conf) / 2 if confidence else ext_conf
+
+        return VerificationResult(claim=claim, verdict=verdict, confidence=confidence, sources=sources)
+
+    # ------------------------------------------------------------------
+    def generate_clarifying_questions(self, claim: str, num_questions: int = 2) -> List[str]:
+        """Generate simple clarifying questions for ``claim``."""
+
+        questions = [
+            f"Что вы подразумеваете под: '{claim}'?",
+            "Можете уточнить источник этой информации?",
+        ]
+        if num_questions > len(questions):
+            questions.extend(
+                [
+                    f"Есть ли дополнительные детали о '{claim}'?"
+                    for _ in range(num_questions - len(questions))
+                ]
+            )
+        return questions[:num_questions]
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _stub_check(_claim: str) -> Tuple[bool, float]:
+        """Default external check stub returning zero confidence."""
+
+        return False, 0.0
+
+
+__all__ = ["VerificationSystem", "VerificationResult"]
+

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -13,6 +13,7 @@ from src.utils.encoding_detector import detect_encoding
 from src.llm import BaseLLM, LLMFactory
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory, WorldMemory, StyleMemory
+from src.analysis import VerificationSystem, VerificationResult
 from src.models import Character
 from src.core.cache_manager import CacheManager
 
@@ -32,6 +33,7 @@ class Neyra:
         self.characters_memory = CharacterMemory()
         self.world_memory = WorldMemory()
         self.style_memory = StyleMemory()
+        self.verification_system = VerificationSystem()
         self.current_user_id = "default"
         self.current_style = ""
         self.emotional_state = "любопытная"
@@ -157,6 +159,11 @@ class Neyra:
 
         if self.characters_memory:
             print("   Главные герои:", list(self.characters_memory.keys())[:5])
+
+    def verify_claim(self, claim: str) -> VerificationResult:
+        """Проверяю утверждение с помощью системы верификации."""
+
+        return self.verification_system.verify_claim(claim)
 
     def process_command(self, text: str) -> str:
         """Обрабатываю команды с пониманием и творчеством."""

--- a/src/memory/index.py
+++ b/src/memory/index.py
@@ -28,6 +28,9 @@ class MemoryIndex:
         self.cold_storage: Dict[str, Any] = {}
         self.usage_stats: Dict[str, int] = {}
         self.access_times: Dict[str, float] = {}
+        # Track how trustworthy each source is perceived to be. 1.0 means
+        # highly reliable while 0.0 indicates unknown or untrusted source.
+        self.source_reliability: Dict[str, float] = {}
         self.hot_threshold = hot_threshold
         self.warm_threshold = warm_threshold
         self.hot_limit = hot_limit
@@ -35,14 +38,32 @@ class MemoryIndex:
 
     # ------------------------------------------------------------------
     # public API
-    def set(self, key: str, value: Any) -> None:
-        """Store ``key``/``value`` in cold storage."""
+    def set(self, key: str, value: Any, reliability: float = 0.5) -> None:
+        """Store ``key``/``value`` in cold storage.
+
+        Parameters
+        ----------
+        key:
+            Identifier for the memory record.
+        value:
+            The data to store.
+        reliability:
+            A float between 0 and 1 representing how trustworthy the source
+            of this record is. Defaults to ``0.5`` which means neutral
+            reliability.
+        """
         self.cold_storage[key] = value
         self.usage_stats[key] = 0
         self.access_times[key] = time.time()
+        self.source_reliability[key] = max(0.0, min(1.0, reliability))
         self._age_items(key)
         self._check_demotions()
         self._enforce_limits()
+
+    def update_reliability(self, key: str, reliability: float) -> None:
+        """Update reliability for ``key`` if it exists."""
+        if key in self.cold_storage or key in self.warm_cache or key in self.hot_cache:
+            self.source_reliability[key] = max(0.0, min(1.0, reliability))
 
     def get(self, key: str) -> Any:
         """Retrieve ``key`` from whichever tier currently holds it."""

--- a/tests/test_analysis/test_verification_system.py
+++ b/tests/test_analysis/test_verification_system.py
@@ -1,0 +1,24 @@
+from src.analysis import VerificationSystem
+from src.memory import MemoryIndex
+
+
+def _dummy_check(_claim: str) -> tuple[bool, float]:
+    return True, 0.8
+
+
+def test_verify_claim_with_memory_and_external() -> None:
+    memory = MemoryIndex()
+    memory.set("the sky is blue", True, reliability=0.9)
+    verifier = VerificationSystem(memory=memory, external_checkers=[_dummy_check])
+    result = verifier.verify_claim("the sky is blue")
+    assert result.verdict is True
+    assert result.confidence >= 0.8
+    assert "memory" in result.sources
+    assert any("_dummy_check" in s for s in result.sources)
+
+
+def test_generate_clarifying_questions() -> None:
+    verifier = VerificationSystem()
+    questions = verifier.generate_clarifying_questions("the sky is blue")
+    assert questions
+    assert "the sky is blue" in questions[0]


### PR DESCRIPTION
## Summary
- add `VerificationSystem` for checking claims against memory and external stubs
- track `source_reliability` in `MemoryIndex` to influence confidence
- wire verification into Neyra core and export via analysis package
- cover verification flow with tests

## Testing
- `pytest tests/test_analysis/test_verification_system.py -q`
- `pytest` *(fails: TagProcessor tests and some integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689385129f448323bf948a478c4e8ab6