### PR TITLE
Add iteration strategy tag handler and tests

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -24,6 +24,7 @@ from src.iteration import (
     IntegrationType,
     IterationController,
     log_metrics,
+    IterationStrategy,
 )
 from src.models import Character
 from src.core.cache_manager import CacheManager
@@ -211,6 +212,8 @@ class Neyra:
             "known_books": self.known_books,
             "worlds": self.world_memory.get(),
             "style_examples": [],
+            "query": text,
+            "neyra": self,
         }
 
         response_parts = []
@@ -229,10 +232,17 @@ class Neyra:
 
         return "\n\n".join(response_parts) if response_parts else "💭 Хм, интересная команда! Обдумываю..."
 
-    def iterative_response(self, query: str) -> str:
+    def iterative_response(
+        self, query: str, strategy: IterationStrategy | None = None
+    ) -> str:
         """Return a refined response using iterative improvement pipeline."""
         self.logger.info("Starting iterative response")
         update_progress("start")
+        if strategy is not None:
+            self.iteration_controller.max_iterations = strategy.max_iterations
+            self.iteration_controller.max_critical_spaces = (
+                strategy.max_critical_spaces
+            )
         response = self.process_command(query)
         draft = self.last_draft or response
         iteration = 1

--- a/src/iteration/strategy_manager.py
+++ b/src/iteration/strategy_manager.py
@@ -82,5 +82,21 @@ class AdaptiveIterationManager:
         controller.max_iterations = self.max_iterations
         controller.max_critical_spaces = self.max_critical_spaces
 
+    # ------------------------------------------------------------------
+    @classmethod
+    def determine_strategy(cls, preset: str) -> IterationStrategy:
+        """Return the strategy configuration for ``preset``.
+
+        Parameters
+        ----------
+        preset:
+            Name of the strategy preset.
+        """
+
+        try:
+            return cls.PRESETS[preset]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            raise ValueError(f"Unknown iteration preset: {preset}") from exc
+
 
 __all__ = ["AdaptiveIterationManager", "IterationStrategy"]

--- a/src/tags/enhanced_parser.py
+++ b/src/tags/enhanced_parser.py
@@ -31,6 +31,7 @@ class EnhancedTagParser:
         "character_reminder": r"@Напомни:\s*(?P<content>[^@]+)@",
         # ``generate_content`` also exposes the topic via params
         "generate_content": r"@Сгенерируй:\s*(?P<topic>[^@]+)@",
+        "iteration_strategy": r"@Итерация:\s*([^@]+)@",
     }
 
     #: block patterns like ``[Пример стиля автора, X]\n...\n[Пример окончен]``

--- a/src/tags/manager.py
+++ b/src/tags/manager.py
@@ -18,7 +18,10 @@
 контекста, а возвращать строку-результат.
 """
 
+import re
 from typing import Callable, Dict, Any, Optional
+
+from src.iteration.strategy_manager import AdaptiveIterationManager
 
 # Словари реестра
 _patterns: Dict[str, str] = {}
@@ -63,3 +66,32 @@ def get_patterns() -> Dict[str, str]:
 def available_tags() -> Dict[str, Callable[[str, Dict[str, Any]], str]]:
     """Возвращает копию реестра обработчиков."""
     return dict(_handlers)
+
+
+def iteration_strategy_handler(mode: str, context: Dict[str, Any]) -> str:
+    """Handle iteration strategy selection tag.
+
+    Parameters
+    ----------
+    mode:
+        Strategy preset name provided inside the tag.
+    context:
+        Execution context which must contain the original user query under
+        ``"query"`` and a reference to the :class:`Neyra` instance under
+        ``"neyra"``.
+    """
+
+    neyra = context.get("neyra")
+    query = context.get("query", "")
+    strategy = AdaptiveIterationManager.determine_strategy(mode.strip().lower())
+    clean_query = re.sub(r"@Итерация:\s*[^@]+@", "", query, flags=re.IGNORECASE).strip()
+    if neyra and hasattr(neyra, "iterative_response"):
+        return neyra.iterative_response(clean_query, strategy)
+    return "🤔 Команда итерации недоступна."
+
+
+register_tag(
+    "iteration_strategy",
+    iteration_strategy_handler,
+    pattern=r"@Итерация:\s*([^@]+)@",
+)

--- a/tests/tags/test_iteration_strategy_tag.py
+++ b/tests/tags/test_iteration_strategy_tag.py
@@ -1,0 +1,32 @@
+import pytest
+
+from src.core.neyra_brain import Neyra
+from src.iteration.strategy_manager import IterationStrategy
+
+
+@pytest.mark.parametrize(
+    "mode, iterations, spaces",
+    [
+        ("quick", 1, 0),
+        ("standard", 3, 0),
+        ("thorough", 5, 0),
+        ("research", 8, 1),
+    ],
+)
+def test_iteration_tag_selects_strategy(monkeypatch, mode, iterations, spaces):
+    neyra = Neyra()
+    captured = {}
+
+    def fake_iterative_response(query: str, strategy: IterationStrategy | None = None):
+        captured["strategy"] = strategy
+        return "ok"
+
+    monkeypatch.setattr(neyra, "iterative_response", fake_iterative_response)
+
+    result = neyra.process_command(f"@Итерация: {mode}@")
+
+    assert result == "ok"
+    strategy = captured["strategy"]
+    assert isinstance(strategy, IterationStrategy)
+    assert strategy.max_iterations == iterations
+    assert strategy.max_critical_spaces == spaces


### PR DESCRIPTION
## Summary
- introduce `iteration_strategy_handler` and register `@Итерация:<режим>@` tag
- expose `AdaptiveIterationManager.determine_strategy` and wire tag through parser
- allow `Neyra.iterative_response` to accept strategies and add tests for presets

## Testing
- `PYTHONPATH=. pytest tests/tags/test_iteration_strategy_tag.py`

------
https://chatgpt.com/codex/tasks/task_e_689445130bd88323a27e3b5a3a2cfb9b