### PR TITLE
Add ReferenceMemory for tracking sources

### DIFF
--- a/src/iteration/reference_memory.py
+++ b/src/iteration/reference_memory.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Utilities for storing reference links for internal and external sources."""
+
+from dataclasses import dataclass
+from typing import List, Dict, Any, TYPE_CHECKING
+
+from src.utils.source_tracker import SourceTracker
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from .deep_searcher import DeepSearcher
+
+
+@dataclass
+class ReferenceEntry:
+    """Information about a stored reference."""
+
+    summary: str
+    path: str
+    confidence: float
+
+
+class ReferenceMemory:
+    """Store references and register them via :class:`SourceTracker`.
+
+    The memory distinguishes between internal references (local file paths)
+    and external references (web links). A :class:`DeepSearcher` instance is
+    used to provide additional context for summaries and is invoked whenever a
+    new reference is created.
+    """
+
+    def __init__(
+        self,
+        tracker: SourceTracker | None = None,
+        searcher: "DeepSearcher" | None = None,
+    ) -> None:
+        self.tracker = tracker or SourceTracker()
+        if searcher is None:
+            from .deep_searcher import DeepSearcher
+
+            searcher = DeepSearcher()
+        self.searcher = searcher
+        self.internal_sources: List[ReferenceEntry] = []
+        self.external_sources: List[ReferenceEntry] = []
+
+    # ------------------------------------------------------------------
+    def _is_external(self, path: str) -> bool:
+        return path.startswith("http://") or path.startswith("https://")
+
+    # ------------------------------------------------------------------
+    def create_reference_link(self, summary: str, full_path: str, confidence: float) -> str:
+        """Create a markdown reference link and track the source.
+
+        The link is registered with :class:`SourceTracker` and stored in either
+        the internal or external list depending on its origin. The associated
+        :class:`DeepSearcher` is queried with ``summary`` to integrate search
+        capabilities.
+        """
+
+        # Register source
+        self.tracker.add(summary, full_path, confidence)
+
+        # Obtain additional context via deep searcher (ignore failures)
+        try:
+            self.searcher.search(summary)
+        except Exception:
+            pass
+
+        entry = ReferenceEntry(summary=summary, path=full_path, confidence=confidence)
+        if self._is_external(full_path):
+            self.external_sources.append(entry)
+        else:
+            self.internal_sources.append(entry)
+
+        return f"[{summary}]({full_path})"
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, user_id: str | None = None, limit: int = 5) -> List[Dict[str, Any]]:
+        """Proxy search requests to the underlying :class:`DeepSearcher`."""
+        return self.searcher.search(query, user_id=user_id, limit=limit)
+
+
+__all__ = ["ReferenceMemory", "ReferenceEntry"]

--- a/tests/iteration/test_reference_memory.py
+++ b/tests/iteration/test_reference_memory.py
@@ -1,0 +1,46 @@
+"""Tests for the ReferenceMemory component."""
+
+from src.iteration.reference_memory import ReferenceMemory
+from src.utils.source_tracker import SourceTracker
+
+
+class DummySearcher:
+    """Simple stub for DeepSearcher that records search queries."""
+
+    def __init__(self) -> None:
+        self.queries = []
+
+    def search(self, query: str, user_id=None, limit: int = 5):
+        self.queries.append(query)
+        return []
+
+
+def test_create_reference_link_internal(tmp_path):
+    tracker = SourceTracker()
+    searcher = DummySearcher()
+    memory = ReferenceMemory(tracker=tracker, searcher=searcher)
+
+    file = tmp_path / "file.txt"
+    file.write_text("hello")
+
+    link = memory.create_reference_link("test summary", str(file), 0.9)
+
+    assert link == f"[test summary]({file})"
+    assert memory.internal_sources[0].path == str(file)
+    assert tracker.entries[0].source == str(file)
+    assert searcher.queries == ["test summary"]
+
+
+def test_create_reference_link_external():
+    tracker = SourceTracker()
+    searcher = DummySearcher()
+    memory = ReferenceMemory(tracker=tracker, searcher=searcher)
+
+    url = "https://example.com"
+
+    link = memory.create_reference_link("external", url, 0.8)
+
+    assert link == f"[external]({url})"
+    assert memory.external_sources[0].path == url
+    assert tracker.entries[0].source == url
+    assert searcher.queries == ["external"]


### PR DESCRIPTION
## Summary
- implement `ReferenceMemory` to track internal and external references
- expose `create_reference_link` and integrate with `SourceTracker` and `DeepSearcher`
- add unit tests for reference link generation

## Testing
- `pytest tests/iteration/test_reference_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d8eadc0c8323b5945d84d733560f