### PR TITLE
Add cache expiration with periodic cleanup

### DIFF
--- a/src/core/cache_manager.py
+++ b/src/core/cache_manager.py
@@ -55,3 +55,9 @@ class CacheManager:
             path = self._path_for(key)
             if path.exists():
                 path.unlink()
+
+    # ------------------------------------------------------------------
+    # maintenance hooks
+    def cleanup(self) -> None:
+        """Hook for subclasses to remove expired or stale entries."""
+        return None

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -243,6 +243,7 @@ class Neyra:
     ) -> str:
         """Return a refined response using iterative improvement pipeline."""
         self.logger.info("Starting iterative response")
+        self.cache.cleanup()
         update_progress("start")
         # Sync dynamic personality traits with iteration controller
         self.iteration_controller.personality = self.personality

--- a/src/iteration/smart_cache.py
+++ b/src/iteration/smart_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import Any, Iterable
 import hashlib
+import time
 
 from src.core.cache_manager import CacheManager
 
@@ -24,12 +25,15 @@ class SmartCache(CacheManager):
         *,
         hot_limit: int = 32,
         warm_limit: int = 128,
+        default_ttl: float | None = None,
     ) -> None:
         super().__init__(cache_dir)
         self.hot_limit = hot_limit
         self.warm_limit = warm_limit
+        self.default_ttl = default_ttl
         self.hot: OrderedDict[str, Any] = OrderedDict()
         self.warm: OrderedDict[str, Any] = OrderedDict()
+        self.expires_at: dict[str, float] = {}
 
     # ------------------------------------------------------------------
     # key helpers
@@ -58,13 +62,31 @@ class SmartCache(CacheManager):
 
     # ------------------------------------------------------------------
     # public API
-    def set(self, query: str, value: Any, tags: Iterable[str] | None = None) -> None:
+    def set(
+        self,
+        query: str,
+        value: Any,
+        tags: Iterable[str] | None = None,
+        ttl: float | None = None,
+    ) -> None:
         key = self._hash_key(query, tags)
-        super().set(key, {"value": value, "tags": list(tags) if tags else []})
+        ttl_value = ttl if ttl is not None else self.default_ttl
+        if ttl_value is not None:
+            exp = time.time() + ttl_value
+            self.expires_at[key] = exp
+        else:
+            self.expires_at.pop(key, None)
+            exp = None
+        data = {"value": value, "tags": list(tags) if tags else []}
+        if exp is not None:
+            data["expires_at"] = exp
+        super().set(key, data)
         self._promote_to_hot(key, value)
 
     def get(self, query: str, tags: Iterable[str] | None = None) -> Any | None:
         key = self._hash_key(query, tags)
+        if self._is_expired(key):
+            return None
         if key in self.hot:
             self.hot.move_to_end(key)
             return self.hot[key]
@@ -75,6 +97,12 @@ class SmartCache(CacheManager):
         data = super().get(key)
         if data is None:
             return None
+        exp = data.get("expires_at") if isinstance(data, dict) else None
+        if exp is not None:
+            self.expires_at[key] = exp
+            if exp < time.time():
+                self.invalidate(query, tags)
+                return None
         if isinstance(data, dict) and "value" in data:
             value = data["value"]
         else:
@@ -87,9 +115,32 @@ class SmartCache(CacheManager):
         if query is None:
             self.hot.clear()
             self.warm.clear()
+            self.expires_at.clear()
             super().invalidate()
             return
         key = self._hash_key(query, tags)
         self.hot.pop(key, None)
         self.warm.pop(key, None)
+        self.expires_at.pop(key, None)
         super().invalidate(key)
+
+    # ------------------------------------------------------------------
+    # expiration helpers
+    def _is_expired(self, key: str) -> bool:
+        exp = self.expires_at.get(key)
+        if exp is not None and exp < time.time():
+            self.hot.pop(key, None)
+            self.warm.pop(key, None)
+            self.expires_at.pop(key, None)
+            super().invalidate(key)
+            return True
+        return False
+
+    def cleanup(self) -> None:
+        now = time.time()
+        expired = [k for k, v in self.expires_at.items() if v < now]
+        for key in expired:
+            self.hot.pop(key, None)
+            self.warm.pop(key, None)
+            self.expires_at.pop(key, None)
+            super().invalidate(key)

--- a/tests/iteration/test_smart_cache_expiration.py
+++ b/tests/iteration/test_smart_cache_expiration.py
@@ -1,0 +1,35 @@
+import time
+import sys
+import types
+from src.iteration.smart_cache import SmartCache
+
+chat_session_stub = types.ModuleType("src.interaction.chat_session")
+chat_session_stub.ChatSession = object
+sys.modules.setdefault("src.interaction.chat_session", chat_session_stub)
+
+from src.core.neyra_brain import Neyra
+
+
+def test_entry_expires(tmp_path):
+    cache = SmartCache(cache_dir=tmp_path)
+    cache.set("q", "v", ttl=0.1)
+    assert cache.get("q") == "v"
+    time.sleep(0.2)
+    assert cache.get("q") is None
+
+
+def test_cleanup_called_during_iteration(monkeypatch, tmp_path):
+    neyra = Neyra()
+    calls = {"count": 0}
+
+    def fake_cleanup():
+        calls["count"] += 1
+
+    neyra.cache = SmartCache(cache_dir=tmp_path)
+    neyra.cache.cleanup = fake_cleanup  # type: ignore
+
+    monkeypatch.setattr(neyra, "process_command", lambda q: "base text")
+    monkeypatch.setattr(neyra.gap_analyzer, "analyze", lambda draft: [])
+
+    neyra.iterative_response("query")
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- add TTL-based expiration and cleanup to SmartCache
- provide cleanup hook in CacheManager and call it from iterative response
- test cache expiration and cleanup triggering

## Testing
- `pytest tests/iteration/test_smart_cache.py tests/iteration/test_smart_cache_expiration.py`
- `pytest tests/iteration`


------
https://chatgpt.com/codex/tasks/task_e_68944d3570b8832395c037d5a63a5b18