### PR TITLE
Add timeline conflict detection

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,6 +1,7 @@
 from .self_corrector import SelfCorrector, SuggestionChooser
 from .verification_system import VerificationSystem, VerificationResult, verify_fact
 from .uncertainty_manager import UncertaintyManager
+from .timeline_checker import TimelineChecker
 
 __all__ = [
     "SelfCorrector",
@@ -8,5 +9,6 @@ __all__ = [
     "VerificationSystem",
     "VerificationResult",
     "UncertaintyManager",
+    "TimelineChecker",
     "verify_fact",
 ]

--- a/src/analysis/timeline_checker.py
+++ b/src/analysis/timeline_checker.py
@@ -1,0 +1,37 @@
+"""Проверяю временную последовательность событий истории."""
+
+from __future__ import annotations
+
+from typing import List
+
+from src.memory.story_timeline import StoryTimeline
+
+
+class TimelineChecker:
+    """Сравниваю события в :class:`StoryTimeline` и ищу конфликты."""
+
+    def __init__(self, timeline: StoryTimeline | None = None) -> None:
+        self.timeline = timeline or StoryTimeline()
+
+    # ------------------------------------------------------------------
+    def check(self) -> List[str]:
+        """Вернуть описания конфликтов во временной линии."""
+        events = self.timeline.get()
+        conflicts: List[str] = []
+        items = list(events.items())
+        for i, (name_a, data_a) in enumerate(items):
+            start_a = data_a.get("start")
+            end_a = data_a.get("end")
+            if start_a is None or end_a is None:
+                continue
+            for name_b, data_b in items[i + 1 :]:
+                start_b = data_b.get("start")
+                end_b = data_b.get("end")
+                if start_b is None or end_b is None:
+                    continue
+                if start_a < end_b and start_b < end_a:
+                    conflicts.append(f"{name_a} overlaps with {name_b}")
+        return conflicts
+
+
+__all__ = ["TimelineChecker"]

--- a/src/iteration/gap_analyzer.py
+++ b/src/iteration/gap_analyzer.py
@@ -8,6 +8,7 @@ from typing import List
 
 from src.analysis.verification_system import VerificationSystem, VerificationResult
 from src.analysis.uncertainty_manager import UncertaintyManager
+from src.analysis.timeline_checker import TimelineChecker
 
 
 @dataclass
@@ -18,6 +19,7 @@ class KnowledgeGap:
     questions: List[str]
     confidence: float
     disclaimer: str | None = None
+    gap_type: str = "knowledge_gap"
 
 
 class GapAnalyzer:
@@ -27,9 +29,11 @@ class GapAnalyzer:
         self,
         verifier: VerificationSystem | None = None,
         uncertainty: UncertaintyManager | None = None,
+        timeline_checker: TimelineChecker | None = None,
     ) -> None:
         self.verifier = verifier or VerificationSystem()
         self.uncertainty = uncertainty or UncertaintyManager()
+        self.timeline_checker = timeline_checker or TimelineChecker()
 
     # ------------------------------------------------------------------
     def analyze(self, draft: str) -> List[KnowledgeGap]:
@@ -50,6 +54,16 @@ class GapAnalyzer:
                         disclaimer=result.disclaimer,
                     )
                 )
+        timeline_conflicts = self.timeline_checker.check()
+        for conflict in timeline_conflicts:
+            gaps.append(
+                KnowledgeGap(
+                    claim=conflict,
+                    questions=[],
+                    confidence=0.0,
+                    gap_type="timeline_conflict",
+                )
+            )
         return gaps
 
 

--- a/tests/analysis/test_timeline_checker.py
+++ b/tests/analysis/test_timeline_checker.py
@@ -1,0 +1,19 @@
+from src.analysis.timeline_checker import TimelineChecker
+from src.memory.story_timeline import StoryTimeline
+
+
+def test_no_conflicts():
+    timeline = StoryTimeline()
+    timeline.add("begin", {"start": 0, "end": 1})
+    timeline.add("middle", {"start": 2, "end": 3})
+    checker = TimelineChecker(timeline)
+    assert checker.check() == []
+
+
+def test_detects_overlapping_events():
+    timeline = StoryTimeline()
+    timeline.add("a", {"start": 0, "end": 5})
+    timeline.add("b", {"start": 3, "end": 6})
+    checker = TimelineChecker(timeline)
+    conflicts = checker.check()
+    assert conflicts == ["a overlaps with b"]


### PR DESCRIPTION
## Summary
- add `TimelineChecker` to spot overlapping events in the story timeline
- extend `GapAnalyzer` to surface timeline conflicts via `KnowledgeGap`
- cover timeline checking with unit tests

## Testing
- `PYTHONPATH=. pytest tests/analysis/test_timeline_checker.py tests/iteration/test_gap_analyzer.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'prompt_toolkit')*


------
https://chatgpt.com/codex/tasks/task_e_68944b55384c8323b78dedb6c71bdccf