### PR TITLE
feat(iteration): add adaptive iteration manager

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -8,6 +8,7 @@ except Exception:  # noqa: BLE001 - fallback when requests is missing
     DeepSearcher = None  # type: ignore
 from .response_enhancer import ResponseEnhancer, IntegrationType
 from .iteration_controller import IterationController
+from .strategy_manager import AdaptiveIterationManager, IterationStrategy
 
 __all__ = [
     "DraftGenerator",
@@ -17,4 +18,6 @@ __all__ = [
     "ResponseEnhancer",
     "IntegrationType",
     "IterationController",
+    "AdaptiveIterationManager",
+    "IterationStrategy",
 ]

--- a/src/iteration/iteration_controller.py
+++ b/src/iteration/iteration_controller.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .strategy_manager import AdaptiveIterationManager
+
 
 @dataclass
 class IterationController:
@@ -11,18 +13,29 @@ class IterationController:
 
     Parameters
     ----------
+    strategy:
+        Name of the iteration strategy preset managed by
+        :class:`AdaptiveIterationManager`.  Defaults to ``"standard"``.
     max_iterations:
-        Maximum number of additional iterations allowed. The controller assumes
-        there is already an initial response (iteration 0) and counts only
-        further refinement steps.
+        Maximum number of additional iterations allowed. When ``None`` the
+        value from the selected ``strategy`` is used.
     max_critical_spaces:
         Threshold for unresolved placeholders (``"___"``) allowed in a response
-        before stopping the loop.
+        before stopping the loop. When ``None`` the value from ``strategy`` is
+        applied.
     """
 
-    max_iterations: int = 3
-    max_critical_spaces: int = 0
+    strategy: str = "standard"
+    max_iterations: int | None = None
+    max_critical_spaces: int | None = None
     _iterations: int = 0
+
+    def __post_init__(self) -> None:
+        manager = AdaptiveIterationManager(self.strategy)
+        if self.max_iterations is None:
+            self.max_iterations = manager.max_iterations
+        if self.max_critical_spaces is None:
+            self.max_critical_spaces = manager.max_critical_spaces
 
     # ------------------------------------------------------------------
     def assess_quality(self, text: str) -> int:

--- a/src/iteration/strategy_manager.py
+++ b/src/iteration/strategy_manager.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Iteration strategy presets for the :class:`IterationController`.
+
+The :class:`AdaptiveIterationManager` encapsulates a small collection of
+predefined iteration strategies.  Each strategy specifies limits for the
+:class:`~src.iteration.iteration_controller.IterationController` such as the
+maximum number of refinement loops and how many critical placeholders are
+allowed to remain in a response.  The presets are intentionally lightweight –
+no external configuration or learning is required – but they provide a
+convenient interface for choosing sensible defaults depending on the desired
+trade‑off between speed and thoroughness.
+
+The available presets are:
+
+``quick``
+    Perform at most one additional iteration.  Suitable for lightweight
+    interactions where speed is preferred over quality.
+``standard``
+    A balanced configuration used as the default throughout the project.
+``thorough``
+    Allow more refinement cycles for detailed answers.
+``research``
+    Aggressive search intended for exploratory or uncertain topics.  It
+    tolerates one unresolved placeholder to keep the loop going a little
+    longer.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IterationStrategy:
+    """Configuration for an iteration strategy."""
+
+    max_iterations: int
+    max_critical_spaces: int
+
+
+class AdaptiveIterationManager:
+    """Manage iteration strategies with simple presets."""
+
+    #: Mapping of preset name to :class:`IterationStrategy`.
+    PRESETS: dict[str, IterationStrategy] = {
+        "quick": IterationStrategy(max_iterations=1, max_critical_spaces=0),
+        "standard": IterationStrategy(max_iterations=3, max_critical_spaces=0),
+        "thorough": IterationStrategy(max_iterations=5, max_critical_spaces=0),
+        "research": IterationStrategy(max_iterations=8, max_critical_spaces=1),
+    }
+
+    def __init__(self, preset: str = "standard") -> None:
+        self.set_preset(preset)
+
+    # ------------------------------------------------------------------
+    def set_preset(self, preset: str) -> None:
+        """Activate ``preset`` as the current iteration strategy.
+
+        Parameters
+        ----------
+        preset:
+            One of :data:`PRESETS`.  A :class:`ValueError` is raised for unknown
+            names.
+        """
+
+        try:
+            strategy = self.PRESETS[preset]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            raise ValueError(f"Unknown iteration preset: {preset}") from exc
+        self.preset = preset
+        self.max_iterations = strategy.max_iterations
+        self.max_critical_spaces = strategy.max_critical_spaces
+
+    # ------------------------------------------------------------------
+    def configure(self, controller: "IterationController") -> None:
+        """Apply the current strategy to ``controller``.
+
+        The method simply copies the ``max_iterations`` and
+        ``max_critical_spaces`` values to the provided
+        :class:`IterationController` instance.
+        """
+
+        controller.max_iterations = self.max_iterations
+        controller.max_critical_spaces = self.max_critical_spaces
+
+
+__all__ = ["AdaptiveIterationManager", "IterationStrategy"]

--- a/tests/iteration/test_strategy_manager.py
+++ b/tests/iteration/test_strategy_manager.py
@@ -1,0 +1,30 @@
+import pytest
+
+from src.iteration.strategy_manager import AdaptiveIterationManager
+from src.iteration.iteration_controller import IterationController
+
+
+@pytest.mark.parametrize(
+    "preset, expected_iterations, expected_spaces",
+    [
+        ("quick", 1, 0),
+        ("standard", 3, 0),
+        ("thorough", 5, 0),
+        ("research", 8, 1),
+    ],
+)
+def test_presets_define_limits(preset, expected_iterations, expected_spaces):
+    manager = AdaptiveIterationManager(preset)
+    assert manager.max_iterations == expected_iterations
+    assert manager.max_critical_spaces == expected_spaces
+
+
+def test_unknown_preset_raises():
+    with pytest.raises(ValueError):
+        AdaptiveIterationManager("unknown")
+
+
+def test_controller_applies_strategy():
+    controller = IterationController(strategy="research")
+    assert controller.max_iterations == 8
+    assert controller.max_critical_spaces == 1


### PR DESCRIPTION
## Summary
- add `AdaptiveIterationManager` with quick, standard, thorough and research presets
- allow `IterationController` to use strategy presets for limits
- cover new manager with unit tests

## Testing
- `pytest tests/iteration/test_strategy_manager.py -q`
- `pytest tests/iteration -q`

------
https://chatgpt.com/codex/tasks/task_e_6893d552d3108323b0280e46d9a48f49