### PR TITLE
Add license validation for search results

### DIFF
--- a/config/licenses.yml
+++ b/config/licenses.yml
@@ -1,0 +1,4 @@
+allowed_licenses:
+  - CC-BY
+  - CC0
+  - MIT

--- a/src/search/api_client.py
+++ b/src/search/api_client.py
@@ -8,6 +8,7 @@ import re
 import json
 from pathlib import Path
 from urllib.parse import urlparse
+import yaml
 
 from src.memory import MemoryIndex
 from src.utils.spam_filter import is_spam
@@ -22,6 +23,7 @@ class SearchAPIClient:
         memory: MemoryIndex | None = None,
         fetcher: Callable[[str, int], Iterable[Dict[str, str]]] | None = None,
         domain_config_path: str | Path | None = None,
+        license_config_path: str | Path | None = None,
     ) -> None:
         """
         Parameters
@@ -44,6 +46,7 @@ class SearchAPIClient:
         self.allowed_domains, self.blocked_domains = self._load_domain_config(
             domain_config_path
         )
+        self.allowed_licenses = self._load_license_config(license_config_path)
 
     # ------------------------------------------------------------------
     def _load_domain_config(
@@ -65,6 +68,23 @@ class SearchAPIClient:
         allowed = {d.lower() for d in data.get("allowed_domains", [])}
         blocked = {d.lower() for d in data.get("blocked_domains", [])}
         return allowed, blocked
+
+    # ------------------------------------------------------------------
+    def _load_license_config(self, path: str | Path | None) -> set[str]:
+        """Load allowed licenses from config file."""
+        config_path = (
+            Path(path)
+            if path is not None
+            else Path(__file__).resolve().parents[2]
+            / "config"
+            / "licenses.yml"
+        )
+        try:
+            with config_path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:  # pragma: no cover - missing or invalid config
+            data = {}
+        return set(data.get("allowed_licenses", []))
 
     # ------------------------------------------------------------------
     def _duckduckgo_fetch(self, query: str, limit: int) -> Iterable[Dict[str, str]]:
@@ -113,6 +133,32 @@ class SearchAPIClient:
         return [s.strip() for s in sentences if s.strip()]
 
     # ------------------------------------------------------------------
+    def check_license(self, url: str) -> bool:
+        """Verify that the page at ``url`` uses an allowed license."""
+        if not self.allowed_licenses:
+            return False
+        try:
+            resp = self.session.get(url, timeout=5)
+        except Exception:  # pragma: no cover - network errors
+            return False
+        license_val = resp.headers.get("License") or resp.headers.get("X-License")
+        if not license_val:
+            meta = re.search(
+                r'<meta[^>]+name=["\']license["\'][^>]*content=["\']([^"\']+)["\']',
+                resp.text,
+                re.IGNORECASE,
+            )
+            if not meta:
+                meta = re.search(
+                    r'<meta[^>]+content=["\']([^"\']+)["\'][^>]*name=["\']license["\']',
+                    resp.text,
+                    re.IGNORECASE,
+                )
+            if meta:
+                license_val = meta.group(1)
+        return bool(license_val and license_val in self.allowed_licenses)
+
+    # ------------------------------------------------------------------
     def search_and_update(self, query: str, limit: int = 5) -> List[Dict[str, str]]:
         """Perform a search and update memory with extracted facts."""
         results = self.search(query, limit)
@@ -120,6 +166,8 @@ class SearchAPIClient:
             url = result.get("url", "")
             snippet = result.get("snippet", "")
             if is_spam(snippet):
+                continue
+            if not self.check_license(url):
                 continue
             reliability = self.memory.source_reliability.get(url, 0.5)
             for fact in self.extract_facts(snippet):

--- a/tests/test_search/test_api_client.py
+++ b/tests/test_search/test_api_client.py
@@ -15,6 +15,7 @@ def test_search_ranking_and_update():
         ]
 
     client = SearchAPIClient(memory=mem, fetcher=fake_fetch)
+    client.check_license = lambda url: True
     results = client.search_and_update("test")
 
     assert [r["url"] for r in results] == ["https://a", "https://b"]

--- a/tests/test_search/test_license_check.py
+++ b/tests/test_search/test_license_check.py
@@ -1,0 +1,45 @@
+from src.search import SearchAPIClient
+
+
+class DummyResponse:
+    def __init__(self, headers=None, text=""):
+        self.headers = headers or {}
+        self.text = text
+
+
+def test_check_license_header(monkeypatch, tmp_path):
+    cfg = tmp_path / "licenses.yml"
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+    client = SearchAPIClient(license_config_path=cfg)
+    monkeypatch.setattr(
+        client.session,
+        "get",
+        lambda url, timeout=5: DummyResponse({"License": "CC-BY"}),
+    )
+    assert client.check_license("https://example.com")
+
+
+def test_check_license_meta(monkeypatch, tmp_path):
+    cfg = tmp_path / "licenses.yml"
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+    client = SearchAPIClient(license_config_path=cfg)
+    html = '<html><head><meta name="license" content="CC-BY"></head></html>'
+    monkeypatch.setattr(
+        client.session,
+        "get",
+        lambda url, timeout=5: DummyResponse(text=html),
+    )
+    assert client.check_license("https://example.com")
+
+
+def test_search_and_update_skips_unlicensed(monkeypatch, tmp_path):
+    cfg = tmp_path / "licenses.yml"
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+
+    def fake_fetch(query: str, limit: int):
+        return [{"url": "https://example.com", "snippet": "Fact"}]
+
+    client = SearchAPIClient(fetcher=fake_fetch, license_config_path=cfg)
+    monkeypatch.setattr(client, "check_license", lambda url: False)
+    client.search_and_update("test")
+    assert "Fact" not in client.memory.cold_storage


### PR DESCRIPTION
## Summary
- load allowed licenses from `config/licenses.yml`
- verify page license via headers or meta tags
- ignore search results without approved licenses
- add tests for license checking

## Testing
- `pytest tests/test_search -q`


------
https://chatgpt.com/codex/tasks/task_e_6893bc15314083238357e981f8b2d935