### PR TITLE
Add grammar proofreading post-processing and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,4 @@ llama-cpp-python>=0.2.77
 
 schedule>=1.2.0
 requests>=2.31.0
+language_tool_python>=2.0.0

--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -2,6 +2,7 @@ from .self_corrector import SelfCorrector, SuggestionChooser
 from .verification_system import VerificationSystem, VerificationResult, verify_fact
 from .uncertainty_manager import UncertaintyManager
 from .timeline_checker import TimelineChecker
+from .grammar_proofreader import GrammarProofreader
 
 __all__ = [
     "SelfCorrector",
@@ -10,5 +11,6 @@ __all__ = [
     "VerificationResult",
     "UncertaintyManager",
     "TimelineChecker",
+    "GrammarProofreader",
     "verify_fact",
 ]

--- a/src/analysis/grammar_proofreader.py
+++ b/src/analysis/grammar_proofreader.py
@@ -1,0 +1,64 @@
+"""Simple grammar proofreader using language_tool_python when available."""
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import language_tool_python  # type: ignore
+except Exception:  # pragma: no cover
+    language_tool_python = None  # type: ignore
+
+
+class GrammarProofreader:
+    """Apply basic grammar and punctuation corrections."""
+
+    def __init__(self, language: str = "ru-RU") -> None:
+        self.language = language
+        self.tool = None
+        if language_tool_python is not None:  # pragma: no cover - optional
+            try:
+                self.tool = language_tool_python.LanguageTool(language)
+            except Exception:
+                self.tool = None
+
+    def proofread(self, text: str) -> Tuple[str, List[str]]:
+        """Return corrected text and list of applied corrections."""
+        if not text:
+            return text, []
+        corrections: List[str] = []
+
+        if self.tool is not None:  # pragma: no cover - optional
+            matches = self.tool.check(text)
+            try:
+                corrected = language_tool_python.utils.correct(text, matches)
+            except Exception:
+                corrected = text
+            for m in matches:
+                if m.replacements:
+                    corrections.append(f"{m.ruleId}:{m.replacements[0]}")
+                else:
+                    corrections.append(m.message)
+            return corrected, corrections
+
+        corrected = text
+        new = re.sub(r"\s+,", ",", corrected)
+        if new != corrected:
+            corrections.append("remove_space_before_comma")
+            corrected = new
+        new = re.sub(r",(?=\S)", ", ", corrected)
+        if new != corrected:
+            corrections.append("space_after_comma")
+            corrected = new
+        new = re.sub(r"\s+\.", ".", corrected)
+        if new != corrected:
+            corrections.append("remove_space_before_period")
+            corrected = new
+        replacements = {"пошол": "пошёл", "превет": "привет"}
+        for wrong, right in replacements.items():
+            pattern = re.compile(wrong, re.IGNORECASE)
+            new = pattern.sub(right, corrected)
+            if new != corrected:
+                corrections.append(f"{wrong}->{right}")
+                corrected = new
+        return corrected, corrections

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -8,14 +8,19 @@ from pathlib import Path
 
 from src.tags.enhanced_parser import EnhancedTagParser as TagParser, Tag
 from src.tags.command_executor import CommandExecutor
-from src.core.neyra_config import NEYRA_GREETING, NeyraPersonality
+from src.core.neyra_config import NEYRA_GREETING, NeyraPersonality, NeyraConfig
 from src.utils.encoding_detector import detect_encoding
 from src.utils.language_adapter import adapt_request, adapt_response
 from src.llm import BaseLLM, LLMFactory
 from src.interaction import RequestHistory
 from src.memory import CharacterMemory, WorldMemory, StyleMemory
 from .session_scoped_memory import SessionScopedMemory
-from src.analysis import VerificationSystem, VerificationResult, UncertaintyManager
+from src.analysis import (
+    VerificationSystem,
+    VerificationResult,
+    UncertaintyManager,
+    GrammarProofreader,
+)
 from types import SimpleNamespace
 
 from src.iteration import (
@@ -46,6 +51,8 @@ class Neyra:
         self.llm = self._load_llm()
         self.executor = CommandExecutor(self)
         self.personality = NeyraPersonality()
+        self.config = NeyraConfig()
+        self.grammar_proofreader = GrammarProofreader()
         self.known_books: List[str] = []
         self.session_memory = SessionScopedMemory()
         (
@@ -285,6 +292,9 @@ class Neyra:
         self, query: str, strategy: IterationStrategy | None = None
     ) -> str:
         """Return a refined response using iterative improvement pipeline."""
+        skip_check = "@Проверка:нет@" in query
+        if skip_check:
+            query = query.replace("@Проверка:нет@", "")
         self.logger.info("Starting iterative response")
         self.cache.cleanup()
         update_progress("start")
@@ -342,6 +352,10 @@ class Neyra:
             iteration += 1
         update_progress("finished", iteration)
         self.logger.info("Iterative response finished at iteration %s", iteration)
+        if self.config.enable_grammar_check and not skip_check:
+            response, corrections = self.grammar_proofreader.proofread(response)
+            if corrections:
+                self.logger.debug("Grammar corrections: %s", corrections)
         return response
 
     def _execute_neyra_command(self, command: str) -> str:

--- a/src/core/neyra_config.py
+++ b/src/core/neyra_config.py
@@ -88,6 +88,13 @@ class MemoryConfig:
     emotional_memory_depth: int = 100
 
 
+@dataclass
+class NeyraConfig:
+    """Общие переключатели функций Нейры."""
+
+    enable_grammar_check: bool = True
+
+
 # Глобальные константы
 NEYRA_VERSION = "0.1.0"
 NEYRA_GREETING = "Привет! Я Нейра, ваш персональный помощник для творчества! ✨"

--- a/tests/analysis/test_grammar_proofreader.py
+++ b/tests/analysis/test_grammar_proofreader.py
@@ -1,0 +1,18 @@
+from src.analysis.grammar_proofreader import GrammarProofreader
+
+
+def test_corrects_typo_and_spacing():
+    proofreader = GrammarProofreader()
+    text = "он пошол домой ,но забыл ключи"
+    corrected, changes = proofreader.proofread(text)
+    assert corrected == "он пошёл домой, но забыл ключи"
+    assert "пошол->пошёл" in changes
+    assert "remove_space_before_comma" in changes
+
+
+def test_returns_original_when_no_errors():
+    proofreader = GrammarProofreader()
+    text = "Он пошёл домой, но забыл ключи."
+    corrected, changes = proofreader.proofread(text)
+    assert corrected == text
+    assert changes == []


### PR DESCRIPTION
## Summary
- add GrammarProofreader with optional language_tool_python usage
- integrate grammar check into Neyra with config toggle and `@Проверка:нет@` tag
- cover typical typo and punctuation corrections with tests

## Testing
- `PYTHONPATH=. pytest tests/analysis/test_grammar_proofreader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68945f6f85488323a81fdfc68ab6cc5a