### PR TITLE
Add simple spam filter for search results

### DIFF
--- a/src/search/api_client.py
+++ b/src/search/api_client.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from src.memory import MemoryIndex
+from src.utils.spam_filter import is_spam
 
 
 class SearchAPIClient:
@@ -117,6 +118,8 @@ class SearchAPIClient:
         for result in results:
             url = result.get("url", "")
             snippet = result.get("snippet", "")
+            if is_spam(snippet):
+                continue
             reliability = self.memory.source_reliability.get(url, 0.5)
             for fact in self.extract_facts(snippet):
                 self.memory.set(fact, True, reliability=reliability)

--- a/src/utils/spam_filter.py
+++ b/src/utils/spam_filter.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Simple heuristics-based spam detection."""
+
+import re
+
+# A small set of common spam keywords and phrases.
+_SPAM_PATTERNS = [
+    r"free\b",
+    r"buy\s+now",
+    r"click\s+here",
+    r"subscribe\s+now",
+    r"win\s+\w+",
+    r"earn\s+money",
+    r"credit\s+card",
+    r"guaranteed",
+]
+
+
+def is_spam(text: str) -> bool:
+    """Return ``True`` if ``text`` is considered spam.
+
+    The implementation relies on a few simple heuristics: if any of the
+    predefined patterns is found or if the text contains an unusual amount of
+    exclamation marks, it is flagged as spam.  While rudimentary, this approach
+    is sufficient for basic filtering and is easily extendable.
+    """
+    if not text:
+        return False
+
+    lowered = text.lower()
+    for pattern in _SPAM_PATTERNS:
+        if re.search(pattern, lowered):
+            return True
+
+    # Excessive punctuation is another common indicator of spam.
+    if lowered.count("!") >= 3:
+        return True
+
+    return False
+
+
+__all__ = ["is_spam"]

--- a/tests/test_utils/test_spam_filter.py
+++ b/tests/test_utils/test_spam_filter.py
@@ -1,0 +1,13 @@
+"""Tests for the spam filter utility."""
+
+from src.utils.spam_filter import is_spam
+
+
+def test_detects_common_spam_phrases() -> None:
+    assert is_spam("Buy now and get one free!")
+    assert is_spam("Click here to win a prize")
+
+
+def test_allows_regular_text() -> None:
+    assert not is_spam("Python is a programming language.")
+    assert not is_spam("The quick brown fox jumps over the lazy dog")


### PR DESCRIPTION
## Summary
- ignore spam snippets when updating search results
- add heuristics-based `is_spam` utility
- cover spam filter with tests

## Testing
- `PYTHONPATH=. pytest tests/test_utils/test_spam_filter.py -q`
- `PYTHONPATH=. pytest -q` *(fails: TagProcessor parsing, integration recall)*

------
https://chatgpt.com/codex/tasks/task_e_6893b7305d6083238ca2bfa121a941a2