### PR TITLE
Introduce token budget manager for iterative pipeline

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -27,6 +27,7 @@ from src.iteration import (
     IterationController,
     log_metrics,
     IterationStrategy,
+    TokenBudgetManager,
 )
 from src.models import Character
 from src.core.cache_manager import CacheManager
@@ -289,8 +290,14 @@ class Neyra:
             self.iteration_controller.max_critical_spaces = (
                 strategy.max_critical_spaces
             )
+        token_manager = TokenBudgetManager(self.llm_max_tokens)
+        self.token_budget_manager = token_manager
+        prev_tokens = self.llm_max_tokens
+        self.llm_max_tokens = token_manager.draft_tokens
         response = self.process_command(query)
+        self.llm_max_tokens = prev_tokens
         draft = self.last_draft or response
+        self.deep_searcher.token_budget_manager = token_manager
         iteration = 1
         while True:
             update_progress("iteration", iteration)
@@ -300,19 +307,26 @@ class Neyra:
                 self.logger.info("No gaps found, finishing at iteration %s", iteration)
                 break
             search_results: List[Dict[str, Any]] = []
+            self.deep_searcher.current_queries = len(gaps)
+            search_limit = token_manager.search_limit(len(gaps))
             for gap in gaps:
                 try:
                     search_results.extend(
                         self.deep_searcher.search(
-                            gap.claim, user_id=getattr(self, "current_user_id", "default")
+                            gap.claim,
+                            user_id=getattr(self, "current_user_id", "default"),
+                            limit=search_limit,
                         )
                     )
                 except Exception:
                     continue
             previous = response
+            prev_tokens = self.llm_max_tokens
+            self.llm_max_tokens = token_manager.refine_tokens
             response = self.response_enhancer.enhance(
                 response, search_results, IntegrationType.IMPORTANT_ADDITION
             )
+            self.llm_max_tokens = prev_tokens
             log_metrics(iteration, previous, response)
             self.logger.info("Iteration %s completed", iteration)
             draft = response

--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -15,6 +15,7 @@ from .low_resource_optimizer import LowResourceOptimizer
 from .smart_cache import SmartCache
 from .metrics import similarity, length, corrected_errors, log_metrics
 from .memory_inspector import MemoryInspector
+from .token_budget_manager import TokenBudgetManager
 
 __all__ = [
     "DraftGenerator",
@@ -31,6 +32,7 @@ __all__ = [
     "LowResourceOptimizer",
     "SmartCache",
     "MemoryInspector",
+    "TokenBudgetManager",
     "similarity",
     "length",
     "corrected_errors",

--- a/src/iteration/deep_searcher.py
+++ b/src/iteration/deep_searcher.py
@@ -15,6 +15,7 @@ from .plugin_registry import (
     register_search_plugin,
 )
 from .resource_iterator import ResourceAwareIterator
+from .token_budget_manager import TokenBudgetManager
 
 
 class DeepSearcher:
@@ -35,6 +36,7 @@ class DeepSearcher:
         use_default_plugins: bool = True,
         resource_iterator: ResourceAwareIterator | None = None,
         parallel: bool | None = None,
+        token_budget_manager: TokenBudgetManager | None = None,
     ) -> None:
         self.character_memory = character_memory or CharacterMemory()
         self.world_memory = world_memory or WorldMemory()
@@ -51,10 +53,30 @@ class DeepSearcher:
                 parallel = True
         self.parallel = parallel
         self.resource_iterator = resource_iterator
+        self.token_budget_manager = token_budget_manager
+        self.current_queries = 1
 
     # ------------------------------------------------------------------
-    def search(self, query: str, user_id: str | None = None, limit: int = 5) -> List[Dict[str, Any]]:
-        """Return ranked results for ``query`` from all configured sources."""
+    def search(
+        self,
+        query: str,
+        user_id: str | None = None,
+        limit: int | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Return ranked results for ``query`` from all configured sources.
+
+        When ``limit`` is ``None`` and a :class:`TokenBudgetManager` is attached,
+        the number of returned results is derived from the remaining token
+        budget.  This allows callers to dynamically control prompt sizes based on
+        available context length.
+        """
+
+        if limit is None:
+            if self.token_budget_manager:
+                limit = self.token_budget_manager.search_limit(self.current_queries)
+            else:
+                limit = 5
+
         results: List[Dict[str, Any]] = []
         q = query.lower()
 
@@ -165,6 +187,16 @@ class DeepSearcher:
                     continue
 
         results.sort(key=lambda r: r["priority"], reverse=True)
+
+        if self.token_budget_manager:
+            max_len = self.token_budget_manager.tokens_per_search_query(
+                self.current_queries
+            )
+            for item in results:
+                content = str(item.get("content", ""))
+                if len(content) > max_len:
+                    item["content"] = content[:max_len]
+
         return results
 
 

--- a/src/iteration/token_budget_manager.py
+++ b/src/iteration/token_budget_manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Utility to distribute available tokens between iteration stages."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenBudgetManager:
+    """Manage allocation of tokens for the iteration pipeline.
+
+    Parameters
+    ----------
+    total_tokens:
+        Maximum number of tokens available for the whole operation.
+    draft_ratio, search_ratio, refine_ratio:
+        Fractions of ``total_tokens`` reserved for the draft generation,
+        search prompts and refinement steps respectively.  The ratios must sum
+        to ``<= 1``.
+    per_result_tokens:
+        Estimated token cost for including one search result snippet in a
+        prompt.  This is used to convert the search budget into a limit on the
+        number of search results to request.
+    """
+
+    total_tokens: int
+    draft_ratio: float = 0.5
+    search_ratio: float = 0.3
+    refine_ratio: float = 0.2
+    per_result_tokens: int = 50
+
+    def __post_init__(self) -> None:
+        if self.total_tokens <= 0:
+            raise ValueError("total_tokens must be positive")
+        if self.draft_ratio + self.search_ratio + self.refine_ratio > 1.0:
+            raise ValueError("token ratios must sum to 1 or less")
+
+    # Draft -----------------------------------------------------------------
+    @property
+    def draft_tokens(self) -> int:
+        return max(int(self.total_tokens * self.draft_ratio), 1)
+
+    # Search ----------------------------------------------------------------
+    def search_tokens(self) -> int:
+        return max(int(self.total_tokens * self.search_ratio), 1)
+
+    def tokens_per_search_query(self, num_queries: int = 1) -> int:
+        return max(self.search_tokens() // max(num_queries, 1), 1)
+
+    def search_limit(self, num_queries: int = 1) -> int:
+        tokens = self.tokens_per_search_query(num_queries)
+        return max(tokens // self.per_result_tokens, 1)
+
+    # Refine ---------------------------------------------------------------
+    @property
+    def refine_tokens(self) -> int:
+        return max(int(self.total_tokens * self.refine_ratio), 1)
+
+
+__all__ = ["TokenBudgetManager"]

--- a/tests/iteration/test_token_budget_manager.py
+++ b/tests/iteration/test_token_budget_manager.py
@@ -1,0 +1,87 @@
+from src.core.neyra_brain import Neyra
+from src.iteration import DeepSearcher, KnowledgeGap, TokenBudgetManager
+from src.iteration.plugin_registry import register_search_plugin, clear_search_plugins
+
+
+class DummyPlugin:
+    def __init__(self):
+        self.limits: list[int] = []
+
+    def search(self, query: str, limit: int = 5):  # pragma: no cover - simple stub
+        self.limits.append(limit)
+        return [
+            {
+                "source": "dummy",
+                "reference": "",
+                "content": "x" * 100,
+                "priority": 0.1,
+            }
+            for _ in range(limit)
+        ]
+
+
+def test_allocation_basic():
+    mgr = TokenBudgetManager(
+        total_tokens=100,
+        draft_ratio=0.4,
+        search_ratio=0.3,
+        refine_ratio=0.3,
+        per_result_tokens=10,
+    )
+    assert mgr.draft_tokens == 40
+    assert mgr.refine_tokens == 30
+    assert mgr.tokens_per_search_query() == 30
+    assert mgr.search_limit() == 3
+
+
+def test_deep_searcher_respects_budget():
+    clear_search_plugins()
+    plugin = DummyPlugin()
+    register_search_plugin(plugin)
+    mgr = TokenBudgetManager(
+        total_tokens=100,
+        draft_ratio=0.4,
+        search_ratio=0.4,
+        refine_ratio=0.2,
+        per_result_tokens=10,
+    )
+    searcher = DeepSearcher(use_default_plugins=False, token_budget_manager=mgr)
+    results = searcher.search("hi")
+    assert plugin.limits == [mgr.search_limit()]
+    max_len = mgr.tokens_per_search_query()
+    assert all(len(r["content"]) <= max_len for r in results)
+    clear_search_plugins()
+
+
+def test_iterative_response_uses_budget(monkeypatch):
+    neyra = Neyra()
+    neyra.llm_max_tokens = 100
+
+    tokens_used = []
+
+    def fake_process(query):
+        tokens_used.append(neyra.llm_max_tokens)
+        neyra.last_draft = "draft"
+        return "draft"
+
+    monkeypatch.setattr(neyra, "process_command", fake_process)
+
+    monkeypatch.setattr(
+        neyra.gap_analyzer,
+        "analyze",
+        lambda draft: [KnowledgeGap(claim="gap", questions=[], confidence=0.0)],
+    )
+
+    limits: list[int | None] = []
+
+    def fake_search(query, user_id=None, limit=None):
+        limits.append(limit)
+        return []
+
+    monkeypatch.setattr(neyra.deep_searcher, "search", fake_search)
+    monkeypatch.setattr(neyra.iteration_controller, "should_iterate", lambda text: False)
+
+    neyra.iterative_response("q")
+    mgr = TokenBudgetManager(100)
+    assert tokens_used[0] == mgr.draft_tokens
+    assert limits[0] == mgr.search_limit(1)


### PR DESCRIPTION
## Summary
- add `TokenBudgetManager` to distribute tokens between draft, search, and refine steps
- wire token budgeting into `Neyra.iterative_response` and `DeepSearcher` for dynamic prompt sizing
- cover token budgeting with dedicated tests

## Testing
- `pytest tests/iteration -q`

------
https://chatgpt.com/codex/tasks/task_e_689453f5f00c83238293c9a4df9b2dde