### PR TITLE
Add PII redaction utility

### DIFF
--- a/src/search/api_client.py
+++ b/src/search/api_client.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 from src.memory import MemoryIndex
 from src.utils.spam_filter import is_spam
+from src.utils.pii import redact_pii
 
 
 class SearchAPIClient:
@@ -122,6 +123,7 @@ class SearchAPIClient:
                 continue
             reliability = self.memory.source_reliability.get(url, 0.5)
             for fact in self.extract_facts(snippet):
+                fact = redact_pii(fact)
                 self.memory.set(fact, True, reliability=reliability)
             # ``MemoryIndex.update_reliability`` only updates existing keys, so we
             # modify the reliability mapping directly to ensure the source is

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility helpers for Neira desktop application."""
 
-__all__ = ["encoding_detector", "source_tracker"]
+__all__ = ["encoding_detector", "source_tracker", "pii"]

--- a/src/utils/pii.py
+++ b/src/utils/pii.py
@@ -1,0 +1,23 @@
+"""Utilities for redacting personally identifiable information (PII)."""
+
+from __future__ import annotations
+
+import re
+
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+")
+_PHONE_RE = re.compile(r"\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){1,2}\d{4}\b")
+
+
+def redact_pii(text: str) -> str:
+    """Replace common PII like emails and phone numbers with ``[REDACTED]``.
+
+    This lightweight implementation uses regular expressions and is not meant
+    to be exhaustive but provides a reasonable safeguard for tests and simple
+    usage.
+    """
+    text = _EMAIL_RE.sub("[REDACTED]", text)
+    text = _PHONE_RE.sub("[REDACTED]", text)
+    return text
+
+
+__all__ = ["redact_pii"]

--- a/tests/test_utils/test_pii.py
+++ b/tests/test_utils/test_pii.py
@@ -1,0 +1,32 @@
+"""Tests for PII redaction utilities."""
+
+from src.utils.pii import redact_pii
+from src.search import SearchAPIClient
+from src.memory import MemoryIndex
+
+
+def test_redacts_email_and_phone() -> None:
+    text = "Contact: john.doe@example.com or 123-456-7890."
+    redacted = redact_pii(text)
+    assert "john.doe@example.com" not in redacted
+    assert "123-456-7890" not in redacted
+    assert redacted.count("[REDACTED]") == 2
+
+
+def test_search_and_update_applies_redaction() -> None:
+    mem = MemoryIndex()
+
+    def fake_fetch(query: str, limit: int):
+        return [
+            {
+                "url": "https://example.com",
+                "snippet": "Call me at 123-456-7890.",
+            }
+        ]
+
+    client = SearchAPIClient(memory=mem, fetcher=fake_fetch)
+    client.search_and_update("test")
+
+    stored_fact = next(iter(mem.cold_storage))
+    assert stored_fact == "Call me at [REDACTED]"
+    assert "123-456-7890" not in stored_fact


### PR DESCRIPTION
## Summary
- add regex-based `redact_pii` utility to strip emails and phone numbers
- run `redact_pii` on extracted facts before saving in `SearchAPIClient`
- cover PII redaction with dedicated unit tests

## Testing
- `PYTHONPATH=. pytest tests/test_utils/test_pii.py tests/test_search/test_api_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b91d31a4832388dfc7f112b270d7