### PR TITLE
Add multi-tier smart cache with context tagging

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -10,6 +10,7 @@ from .response_enhancer import ResponseEnhancer, IntegrationType
 from .iteration_controller import IterationController
 from .strategy_manager import AdaptiveIterationManager, IterationStrategy
 from .resource_iterator import ResourceAwareIterator
+from .smart_cache import SmartCache
 
 __all__ = [
     "DraftGenerator",
@@ -22,4 +23,5 @@ __all__ = [
     "AdaptiveIterationManager",
     "IterationStrategy",
     "ResourceAwareIterator",
+    "SmartCache",
 ]

--- a/src/iteration/smart_cache.py
+++ b/src/iteration/smart_cache.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Iterable
+import hashlib
+
+from src.core.cache_manager import CacheManager
+
+
+class SmartCache(CacheManager):
+    """Cache with hot/warm/cold tiers built on top of :class:`CacheManager`.
+
+    ``hot`` and ``warm`` tiers are in-memory :class:`OrderedDict` structures that
+    implement a simple LRU replacement strategy.  ``cold`` storage uses the
+    underlying :class:`CacheManager` persistence layer.
+
+    Keys are derived from the hash of the ``query`` and optional ``tags`` which
+    makes the cache context aware.
+    """
+
+    def __init__(
+        self,
+        cache_dir: str | None = ".cache",
+        *,
+        hot_limit: int = 32,
+        warm_limit: int = 128,
+    ) -> None:
+        super().__init__(cache_dir)
+        self.hot_limit = hot_limit
+        self.warm_limit = warm_limit
+        self.hot: OrderedDict[str, Any] = OrderedDict()
+        self.warm: OrderedDict[str, Any] = OrderedDict()
+
+    # ------------------------------------------------------------------
+    # key helpers
+    def _hash_key(self, query: str, tags: Iterable[str] | None) -> str:
+        tags_part = "|".join(sorted(tags)) if tags else ""
+        raw = f"{query}|{tags_part}".encode("utf-8")
+        return hashlib.sha256(raw).hexdigest()
+
+    # ------------------------------------------------------------------
+    # tier maintenance
+    def _trim_hot(self) -> None:
+        while len(self.hot) > self.hot_limit:
+            key, value = self.hot.popitem(last=False)
+            self.warm[key] = value
+            self._trim_warm()
+
+    def _trim_warm(self) -> None:
+        while len(self.warm) > self.warm_limit:
+            # dropping from warm leaves it only in cold storage (disk)
+            self.warm.popitem(last=False)
+
+    def _promote_to_hot(self, key: str, value: Any) -> None:
+        self.hot[key] = value
+        self.hot.move_to_end(key)
+        self._trim_hot()
+
+    # ------------------------------------------------------------------
+    # public API
+    def set(self, query: str, value: Any, tags: Iterable[str] | None = None) -> None:
+        key = self._hash_key(query, tags)
+        super().set(key, {"value": value, "tags": list(tags) if tags else []})
+        self._promote_to_hot(key, value)
+
+    def get(self, query: str, tags: Iterable[str] | None = None) -> Any | None:
+        key = self._hash_key(query, tags)
+        if key in self.hot:
+            self.hot.move_to_end(key)
+            return self.hot[key]
+        if key in self.warm:
+            value = self.warm.pop(key)
+            self._promote_to_hot(key, value)
+            return value
+        data = super().get(key)
+        if data is None:
+            return None
+        if isinstance(data, dict) and "value" in data:
+            value = data["value"]
+        else:
+            value = data
+        self.warm[key] = value
+        self._trim_warm()
+        return value
+
+    def invalidate(self, query: str | None = None, tags: Iterable[str] | None = None) -> None:
+        if query is None:
+            self.hot.clear()
+            self.warm.clear()
+            super().invalidate()
+            return
+        key = self._hash_key(query, tags)
+        self.hot.pop(key, None)
+        self.warm.pop(key, None)
+        super().invalidate(key)

--- a/tests/iteration/test_smart_cache.py
+++ b/tests/iteration/test_smart_cache.py
@@ -1,0 +1,34 @@
+import pytest
+
+from src.iteration.smart_cache import SmartCache
+
+
+def test_tags_affect_key(tmp_path):
+    cache = SmartCache(cache_dir=tmp_path)
+    cache.set("hello", "A", tags=["t1"])
+    cache.set("hello", "B", tags=["t2"])
+    assert cache.get("hello", tags=["t1"]) == "A"
+    assert cache.get("hello", tags=["t2"]) == "B"
+    cache.set("foo", "bar", tags=["x", "y"])
+    # Order of tags should not matter
+    assert cache.get("foo", tags=["y", "x"]) == "bar"
+
+
+def test_tier_promotion_and_cold_fetch(tmp_path):
+    cache = SmartCache(cache_dir=tmp_path, hot_limit=1, warm_limit=1)
+    cache.set("q1", "v1")
+    cache.set("q2", "v2")
+    cache.get("q1")  # promote q1 -> hot, q2 -> warm
+    cache.set("q3", "v3")  # q2 should move to cold storage
+    key2 = cache._hash_key("q2", None)
+    assert key2 not in cache.hot and key2 not in cache.warm
+    # retrieving should bring it back from cold
+    assert cache.get("q2") == "v2"
+    assert key2 in cache.warm or key2 in cache.hot
+
+
+def test_persistence_across_instances(tmp_path):
+    cache = SmartCache(cache_dir=tmp_path)
+    cache.set("q", 123, tags=["a"])
+    other = SmartCache(cache_dir=tmp_path)
+    assert other.get("q", tags=["a"]) == 123


### PR DESCRIPTION
## Summary
- implement SmartCache with hot/warm/cold tiers and contextual hashing
- expose SmartCache through iteration package
- add unit tests for tiering, tag keys, and persistence

## Testing
- `pytest tests/iteration/test_smart_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893dbae86c483238d272d008f58a8d4