### PR TITLE
Add resource-aware iteration planning

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -9,6 +9,7 @@ except Exception:  # noqa: BLE001 - fallback when requests is missing
 from .response_enhancer import ResponseEnhancer, IntegrationType
 from .iteration_controller import IterationController
 from .strategy_manager import AdaptiveIterationManager, IterationStrategy
+from .resource_iterator import ResourceAwareIterator
 
 __all__ = [
     "DraftGenerator",
@@ -20,4 +21,5 @@ __all__ = [
     "IterationController",
     "AdaptiveIterationManager",
     "IterationStrategy",
+    "ResourceAwareIterator",
 ]

--- a/src/iteration/resource_iterator.py
+++ b/src/iteration/resource_iterator.py
@@ -1,0 +1,51 @@
+"""Plan iteration count based on available system resources."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+class ResourceAwareIterator:
+    """Determine iteration plan given resource constraints.
+
+    Parameters
+    ----------
+    resources:
+        Mapping describing currently available resources. Typical keys are
+        ``"gpu"`` for GPU memory, ``"cpu"`` for CPU memory and ``"time"`` for
+        the time budget in seconds.
+    """
+
+    def __init__(self, resources: Mapping[str, float]) -> None:
+        self.resources = dict(resources)
+
+    # ------------------------------------------------------------------
+    def plan(self, per_iteration: Mapping[str, float]) -> list[int]:
+        """Return iteration indices that fit within ``per_iteration`` usage.
+
+        Parameters
+        ----------
+        per_iteration:
+            Mapping of resource consumption for a single iteration.
+
+        Returns
+        -------
+        list[int]
+            List of iteration numbers starting from ``0``. Its length equals
+            the maximum number of iterations possible under the given
+            constraints. When no resources are specified the result is an empty
+            list.
+        """
+
+        capacities: list[int] = []
+        for name, usage in per_iteration.items():
+            if usage <= 0:
+                continue
+            available = self.resources.get(name, 0)
+            capacities.append(int(available // usage))
+
+        count = min(capacities) if capacities else 0
+        return list(range(count))
+
+
+__all__ = ["ResourceAwareIterator"]

--- a/tests/iteration/test_resource_iterator.py
+++ b/tests/iteration/test_resource_iterator.py
@@ -1,0 +1,19 @@
+from src.iteration import ResourceAwareIterator
+
+
+def test_plan_basic() -> None:
+    iterator = ResourceAwareIterator({"gpu": 4, "cpu": 8, "time": 120})
+    plan = iterator.plan({"gpu": 2, "cpu": 1, "time": 30})
+    assert plan == [0, 1]
+
+
+def test_plan_no_gpu() -> None:
+    iterator = ResourceAwareIterator({"cpu": 8, "time": 120})
+    plan = iterator.plan({"gpu": 2, "cpu": 1, "time": 60})
+    assert plan == []
+
+
+def test_plan_ignores_unused_resources() -> None:
+    iterator = ResourceAwareIterator({"gpu": 16, "cpu": 8, "time": 120})
+    plan = iterator.plan({"cpu": 2, "time": 30})
+    assert plan == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary
- add `ResourceAwareIterator` to compute iteration counts based on GPU/CPU memory and time limits
- expose `ResourceAwareIterator` via iteration package
- test iteration planning for resource constraints

## Testing
- `pytest tests/iteration/test_resource_iterator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d73793508323882242aca692d7b1