### PR TITLE
feat: allow skipping grammar check

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -301,7 +301,9 @@ class Neyra:
         # Sync dynamic personality traits with iteration controller
         self.iteration_controller.personality = self.personality
         self.iteration_controller.emotional_state = self.emotional_state
-        self.iteration_controller.min_iterations = self.config.min_iterations
+        self.iteration_controller.min_iterations = (
+            1 if skip_check else self.config.min_iterations
+        )
         self.iteration_controller.reset()
         if strategy is not None:
             self.iteration_controller.max_iterations = strategy.max_iterations

--- a/tests/iteration/test_min_iterations.py
+++ b/tests/iteration/test_min_iterations.py
@@ -51,3 +51,42 @@ def test_min_iterations_with_grammar(monkeypatch):
     assert metrics[0] == (1, "превет мир", "превет мир")
     assert metrics[1] == (2, "превет мир", "привет мир")
     assert result == "привет мир"
+
+
+def test_skip_check_tag_disables_grammar(monkeypatch):
+    neyra = Neyra()
+    monkeypatch.setattr(neyra, "process_command", lambda q: "превет мир")
+    monkeypatch.setattr(neyra.gap_analyzer, "analyze", lambda draft: [])
+    monkeypatch.setattr(neyra.deep_searcher, "search", lambda *a, **k: [])
+    monkeypatch.setattr(
+        neyra.response_enhancer,
+        "enhance",
+        lambda text, results, integration, self_correct=True: text,
+    )
+    monkeypatch.setattr(
+        neyra.iteration_controller, "should_iterate", lambda text: False
+    )
+
+    called: list[str] = []
+
+    def fake_proofread(text: str):
+        called.append(text)
+        return text, []
+
+    monkeypatch.setattr(neyra.grammar_proofreader, "proofread", fake_proofread)
+
+    iterations: list[int] = []
+
+    def fake_update(stage, iteration=None):
+        if stage == "iteration":
+            iterations.append(iteration)
+
+    monkeypatch.setattr("src.core.neyra_brain.update_progress", fake_update)
+
+    result = neyra.iterative_response("@Проверка:нет@ query")
+
+    assert called == []
+    assert iterations == [1]
+    assert neyra.iteration_controller.min_iterations == 1
+    assert neyra.iteration_controller._iterations == 1
+    assert result == "превет мир"


### PR DESCRIPTION
## Summary
- honor `@Проверка:нет@` tag in iterative responses
- test grammar check skipping and minimum iteration override

## Testing
- `pytest tests/iteration/test_min_iterations.py -q`
- `pip install requests prompt_toolkit`
- `pip install pyyaml rich`
- `pytest tests/iteration -q`


------
https://chatgpt.com/codex/tasks/task_e_6894740eb98c8323a3687bafae3eb6fc