### PR TITLE
Add MemoryInspector for reference source reporting

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -13,6 +13,7 @@ from .resource_iterator import ResourceAwareIterator
 from .low_resource_optimizer import LowResourceOptimizer
 from .smart_cache import SmartCache
 from .metrics import similarity, length, corrected_errors, log_metrics
+from .memory_inspector import MemoryInspector
 
 __all__ = [
     "DraftGenerator",
@@ -27,6 +28,7 @@ __all__ = [
     "ResourceAwareIterator",
     "LowResourceOptimizer",
     "SmartCache",
+    "MemoryInspector",
     "similarity",
     "length",
     "corrected_errors",

--- a/src/iteration/memory_inspector.py
+++ b/src/iteration/memory_inspector.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Utilities for inspecting stored reference memory."""
+
+from dataclasses import dataclass
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .reference_memory import ReferenceMemory, ReferenceEntry
+
+
+@dataclass
+class SourceContribution:
+    """Representation of a single source and its contribution."""
+
+    summary: str
+    path: str
+    confidence: float
+
+
+class MemoryInspector:
+    """Inspect :class:`ReferenceMemory` and report linked sources."""
+
+    def __init__(self, memory: "ReferenceMemory") -> None:
+        self.memory = memory
+
+    # ------------------------------------------------------------------
+    def linked_sources(self) -> List[SourceContribution]:
+        """Return a list describing all linked sources."""
+
+        sources: List[SourceContribution] = []
+        for entry in self.memory.internal_sources + self.memory.external_sources:
+            sources.append(
+                SourceContribution(
+                    summary=entry.summary, path=entry.path, confidence=entry.confidence
+                )
+            )
+        return sources
+
+    # ------------------------------------------------------------------
+    def generate_report(self) -> str:
+        """Return a human readable report of linked sources."""
+
+        sources = self.linked_sources()
+        if not sources:
+            return "No sources linked."
+        lines = [
+            f"- {src.summary}: {src.path} (confidence {src.confidence:.2f})"
+            for src in sources
+        ]
+        return "\n".join(lines)
+
+
+__all__ = ["MemoryInspector", "SourceContribution"]

--- a/src/iteration/reference_memory.py
+++ b/src/iteration/reference_memory.py
@@ -79,5 +79,14 @@ class ReferenceMemory:
         """Proxy search requests to the underlying :class:`DeepSearcher`."""
         return self.searcher.search(query, user_id=user_id, limit=limit)
 
+    # ------------------------------------------------------------------
+    def report(self) -> str:
+        """Return a report of all linked sources."""
+
+        from .memory_inspector import MemoryInspector
+
+        inspector = MemoryInspector(self)
+        return inspector.generate_report()
+
 
 __all__ = ["ReferenceMemory", "ReferenceEntry"]

--- a/tests/iteration/test_memory_inspector.py
+++ b/tests/iteration/test_memory_inspector.py
@@ -1,0 +1,55 @@
+"""Tests for the MemoryInspector component."""
+
+from src.iteration.reference_memory import ReferenceMemory
+from src.iteration.memory_inspector import MemoryInspector
+from src.utils.source_tracker import SourceTracker
+
+
+class DummySearcher:
+    """Stub deep searcher that records queries."""
+
+    def __init__(self) -> None:
+        self.queries = []
+
+    def search(self, query: str, user_id=None, limit: int = 5):  # noqa: D401 - simple stub
+        self.queries.append(query)
+        return []
+
+
+def test_linked_sources_and_report(tmp_path):
+    tracker = SourceTracker()
+    searcher = DummySearcher()
+    memory = ReferenceMemory(tracker=tracker, searcher=searcher)
+
+    file = tmp_path / "file.txt"
+    file.write_text("hello")
+
+    memory.create_reference_link("internal", str(file), 0.9)
+    url = "https://example.com"
+    memory.create_reference_link("external", url, 0.8)
+
+    inspector = MemoryInspector(memory)
+    sources = inspector.linked_sources()
+
+    assert len(sources) == 2
+    assert sources[0].path == str(file)
+    assert sources[1].path == url
+
+    report = inspector.generate_report()
+    assert "internal" in report and str(file) in report
+    assert "external" in report and url in report
+
+
+def test_reference_memory_report(tmp_path):
+    tracker = SourceTracker()
+    searcher = DummySearcher()
+    memory = ReferenceMemory(tracker=tracker, searcher=searcher)
+
+    file = tmp_path / "note.txt"
+    file.write_text("hi")
+
+    memory.create_reference_link("note", str(file), 0.7)
+
+    report = memory.report()
+    assert "note" in report
+    assert str(file) in report


### PR DESCRIPTION
## Summary
- add `MemoryInspector` module to list linked reference sources and their confidence
- integrate `ReferenceMemory` with an accessible `report()` method
- expose `MemoryInspector` in iteration package and cover with tests

## Testing
- `pytest tests/iteration/test_memory_inspector.py -q`
- `pytest tests/iteration -q`


------
https://chatgpt.com/codex/tasks/task_e_689441ffebbc832384e964b26f4bedab