### PR TITLE
Add gap analyzer for detecting uncertain claims

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -1,5 +1,6 @@
 """Iteration utilities for Neyra."""
 
 from .draft_generator import DraftGenerator
+from .gap_analyzer import GapAnalyzer, KnowledgeGap
 
-__all__ = ["DraftGenerator"]
+__all__ = ["DraftGenerator", "GapAnalyzer", "KnowledgeGap"]

--- a/src/iteration/gap_analyzer.py
+++ b/src/iteration/gap_analyzer.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Detect missing knowledge in draft responses."""
+
+from dataclasses import dataclass
+import re
+from typing import List
+
+from src.analysis.verification_system import VerificationSystem, VerificationResult
+from src.analysis.uncertainty_manager import UncertaintyManager
+
+
+@dataclass
+class KnowledgeGap:
+    """Information missing or uncertain in a draft."""
+
+    claim: str
+    questions: List[str]
+    confidence: float
+    disclaimer: str | None = None
+
+
+class GapAnalyzer:
+    """Analyze text and highlight claims with low confidence."""
+
+    def __init__(
+        self,
+        verifier: VerificationSystem | None = None,
+        uncertainty: UncertaintyManager | None = None,
+    ) -> None:
+        self.verifier = verifier or VerificationSystem()
+        self.uncertainty = uncertainty or UncertaintyManager()
+
+    # ------------------------------------------------------------------
+    def analyze(self, draft: str) -> List[KnowledgeGap]:
+        """Return knowledge gaps detected in ``draft`` text."""
+
+        gaps: List[KnowledgeGap] = []
+        sentences = [s.strip() for s in re.split(r"[.!?\n]+", draft) if s.strip()]
+        for claim in sentences:
+            result: VerificationResult = self.verifier.verify_claim(claim)
+            result = self.uncertainty.handle(result)
+            if result.verdict is False or result.confidence < self.uncertainty.threshold:
+                questions = self.verifier.generate_clarifying_questions(claim)
+                gaps.append(
+                    KnowledgeGap(
+                        claim=claim,
+                        questions=questions,
+                        confidence=result.confidence,
+                        disclaimer=result.disclaimer,
+                    )
+                )
+        return gaps
+
+
+__all__ = ["GapAnalyzer", "KnowledgeGap"]

--- a/tests/iteration/test_gap_analyzer.py
+++ b/tests/iteration/test_gap_analyzer.py
@@ -1,0 +1,36 @@
+from src.iteration import GapAnalyzer, KnowledgeGap
+from src.memory import MemoryIndex
+from src.analysis.verification_system import VerificationSystem
+from src.analysis.uncertainty_manager import UncertaintyManager
+
+
+def test_detects_unknown_claim():
+    analyzer = GapAnalyzer()
+    gaps = analyzer.analyze("The sky is green.")
+    assert len(gaps) == 1
+    gap = gaps[0]
+    assert isinstance(gap, KnowledgeGap)
+    assert "sky is green" in gap.claim.lower()
+    assert gap.disclaimer is not None
+
+
+def test_verified_claim_produces_no_gap():
+    index = MemoryIndex()
+    index.set("Earth is round", True, reliability=0.9)
+    verifier = VerificationSystem(memory=index, external_checkers=[])
+    analyzer = GapAnalyzer(verifier=verifier)
+    gaps = analyzer.analyze("Earth is round.")
+    assert gaps == []
+
+
+def test_low_confidence_generates_disclaimer():
+    index = MemoryIndex()
+    index.set("Water is wet", True, reliability=0.4)
+    verifier = VerificationSystem(memory=index, external_checkers=[])
+    uncertainty = UncertaintyManager(threshold=0.5)
+    analyzer = GapAnalyzer(verifier=verifier, uncertainty=uncertainty)
+    gaps = analyzer.analyze("Water is wet.")
+    assert len(gaps) == 1
+    gap = gaps[0]
+    assert gap.confidence == 0.4
+    assert gap.disclaimer is not None


### PR DESCRIPTION
## Summary
- introduce `GapAnalyzer` with `KnowledgeGap` dataclass to flag uncertain or unverified claims
- expose new gap analysis utilities via iteration package
- cover gap detection with tests including low-confidence disclaimers

## Testing
- `pytest tests/iteration/test_gap_analyzer.py -q`
- `pytest tests/iteration -q`


------
https://chatgpt.com/codex/tasks/task_e_6893cbbb437883239903ca3600e4123b