### PR TITLE
feat: add session scoped memory per user

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -13,6 +13,7 @@ from src.utils.encoding_detector import detect_encoding
 from src.llm import BaseLLM, LLMFactory
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory, WorldMemory, StyleMemory
+from .session_scoped_memory import SessionScopedMemory
 from src.analysis import VerificationSystem, VerificationResult, UncertaintyManager
 from types import SimpleNamespace
 
@@ -44,9 +45,12 @@ class Neyra:
         self.executor = CommandExecutor(self)
         self.personality = NeyraPersonality()
         self.known_books: List[str] = []
-        self.characters_memory = CharacterMemory()
-        self.world_memory = WorldMemory()
-        self.style_memory = StyleMemory()
+        self.session_memory = SessionScopedMemory()
+        (
+            self.characters_memory,
+            self.world_memory,
+            self.style_memory,
+        ) = self.session_memory.get("default")
         self.draft_generator = DraftGenerator(
             self.characters_memory, self.world_memory, self.style_memory
         )
@@ -68,12 +72,44 @@ class Neyra:
         self.iteration_controller = IterationController()
         self.iteration_controller.personality = self.personality
         self.iteration_controller.emotional_state = self.emotional_state
-        self.current_user_id = "default"
+        self._current_user_id = "default"
         self.current_style = ""
         self.history = RequestHistory(load_existing=False)
         self.cache = CacheManager()
 
         self.logger.info("Нейра проснулась! ✨")
+
+    # ------------------------------------------------------------------
+    def _apply_memory_set(self, user_id: str) -> None:
+        """Switch all memory references to those associated with ``user_id``."""
+        (
+            self.characters_memory,
+            self.world_memory,
+            self.style_memory,
+        ) = self.session_memory.get(user_id)
+        # Update dependant components to use new memory objects
+        if hasattr(self, "draft_generator"):
+            self.draft_generator.character_memory = self.characters_memory
+            self.draft_generator.world_memory = self.world_memory
+            self.draft_generator.style_memory = self.style_memory
+        if hasattr(self, "deep_searcher"):
+            self.deep_searcher.character_memory = self.characters_memory
+            self.deep_searcher.world_memory = self.world_memory
+            self.deep_searcher.style_memory = self.style_memory
+        if hasattr(self, "feedback_learner"):
+            self.feedback_learner.characters = self.characters_memory
+            self.feedback_learner.worlds = self.world_memory
+            self.feedback_learner.styles = self.style_memory
+
+    # ------------------------------------------------------------------
+    @property
+    def current_user_id(self) -> str:
+        return self._current_user_id
+
+    @current_user_id.setter
+    def current_user_id(self, value: str) -> None:
+        self._current_user_id = value
+        self._apply_memory_set(value)
 
     def _load_llm(self) -> BaseLLM | None:
         """Загружаю локальную LLM при наличии конфига."""

--- a/src/core/session_scoped_memory.py
+++ b/src/core/session_scoped_memory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Utilities for per-user memory isolation.
+
+This module exposes :class:`SessionScopedMemory` which lazily creates
+``CharacterMemory``, ``WorldMemory`` and ``StyleMemory`` instances for each
+``user_id``.  The memory for a user is stored inside a dedicated directory under
+``base_path / user_id`` ensuring complete isolation between users.
+"""
+
+from pathlib import Path
+from typing import Dict, Tuple
+
+from src.memory import CharacterMemory, WorldMemory, StyleMemory
+
+
+MemoryTuple = Tuple[CharacterMemory, WorldMemory, StyleMemory]
+
+
+class SessionScopedMemory:
+    """Manage separate memory objects for each user."""
+
+    def __init__(self, base_path: str | Path = "data") -> None:
+        self.base_path = Path(base_path)
+        self._cache: Dict[str, MemoryTuple] = {}
+
+    # ------------------------------------------------------------------
+    def get(self, user_id: str) -> MemoryTuple:
+        """Return memory objects associated with ``user_id``.
+
+        Memory instances are created on first access and cached for subsequent
+        calls.  Each user's data is stored under ``base_path / user_id``.
+        """
+
+        if user_id not in self._cache:
+            user_dir = self.base_path / user_id
+            char_mem = CharacterMemory(user_dir / "characters.json")
+            world_mem = WorldMemory(user_dir / "world.json")
+            style_mem = StyleMemory(user_dir / "styles.json")
+            self._cache[user_id] = (char_mem, world_mem, style_mem)
+        return self._cache[user_id]
+
+
+__all__ = ["SessionScopedMemory"]

--- a/src/iteration/deep_searcher.py
+++ b/src/iteration/deep_searcher.py
@@ -40,7 +40,7 @@ class DeepSearcher:
         self.world_memory = world_memory or WorldMemory()
         self.style_memory = style_memory or StyleMemory()
         self.api_client = api_client or SearchAPIClient()
-        self.data_path = Path(data_path or "data")
+        self.data_path = Path(data_path) if data_path else None
         if use_default_plugins:
             register_search_plugin(APISearchPlugin(self.api_client))
 
@@ -118,7 +118,7 @@ class DeepSearcher:
             pass
 
         # Cold storage files -----------------------------------------------
-        if self.data_path.exists():
+        if self.data_path and self.data_path.exists():
             for file in self.data_path.rglob("*"):
                 if not file.is_file():
                     continue

--- a/tests/core/test_session_scoped_memory.py
+++ b/tests/core/test_session_scoped_memory.py
@@ -1,0 +1,33 @@
+import pytest
+
+from src.core.session_scoped_memory import SessionScopedMemory
+from src.models import Character
+
+
+def test_returns_separate_instances_per_user(tmp_path):
+    sm = SessionScopedMemory(base_path=tmp_path)
+    c1, w1, s1 = sm.get("u1")
+    c2, w2, s2 = sm.get("u2")
+    assert c1 is not c2
+    assert w1 is not w2
+    assert s1 is not s2
+    assert "u1" in str(c1.storage_path)
+    assert "u2" in str(c2.storage_path)
+
+
+def test_caches_instances(tmp_path):
+    sm = SessionScopedMemory(base_path=tmp_path)
+    c1, w1, s1 = sm.get("u1")
+    c1b, w1b, s1b = sm.get("u1")
+    assert c1 is c1b
+    assert w1 is w1b
+    assert s1 is s1b
+
+
+def test_memories_are_isolated(tmp_path):
+    sm = SessionScopedMemory(base_path=tmp_path)
+    c1, _, _ = sm.get("u1")
+    c2, _, _ = sm.get("u2")
+    alice = Character(name="Alice")
+    c1.add(alice)
+    assert c2.get("Alice") is None


### PR DESCRIPTION
## Summary
- add SessionScopedMemory to isolate Character, World and Style memories by user
- switch Neyra to session-scoped memories and update on user change
- avoid unintended file search in DeepSearcher when no data path is provided
- test SessionScopedMemory behaviour

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689451588e18832384977c5ceca0411e