### PR TITLE
Add FeedbackLearner for applying user corrections

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -21,6 +21,7 @@ from src.iteration import (
     GapAnalyzer,
     DeepSearcher,
     ResponseEnhancer,
+    FeedbackLearner,
     IntegrationType,
     IterationController,
     log_metrics,
@@ -60,6 +61,9 @@ class Neyra:
         else:  # pragma: no cover - fallback when optional deps missing
             self.deep_searcher = SimpleNamespace(search=lambda *a, **k: [])
         self.response_enhancer = ResponseEnhancer()
+        self.feedback_learner = FeedbackLearner(
+            self.characters_memory, self.world_memory, self.style_memory
+        )
         self.emotional_state = "любопытная"
         self.iteration_controller = IterationController()
         self.iteration_controller.personality = self.personality

--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -7,6 +7,7 @@ try:  # pragma: no cover - optional dependency during tests
 except Exception:  # noqa: BLE001 - fallback when requests is missing
     DeepSearcher = None  # type: ignore
 from .response_enhancer import ResponseEnhancer, IntegrationType
+from .feedback_learner import FeedbackLearner
 from .iteration_controller import IterationController
 from .strategy_manager import AdaptiveIterationManager, IterationStrategy
 from .resource_iterator import ResourceAwareIterator
@@ -21,6 +22,7 @@ __all__ = [
     "KnowledgeGap",
     "DeepSearcher",
     "ResponseEnhancer",
+    "FeedbackLearner",
     "IntegrationType",
     "IterationController",
     "AdaptiveIterationManager",

--- a/src/iteration/feedback_learner.py
+++ b/src/iteration/feedback_learner.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Learn from user feedback and update persistent memories."""
+
+from typing import Any, Dict, Iterable
+
+from src.memory import CharacterMemory, WorldMemory, StyleMemory
+from src.models import Character
+
+
+class FeedbackLearner:
+    """Analyse confirmed corrections and store them in memory.
+
+    Parameters
+    ----------
+    characters:
+        Shared :class:`~src.memory.character_memory.CharacterMemory` instance.
+    worlds:
+        Shared :class:`~src.memory.world_memory.WorldMemory` instance.
+    styles:
+        Shared :class:`~src.memory.style_memory.StyleMemory` instance.
+    """
+
+    def __init__(
+        self,
+        characters: CharacterMemory,
+        worlds: WorldMemory,
+        styles: StyleMemory,
+    ) -> None:
+        self.characters = characters
+        self.worlds = worlds
+        self.styles = styles
+
+    # ------------------------------------------------------------------
+    def apply(self, feedback: Iterable[Dict[str, Any]]) -> None:
+        """Process an iterable of feedback items.
+
+        Each item should contain ``type``, ``data`` and ``confirmed`` keys. When
+        ``confirmed`` is ``True`` the corresponding memory is updated.
+        """
+
+        for item in feedback:
+            if not item.get("confirmed"):
+                continue
+            data = item.get("data", {})
+            kind = item.get("type")
+            if kind == "character":
+                self._update_character(data)
+            elif kind == "world":
+                self._update_world(data)
+            elif kind == "style":
+                self._update_style(data)
+
+    # ------------------------------------------------------------------
+    def _update_character(self, data: Dict[str, Any]) -> None:
+        """Store a character description."""
+        try:
+            character = Character.from_dict(data)
+        except Exception:  # pragma: no cover - best effort
+            return
+        self.characters.add(character)
+        self.characters.save()
+
+    def _update_world(self, data: Dict[str, Any]) -> None:
+        """Store world information using the legacy ``add`` API."""
+        name = data.get("name")
+        info = data.get("info", {})
+        if not name:
+            return
+        self.worlds.add(name, info)
+        self.worlds.save()
+
+    def _update_style(self, data: Dict[str, Any]) -> None:
+        """Store style preferences or examples."""
+        user_id = data.get("user_id", "default")
+        author = data.get("author", "preferred")
+        example = data.get("example")
+        description = data.get("description")
+        characteristics = data.get("characteristics")
+        self.styles.add(
+            user_id,
+            author,
+            example=example,
+            description=description,
+            characteristics=characteristics,
+        )
+        self.styles.save()
+
+
+__all__ = ["FeedbackLearner"]

--- a/tests/iteration/test_feedback_learner.py
+++ b/tests/iteration/test_feedback_learner.py
@@ -1,0 +1,41 @@
+from src.iteration import FeedbackLearner
+from src.memory import CharacterMemory, WorldMemory, StyleMemory
+
+
+def test_feedback_updates_memories(tmp_path):
+    char_mem = CharacterMemory(tmp_path / "chars.json")
+    world_mem = WorldMemory(tmp_path / "world.json")
+    style_mem = StyleMemory(tmp_path / "style.json")
+    learner = FeedbackLearner(char_mem, world_mem, style_mem)
+
+    feedback = [
+        {"type": "character", "confirmed": True, "data": {"name": "Bob", "appearance": "tall"}},
+        {
+            "type": "world",
+            "confirmed": True,
+            "data": {
+                "name": "Earth",
+                "info": {"rules": [{"category": "physics", "description": "gravity"}]},
+            },
+        },
+        {
+            "type": "style",
+            "confirmed": True,
+            "data": {
+                "user_id": "u1",
+                "author": "Bob",
+                "example": "Hello world",
+                "description": "friendly",
+            },
+        },
+        {"type": "character", "confirmed": False, "data": {"name": "Ignored"}},
+    ]
+
+    learner.apply(feedback)
+
+    assert char_mem.get("Bob").appearance == "tall"
+    world_rules = world_mem.get("Earth")["rules"]
+    assert world_rules[0]["category"] == "physics"
+    style = style_mem.get_style("u1", "Bob")
+    assert "Hello world" in style.examples
+    assert char_mem.get("Ignored") is None


### PR DESCRIPTION
## Summary
- implement `FeedbackLearner` to process confirmed user feedback and update character, world, and style memories
- integrate `FeedbackLearner` into `Neyra` core after `ResponseEnhancer`
- add unit tests covering memory updates from feedback

## Testing
- `pytest tests/iteration/test_feedback_learner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689449eba82c832388f80e4b6da24e73