### PR TITLE
Add draft generator leveraging memory caches

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -14,6 +14,7 @@ from src.llm import BaseLLM, LLMFactory
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory, WorldMemory, StyleMemory
 from src.analysis import VerificationSystem, VerificationResult, UncertaintyManager
+from src.iteration import DraftGenerator
 from src.models import Character
 from src.core.cache_manager import CacheManager
 
@@ -33,6 +34,8 @@ class Neyra:
         self.characters_memory = CharacterMemory()
         self.world_memory = WorldMemory()
         self.style_memory = StyleMemory()
+        self.draft_generator = DraftGenerator()
+        self.last_draft: str = ""
         self.verification_system = VerificationSystem()
         self.uncertainty_manager = UncertaintyManager()
         self.current_user_id = "default"
@@ -171,6 +174,9 @@ class Neyra:
 
     def process_command(self, text: str) -> str:
         """Обрабатываю команды с пониманием и творчеством."""
+        self.last_draft = self.draft_generator.generate_draft(
+            text, self.verification_system.memory
+        )
         tags = self.parser.parse_user_input(text)
 
         if not tags:

--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -1,0 +1,5 @@
+"""Iteration utilities for Neyra."""
+
+from .draft_generator import DraftGenerator
+
+__all__ = ["DraftGenerator"]

--- a/src/iteration/draft_generator.py
+++ b/src/iteration/draft_generator.py
@@ -1,0 +1,73 @@
+"""Utilities for building quick drafts based on existing memories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.memory import CharacterMemory, WorldMemory, StyleMemory, MemoryIndex
+
+
+class DraftGenerator:
+    """Generate draft responses using cached memory objects.
+
+    The generator attempts a fast lookup in ``hot_memory`` before falling back
+    to the slower persistent memories like :class:`CharacterMemory`,
+    :class:`WorldMemory` and :class:`StyleMemory`.
+    """
+
+    def __init__(
+        self,
+        character_memory: CharacterMemory | None = None,
+        world_memory: WorldMemory | None = None,
+        style_memory: StyleMemory | None = None,
+    ) -> None:
+        self.character_memory = character_memory or CharacterMemory()
+        self.world_memory = world_memory or WorldMemory()
+        self.style_memory = style_memory or StyleMemory()
+
+    # ------------------------------------------------------------------
+    def generate_draft(self, query: str, hot_memory: MemoryIndex | Any) -> str:
+        """Return a quick draft for ``query`` using ``hot_memory``.
+
+        Parameters
+        ----------
+        query:
+            Key describing the information of interest.
+        hot_memory:
+            The fast tier cache, typically a :class:`MemoryIndex` instance.
+        """
+
+        if hasattr(hot_memory, "get"):
+            try:
+                result = hot_memory.get(query)
+            except Exception:  # pragma: no cover - defensive
+                result = None
+            if result:
+                return str(result)
+
+        try:
+            char = self.character_memory.get(query)
+        except Exception:  # pragma: no cover - defensive
+            char = None
+        if char:
+            appearance = getattr(char, "appearance", "")
+            return f"{char.name}: {appearance}" if appearance else char.name
+
+        try:
+            world_info = self.world_memory.get(query)
+        except Exception:  # pragma: no cover - defensive
+            world_info = None
+        if world_info:
+            return str(world_info)
+
+        try:
+            examples = self.style_memory.get_examples("default")
+        except Exception:  # pragma: no cover - defensive
+            examples = []
+        if examples:
+            return examples[0]
+
+        return ""
+
+
+__all__ = ["DraftGenerator"]

--- a/tests/iteration/test_draft_generator.py
+++ b/tests/iteration/test_draft_generator.py
@@ -1,0 +1,47 @@
+from src.iteration import DraftGenerator
+from src.memory import CharacterMemory, WorldMemory, StyleMemory, MemoryIndex
+from src.models import Character
+
+
+def test_returns_from_hot_memory(tmp_path):
+    index = MemoryIndex()
+    index.set("question", "answer")
+
+    generator = DraftGenerator(
+        CharacterMemory(storage_path=tmp_path / "chars.json"),
+        WorldMemory(storage_path=tmp_path / "world.json"),
+        StyleMemory(storage_path=tmp_path / "style.json"),
+    )
+
+    result = generator.generate_draft("question", index)
+    assert result == "answer"
+
+
+def test_fallback_to_character_memory(tmp_path):
+    char_mem = CharacterMemory(storage_path=tmp_path / "chars.json")
+    char_mem.add(Character(name="Alice", appearance="brave"))
+
+    generator = DraftGenerator(
+        char_mem,
+        WorldMemory(storage_path=tmp_path / "world.json"),
+        StyleMemory(storage_path=tmp_path / "style.json"),
+    )
+
+    index = MemoryIndex()
+    result = generator.generate_draft("Alice", index)
+    assert "Alice" in result
+
+
+def test_style_memory_fallback(tmp_path):
+    style_mem = StyleMemory(storage_path=tmp_path / "style.json")
+    style_mem.add("default", "classic", example="stylish example")
+
+    generator = DraftGenerator(
+        CharacterMemory(storage_path=tmp_path / "chars.json"),
+        WorldMemory(storage_path=tmp_path / "world.json"),
+        style_mem,
+    )
+
+    index = MemoryIndex()
+    result = generator.generate_draft("unknown", index)
+    assert result == "stylish example"


### PR DESCRIPTION
## Summary
- add `DraftGenerator` for generating drafts using hot memory and persistent memories
- integrate draft generation into `Neyra` core before command parsing
- add unit tests for draft generation behavior

## Testing
- `pytest tests/iteration/test_draft_generator.py -q`
- `pytest tests/test_neyra_integration.py::test_neyra_responds_to_casual_text -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c8a16ed88323b834fdb69ad21a13