### PR TITLE
feat: implement search plugin registry

### DIFF
--- a/src/iteration/deep_searcher.py
+++ b/src/iteration/deep_searcher.py
@@ -8,6 +8,11 @@ import json
 
 from src.memory import CharacterMemory, WorldMemory, StyleMemory
 from src.search import SearchAPIClient
+from .plugin_registry import (
+    APISearchPlugin,
+    get_search_plugins,
+    register_search_plugin,
+)
 
 
 class DeepSearcher:
@@ -25,12 +30,15 @@ class DeepSearcher:
         style_memory: StyleMemory | None = None,
         api_client: SearchAPIClient | None = None,
         data_path: str | Path | None = None,
+        use_default_plugins: bool = True,
     ) -> None:
         self.character_memory = character_memory or CharacterMemory()
         self.world_memory = world_memory or WorldMemory()
         self.style_memory = style_memory or StyleMemory()
         self.api_client = api_client or SearchAPIClient()
         self.data_path = Path(data_path or "data")
+        if use_default_plugins:
+            register_search_plugin(APISearchPlugin(self.api_client))
 
     # ------------------------------------------------------------------
     def search(self, query: str, user_id: str | None = None, limit: int = 5) -> List[Dict[str, Any]]:
@@ -117,19 +125,15 @@ class DeepSearcher:
                     )
                     break
 
-        # Web search -------------------------------------------------------
-        try:
-            for item in self.api_client.search(query, limit):
-                results.append(
-                    {
-                        "source": "web",
-                        "reference": item.get("url", ""),
-                        "content": item.get("snippet", ""),
-                        "priority": 0.3,
-                    }
-                )
-        except Exception:
-            pass
+        # Plugin search ----------------------------------------------------
+        for plugin in get_search_plugins():
+            try:
+                for item in plugin.search(query, limit):
+                    item.setdefault("source", plugin.__class__.__name__)
+                    item.setdefault("priority", 0.0)
+                    results.append(item)
+            except Exception:
+                continue
 
         results.sort(key=lambda r: r["priority"], reverse=True)
         return results

--- a/src/iteration/plugin_registry.py
+++ b/src/iteration/plugin_registry.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Registry for search plugins used by :class:`DeepSearcher`.
+
+This module provides a minimal plugin system allowing external components to
+register search handlers that implement the :class:`SearchPlugin` protocol.
+Registered plugins are later invoked by ``DeepSearcher`` to obtain additional
+search results.  A simple example plugin wrapping :class:`SearchAPIClient` is
+provided for convenience.
+"""
+
+from typing import Dict, List, Any, Protocol, runtime_checkable
+
+from src.search import SearchAPIClient
+
+
+@runtime_checkable
+class SearchPlugin(Protocol):
+    """Protocol that all search plugins must follow."""
+
+    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
+        """Return a list of search result dictionaries."""
+        ...
+
+
+# Internal storage for registered plugins.  A dictionary keyed by plugin name
+# is used to avoid duplicate registrations of the same plugin class.
+_search_plugins: Dict[str, SearchPlugin] = {}
+
+
+# ---------------------------------------------------------------------------
+def register_search_plugin(plugin: SearchPlugin, name: str | None = None) -> None:
+    """Register ``plugin`` under ``name``.
+
+    Parameters
+    ----------
+    plugin:
+        Instance implementing :class:`SearchPlugin`.
+    name:
+        Optional name under which the plugin is stored.  When omitted, the
+        plugin's class name is used.  Registering another plugin with the same
+        name replaces the previous entry.
+    """
+
+    key = name or plugin.__class__.__name__
+    _search_plugins[key] = plugin
+
+
+# ---------------------------------------------------------------------------
+def get_search_plugins() -> List[SearchPlugin]:
+    """Return all registered search plugins."""
+
+    return list(_search_plugins.values())
+
+
+# ---------------------------------------------------------------------------
+def clear_search_plugins() -> None:
+    """Remove all registered search plugins.
+
+    Primarily intended for test isolation.
+    """
+
+    _search_plugins.clear()
+
+
+# ---------------------------------------------------------------------------
+class APISearchPlugin:
+    """Example plugin that delegates to :class:`SearchAPIClient`.
+
+    The plugin performs a web search and converts results to the structure
+    expected by :class:`DeepSearcher`.
+    """
+
+    def __init__(self, client: SearchAPIClient | None = None) -> None:
+        self.client = client or SearchAPIClient()
+
+    def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
+        results: List[Dict[str, Any]] = []
+        for item in self.client.search(query, limit):
+            results.append(
+                {
+                    "source": "web",
+                    "reference": item.get("url", ""),
+                    "content": item.get("snippet", ""),
+                    "priority": 0.3,
+                }
+            )
+        return results
+
+
+__all__ = [
+    "SearchPlugin",
+    "register_search_plugin",
+    "get_search_plugins",
+    "clear_search_plugins",
+    "APISearchPlugin",
+]

--- a/tests/iteration/test_plugin_registry.py
+++ b/tests/iteration/test_plugin_registry.py
@@ -1,0 +1,39 @@
+from src.iteration import DeepSearcher
+from src.iteration import DeepSearcher
+from src.iteration.plugin_registry import (
+    clear_search_plugins,
+    get_search_plugins,
+    register_search_plugin,
+)
+
+
+class DummyPlugin:
+    """Simple plugin returning the query as content."""
+
+    def search(self, query: str, limit: int = 5):
+        return [
+            {
+                "source": "dummy",
+                "reference": "",
+                "content": query,
+                "priority": 0.42,
+            }
+        ]
+
+
+def test_register_and_use_plugin():
+    clear_search_plugins()
+    register_search_plugin(DummyPlugin())
+    assert len(get_search_plugins()) == 1
+
+    searcher = DeepSearcher(use_default_plugins=False)
+    results = searcher.search("hello")
+
+    assert results == [
+        {
+            "source": "dummy",
+            "reference": "",
+            "content": "hello",
+            "priority": 0.42,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add pluggable search plugin registry with API-based example plugin
- integrate DeepSearcher with plugin system for extensible searches
- test plugin registration and DeepSearcher integration

## Testing
- `pytest tests/iteration/test_deep_searcher.py tests/iteration/test_plugin_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689425f6ea8883239a3d7a2d620168df