### PR TITLE
Add fact verification before storing search results

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,5 +1,5 @@
 from .self_corrector import SelfCorrector, SuggestionChooser
-from .verification_system import VerificationSystem, VerificationResult
+from .verification_system import VerificationSystem, VerificationResult, verify_fact
 from .uncertainty_manager import UncertaintyManager
 
 __all__ = [
@@ -8,4 +8,5 @@ __all__ = [
     "VerificationSystem",
     "VerificationResult",
     "UncertaintyManager",
+    "verify_fact",
 ]

--- a/src/analysis/verification_system.py
+++ b/src/analysis/verification_system.py
@@ -9,7 +9,7 @@ and designed primarily for unit testing and demonstration purposes.
 
 from dataclasses import dataclass, field
 import re
-from typing import Callable, List, Tuple
+from typing import Callable, Iterable, List, Tuple, Dict
 
 from src.memory import MemoryIndex
 
@@ -119,5 +119,29 @@ class VerificationSystem:
         return False, 0.0
 
 
-__all__ = ["VerificationSystem", "VerificationResult"]
+def verify_fact(
+    fact: str,
+    search_func: Callable[[str, int], Iterable[Dict[str, str]]] | None = None,
+    limit: int = 3,
+) -> bool:
+    """Perform an additional search for ``fact`` and verify matches.
+
+    The ``search_func`` should accept a query and a limit and return an
+    iterable of result dictionaries containing a ``snippet`` field.  The fact
+    is considered verified if it appears in any snippet.
+    """
+
+    search_func = search_func or (lambda q, limit=limit: [])
+    try:
+        results = search_func(fact, limit)
+    except Exception:  # pragma: no cover - defensive programming
+        return False
+    for result in results:
+        snippet = result.get("snippet", "")
+        if fact.lower() in snippet.lower():
+            return True
+    return False
+
+
+__all__ = ["VerificationSystem", "VerificationResult", "verify_fact"]
 

--- a/src/search/api_client.py
+++ b/src/search/api_client.py
@@ -14,6 +14,7 @@ from src.memory import MemoryIndex
 from src.utils.spam_filter import is_spam
 from src.utils.pii import redact_pii
 from src.utils.lang_quality import detect_language, quality_score
+from src.analysis.verification_system import verify_fact
 
 
 class SearchAPIClient:
@@ -204,11 +205,14 @@ class SearchAPIClient:
                     continue
                 if quality_score(fact) < self.quality_threshold:
                     continue
+                original_fact = fact
                 fact = redact_pii(fact)
-                # Store the fact itself as the value so that the memory index
-                # can perform deduplication based on content rather than the
-                # constant ``True`` placeholder.
-                self.memory.set(fact, fact, reliability=reliability)
+                # Only store the fact if independent search confirms it.
+                if verify_fact(original_fact, search_func=self.search):
+                    # Store the redacted fact so that the memory index can perform
+                    # deduplication based on content rather than the constant
+                    # ``True`` placeholder.
+                    self.memory.set(fact, fact, reliability=reliability)
             # ``MemoryIndex.update_reliability`` only updates existing keys, so we
             # modify the reliability mapping directly to ensure the source is
             # tracked even if it wasn't previously stored.

--- a/tests/test_analysis/test_verification_system.py
+++ b/tests/test_analysis/test_verification_system.py
@@ -1,4 +1,4 @@
-from src.analysis import VerificationSystem
+from src.analysis import VerificationSystem, verify_fact
 from src.memory import MemoryIndex
 
 
@@ -22,3 +22,17 @@ def test_generate_clarifying_questions() -> None:
     questions = verifier.generate_clarifying_questions("the sky is blue")
     assert questions
     assert "the sky is blue" in questions[0]
+
+
+def test_verify_fact_success() -> None:
+    def fake_search(query: str, limit: int):
+        return [{"snippet": f"Some text {query} end"}]
+
+    assert verify_fact("the sky is blue", search_func=fake_search)
+
+
+def test_verify_fact_failure() -> None:
+    def fake_search(_query: str, limit: int):
+        return [{"snippet": "unrelated"}]
+
+    assert not verify_fact("the sky is blue", search_func=fake_search)


### PR DESCRIPTION
## Summary
- add `verify_fact` helper to perform secondary search validation
- use `verify_fact` in `search_and_update` so only confirmed facts are saved
- cover fact verification with success and failure tests

## Testing
- `pytest tests/test_analysis/test_verification_system.py tests/test_search/test_api_client.py tests/test_search/test_license_check.py tests/test_utils/test_pii.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c495a0808323a2b16bc84205d88e