### PR TITLE
feat: adjust iteration priority by personality

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -60,10 +60,12 @@ class Neyra:
         else:  # pragma: no cover - fallback when optional deps missing
             self.deep_searcher = SimpleNamespace(search=lambda *a, **k: [])
         self.response_enhancer = ResponseEnhancer()
+        self.emotional_state = "любопытная"
         self.iteration_controller = IterationController()
+        self.iteration_controller.personality = self.personality
+        self.iteration_controller.emotional_state = self.emotional_state
         self.current_user_id = "default"
         self.current_style = ""
-        self.emotional_state = "любопытная"
         self.history = RequestHistory(load_existing=False)
         self.cache = CacheManager()
 
@@ -238,6 +240,9 @@ class Neyra:
         """Return a refined response using iterative improvement pipeline."""
         self.logger.info("Starting iterative response")
         update_progress("start")
+        # Sync dynamic personality traits with iteration controller
+        self.iteration_controller.personality = self.personality
+        self.iteration_controller.emotional_state = self.emotional_state
         if strategy is not None:
             self.iteration_controller.max_iterations = strategy.max_iterations
             self.iteration_controller.max_critical_spaces = (

--- a/src/iteration/iteration_controller.py
+++ b/src/iteration/iteration_controller.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from src.core.neyra_config import NeyraPersonality
+
 from .strategy_manager import AdaptiveIterationManager
 
 
@@ -28,6 +30,8 @@ class IterationController:
     strategy: str = "standard"
     max_iterations: int | None = None
     max_critical_spaces: int | None = None
+    personality: NeyraPersonality | None = None
+    emotional_state: str = "neutral"
     _iterations: int = 0
 
     def __post_init__(self) -> None:
@@ -38,15 +42,35 @@ class IterationController:
             self.max_critical_spaces = manager.max_critical_spaces
 
     # ------------------------------------------------------------------
-    def assess_quality(self, text: str) -> int:
-        """Return the number of critical placeholders remaining in ``text``.
+    def _priority_multiplier(self) -> float:
+        """Return weighting factor based on personality and emotion."""
+
+        factor = 1.0
+        if self.personality:
+            # Combine relevant personality traits
+            factor *= (
+                self.personality.curiosity_level
+                + self.personality.attention_to_detail
+            ) / 2
+        mood = {
+            "спокойная": 0.9,
+            "любопытная": 1.0,
+            "взволнованная": 1.1,
+        }
+        factor *= mood.get(self.emotional_state, 1.0)
+        return factor
+
+    def assess_quality(self, text: str) -> float:
+        """Return weighted count of critical placeholders in ``text``.
 
         A *critical space* is represented by the sequence ``"___"``. Each
         occurrence signals missing or uncertain information that should be
-        resolved before finalising the response.
+        resolved before finalising the response.  The count is weighted by
+        :class:`NeyraPersonality` and current ``emotional_state`` to reflect
+        how much attention should be given to these gaps.
         """
 
-        return text.count("___")
+        return text.count("___") * self._priority_multiplier()
 
     # ------------------------------------------------------------------
     def should_iterate(self, text: str) -> bool:

--- a/tests/iteration/test_personality_influence.py
+++ b/tests/iteration/test_personality_influence.py
@@ -1,0 +1,72 @@
+import sys
+import types
+
+
+stub = types.ModuleType("prompt_toolkit")
+stub.PromptSession = object
+completion = types.ModuleType("prompt_toolkit.completion")
+completion.WordCompleter = object
+history = types.ModuleType("prompt_toolkit.history")
+history.InMemoryHistory = object
+sys.modules.setdefault("prompt_toolkit", stub)
+sys.modules.setdefault("prompt_toolkit.completion", completion)
+sys.modules.setdefault("prompt_toolkit.history", history)
+
+rich = types.ModuleType("rich")
+console = types.ModuleType("rich.console")
+console.Console = object
+markdown = types.ModuleType("rich.markdown")
+markdown.Markdown = object
+panel = types.ModuleType("rich.panel")
+panel.Panel = object
+sys.modules.setdefault("rich", rich)
+sys.modules.setdefault("rich.console", console)
+sys.modules.setdefault("rich.markdown", markdown)
+sys.modules.setdefault("rich.panel", panel)
+
+from src.core.neyra_brain import Neyra
+from src.iteration import KnowledgeGap
+
+
+def _prepare(monkeypatch, attention: float, curiosity: float, mood: str) -> Neyra:
+    neyra = Neyra()
+    neyra.iteration_controller.max_iterations = 5
+    neyra.iteration_controller.max_critical_spaces = 1
+    neyra.personality.attention_to_detail = attention
+    neyra.personality.curiosity_level = curiosity
+    neyra.emotional_state = mood
+
+    def fake_process(text: str) -> str:
+        neyra.last_draft = text
+        return text
+
+    monkeypatch.setattr(neyra, "process_command", fake_process)
+    monkeypatch.setattr(
+        neyra.gap_analyzer,
+        "analyze",
+        lambda draft: [KnowledgeGap(claim=draft, questions=[], confidence=0.0)],
+    )
+    monkeypatch.setattr(neyra.deep_searcher, "search", lambda *a, **k: [])
+    monkeypatch.setattr(
+        neyra.response_enhancer,
+        "enhance",
+        lambda text, results, integration, self_correct=True: text,
+    )
+    return neyra
+
+
+def _run_iterations(neyra: Neyra) -> int:
+    neyra.iteration_controller._iterations = 0
+    neyra.iterative_response("___")
+    return neyra.iteration_controller._iterations
+
+
+def test_personality_and_emotion_influence_iterations(monkeypatch):
+    high = _prepare(monkeypatch, attention=1.0, curiosity=1.0, mood="взволнованная")
+    low = _prepare(monkeypatch, attention=0.1, curiosity=0.1, mood="спокойная")
+
+    high_iters = _run_iterations(high)
+    low_iters = _run_iterations(low)
+
+    assert high_iters > low_iters
+    assert low_iters == 0


### PR DESCRIPTION
## Summary
- factor in personality traits and emotional state when prioritising unresolved gaps
- wire Neyra's current personality and mood into the iteration controller
- test that different personalities produce different iteration counts

## Testing
- `pytest tests/iteration/test_iteration_controller.py tests/iteration/test_personality_influence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894479346648323aa5ab2678f4c77b0