### PR TITLE
feat: enforce minimum iteration cycles with grammar pass

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -301,6 +301,8 @@ class Neyra:
         # Sync dynamic personality traits with iteration controller
         self.iteration_controller.personality = self.personality
         self.iteration_controller.emotional_state = self.emotional_state
+        self.iteration_controller.min_iterations = self.config.min_iterations
+        self.iteration_controller.reset()
         if strategy is not None:
             self.iteration_controller.max_iterations = strategy.max_iterations
             self.iteration_controller.max_critical_spaces = (
@@ -318,44 +320,48 @@ class Neyra:
         while True:
             update_progress("iteration", iteration)
             self.logger.info("Iteration %s started", iteration)
-            gaps = self.gap_analyzer.analyze(draft)
-            if not gaps:
-                self.logger.info("No gaps found, finishing at iteration %s", iteration)
-                break
-            search_results: List[Dict[str, Any]] = []
-            self.deep_searcher.current_queries = len(gaps)
-            search_limit = token_manager.search_limit(len(gaps))
-            for gap in gaps:
-                try:
-                    search_results.extend(
-                        self.deep_searcher.search(
-                            gap.claim,
-                            user_id=getattr(self, "current_user_id", "default"),
-                            limit=search_limit,
-                        )
-                    )
-                except Exception:
-                    continue
             previous = response
-            prev_tokens = self.llm_max_tokens
-            self.llm_max_tokens = token_manager.refine_tokens
-            response = self.response_enhancer.enhance(
-                response, search_results, IntegrationType.IMPORTANT_ADDITION
-            )
-            self.llm_max_tokens = prev_tokens
+            if iteration == 2 and self.config.enable_grammar_check and not skip_check:
+                response, corrections = self.grammar_proofreader.proofread(response)
+                if corrections:
+                    self.logger.debug("Grammar corrections: %s", corrections)
+            else:
+                gaps = self.gap_analyzer.analyze(draft)
+                if gaps:
+                    search_results: List[Dict[str, Any]] = []
+                    self.deep_searcher.current_queries = len(gaps)
+                    search_limit = token_manager.search_limit(len(gaps))
+                    for gap in gaps:
+                        try:
+                            search_results.extend(
+                                self.deep_searcher.search(
+                                    gap.claim,
+                                    user_id=getattr(self, "current_user_id", "default"),
+                                    limit=search_limit,
+                                )
+                            )
+                        except Exception:
+                            continue
+                    prev_tokens = self.llm_max_tokens
+                    self.llm_max_tokens = token_manager.refine_tokens
+                    response = self.response_enhancer.enhance(
+                        response, search_results, IntegrationType.IMPORTANT_ADDITION
+                    )
+                    self.llm_max_tokens = prev_tokens
+                else:
+                    self.logger.info("No gaps found at iteration %s", iteration)
             log_metrics(iteration, previous, response)
             self.logger.info("Iteration %s completed", iteration)
             draft = response
+            if iteration >= self.iteration_controller.min_iterations and self.iteration_controller.assess_quality(response) <= self.iteration_controller.max_critical_spaces:
+                break
             if not self.iteration_controller.should_iterate(response):
                 self.logger.info("Iteration controller stopped at %s", iteration)
                 break
             iteration += 1
         update_progress("finished", iteration)
         self.logger.info("Iterative response finished at iteration %s", iteration)
-        if self.config.enable_grammar_check and not skip_check:
-            response, corrections = self.grammar_proofreader.proofread(response)
-            if corrections:
-                self.logger.debug("Grammar corrections: %s", corrections)
+        self.iteration_controller._iterations = iteration
         return response
 
     def _execute_neyra_command(self, command: str) -> str:

--- a/src/core/neyra_config.py
+++ b/src/core/neyra_config.py
@@ -93,6 +93,7 @@ class NeyraConfig:
     """Общие переключатели функций Нейры."""
 
     enable_grammar_check: bool = True
+    min_iterations: int = 2
 
 
 # Глобальные константы

--- a/src/iteration/iteration_controller.py
+++ b/src/iteration/iteration_controller.py
@@ -25,11 +25,14 @@ class IterationController:
         Threshold for unresolved placeholders (``"___"``) allowed in a response
         before stopping the loop. When ``None`` the value from ``strategy`` is
         applied.
+    min_iterations:
+        Minimum number of iterations to perform regardless of detected gaps.
     """
 
     strategy: str = "standard"
     max_iterations: int | None = None
     max_critical_spaces: int | None = None
+    min_iterations: int = 0
     personality: NeyraPersonality | None = None
     emotional_state: str = "neutral"
     _iterations: int = 0
@@ -40,6 +43,10 @@ class IterationController:
             self.max_iterations = manager.max_iterations
         if self.max_critical_spaces is None:
             self.max_critical_spaces = manager.max_critical_spaces
+
+    def reset(self) -> None:
+        """Reset internal iteration counter."""
+        self._iterations = 0
 
     # ------------------------------------------------------------------
     def _priority_multiplier(self) -> float:
@@ -76,13 +83,14 @@ class IterationController:
     def should_iterate(self, text: str) -> bool:
         """Return ``True`` if another refinement iteration is required.
 
-        The decision is based on two criteria:
-
-        * the response still contains more than ``max_critical_spaces``
-          placeholders, indicating low quality;
-        * the number of iterations performed so far is less than
-          ``max_iterations``.
+        The loop will continue for at least ``min_iterations`` cycles.
+        After that it stops when the number of critical placeholders falls
+        below ``max_critical_spaces`` or ``max_iterations`` is reached.
         """
+
+        if self._iterations < self.min_iterations:
+            self._iterations += 1
+            return True
 
         if self._iterations >= self.max_iterations:
             return False

--- a/tests/iteration/test_min_iterations.py
+++ b/tests/iteration/test_min_iterations.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+prompt_toolkit = types.SimpleNamespace(
+    PromptSession=lambda *a, **k: None,
+    completion=types.SimpleNamespace(WordCompleter=lambda *a, **k: None),
+    history=types.SimpleNamespace(InMemoryHistory=lambda *a, **k: None),
+)
+sys.modules.setdefault("prompt_toolkit", prompt_toolkit)
+sys.modules.setdefault("prompt_toolkit.completion", prompt_toolkit.completion)
+sys.modules.setdefault("prompt_toolkit.history", prompt_toolkit.history)
+
+rich_console = types.SimpleNamespace(Console=lambda *a, **k: None)
+rich_markdown = types.SimpleNamespace(Markdown=lambda *a, **k: None)
+rich_panel = types.SimpleNamespace(Panel=lambda *a, **k: None)
+sys.modules.setdefault("rich.console", rich_console)
+sys.modules.setdefault("rich.markdown", rich_markdown)
+sys.modules.setdefault("rich.panel", rich_panel)
+sys.modules.setdefault("rich", types.SimpleNamespace(console=rich_console, markdown=rich_markdown, panel=rich_panel))
+
+from src.core.neyra_brain import Neyra
+
+
+def test_min_iterations_with_grammar(monkeypatch):
+    neyra = Neyra()
+    monkeypatch.setattr(neyra, "process_command", lambda q: "превет мир")
+    monkeypatch.setattr(neyra.gap_analyzer, "analyze", lambda draft: [])
+    monkeypatch.setattr(neyra.deep_searcher, "search", lambda *a, **k: [])
+    monkeypatch.setattr(
+        neyra.response_enhancer,
+        "enhance",
+        lambda text, results, integration, self_correct=True: text,
+    )
+
+    iterations = []
+    metrics = []
+
+    def fake_update(stage, iteration=None):
+        if stage == "iteration":
+            iterations.append(iteration)
+
+    def fake_metrics(iteration, prev, current):
+        metrics.append((iteration, prev, current))
+
+    monkeypatch.setattr("src.core.neyra_brain.update_progress", fake_update)
+    monkeypatch.setattr("src.core.neyra_brain.log_metrics", fake_metrics)
+
+    result = neyra.iterative_response("query")
+
+    assert iterations == [1, 2]
+    assert metrics[0] == (1, "превет мир", "превет мир")
+    assert metrics[1] == (2, "превет мир", "привет мир")
+    assert result == "привет мир"

--- a/tests/iteration/test_personality_influence.py
+++ b/tests/iteration/test_personality_influence.py
@@ -69,4 +69,4 @@ def test_personality_and_emotion_influence_iterations(monkeypatch):
     low_iters = _run_iterations(low)
 
     assert high_iters > low_iters
-    assert low_iters == 0
+    assert low_iters == 2


### PR DESCRIPTION
## Summary
- add `min_iterations` configuration and support in controller
- run grammar proofreader as a dedicated second iteration and store iteration count
- test minimum iterations and update personality influence expectations

## Testing
- `pytest tests/iteration`


------
https://chatgpt.com/codex/tasks/task_e_68946c41a2908323842a593ef9d1ee1e