### PR TITLE
feat: add source tracking utility

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from src.core.neyra_brain import Neyra
 from src.interaction.chat_session import ChatSession
 from src.models import Character
+from src.utils.source_tracker import SourceTracker
 
 def setup_logging() -> None:
     """Настраиваю систему для записи того, что думает Нейра"""
@@ -23,6 +24,7 @@ def main() -> None:
     """Нейра просыпается и начинает работать!"""
     setup_logging()
     logger = logging.getLogger(__name__)
+    tracker = SourceTracker()
     
     print("🌟 Пробуждение Нейры... 🌟")
     
@@ -50,9 +52,10 @@ def main() -> None:
         books_dir = Path("data/books/")
         if books_dir.exists() and list(books_dir.glob("*.txt")):
             print("\n📚 Вижу книги для изучения!")
-            
+
             for book_file in books_dir.glob("*.txt"):
                 logger.info(f"Нейра изучает: {book_file.name}")
+                tracker.add(f"Изучена книга {book_file.name}", str(book_file), 0.9)
                 neyra.load_book(str(book_file))
                 
             neyra.analyze_content()
@@ -67,6 +70,9 @@ def main() -> None:
             print(f"\n🏷️ Демонстрация тегов: {demo_command}")
             result = neyra.process_command(demo_command)
             print(f"\n✨ Результат Нейры:\n{result}")
+            if tracker.get_sources():
+                print("\n🔗 Использованные источники:")
+                print(tracker.format_citations())
             
         else:
             print("\n📖 Пока нет книг для изучения.")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility helpers for Neira desktop application."""
 
-__all__ = ["encoding_detector"]
+__all__ = ["encoding_detector", "source_tracker"]

--- a/src/utils/source_tracker.py
+++ b/src/utils/source_tracker.py
@@ -1,0 +1,49 @@
+"""Track information sources and their trustworthiness for Neyra."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import List
+
+
+@dataclass
+class SourceEntry:
+    """Information about a single source."""
+    info: str
+    source: str
+    confidence: float
+
+
+class SourceTracker:
+    """Collects citations and ensures only trusted sources are used."""
+
+    def __init__(self, reliability_threshold: float = 0.5) -> None:
+        self.reliability_threshold = reliability_threshold
+        self.entries: List[SourceEntry] = []
+        self.logger = logging.getLogger(__name__)
+
+    def add(self, info: str, source: str, confidence: float) -> None:
+        """Register a new source for *info* with *confidence* rating.
+
+        Raises
+        ------
+        ValueError
+            If *confidence* is below the reliability threshold.
+        """
+        if confidence < self.reliability_threshold:
+            self.logger.warning("Источник заблокирован: %s (%.2f)", source, confidence)
+            raise ValueError("Ненадёжный источник заблокирован")
+        entry = SourceEntry(info=info, source=source, confidence=confidence)
+        self.entries.append(entry)
+        self.logger.info("Источник принят: %s (%.2f)", source, confidence)
+
+    def get_sources(self) -> List[str]:
+        """Return list of all source links."""
+        return [entry.source for entry in self.entries]
+
+    def format_citations(self) -> str:
+        """Return formatted citations suitable for display."""
+        return "\n".join(
+            f"{idx + 1}. {entry.source}" for idx, entry in enumerate(self.entries)
+        )

--- a/tests/test_utils/test_source_tracker.py
+++ b/tests/test_utils/test_source_tracker.py
@@ -1,0 +1,21 @@
+"""Tests for the SourceTracker utility."""
+
+import logging
+import pytest
+
+from src.utils.source_tracker import SourceTracker
+
+
+def test_add_source_and_format(caplog) -> None:
+    tracker = SourceTracker()
+    with caplog.at_level(logging.INFO, logger="src.utils.source_tracker"):
+        tracker.add("fact", "http://example.com", 0.9)
+    assert tracker.get_sources() == ["http://example.com"]
+    assert "http://example.com" in tracker.format_citations()
+    assert "Источник принят" in caplog.text
+
+
+def test_block_unreliable_source() -> None:
+    tracker = SourceTracker(reliability_threshold=0.8)
+    with pytest.raises(ValueError):
+        tracker.add("fact", "http://bad.com", 0.5)


### PR DESCRIPTION
## Summary
- track citations with new `SourceTracker` utility
- log and display source links during Neyra startup
- test source tracker for logging and reliability filtering

## Testing
- `pytest` *(fails: test_tag_processor tests, test_neyra_recall_history)*

------
https://chatgpt.com/codex/tasks/task_e_689394c1833c8323a5a66065e586663d