### PR TITLE
feat: add dynamic min-iteration tag

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -78,7 +78,9 @@ class Neyra:
             self.characters_memory, self.world_memory, self.style_memory
         )
         self.emotional_state = "любопытная"
-        self.iteration_controller = IterationController()
+        self.iteration_controller = IterationController(
+            min_iterations=self.config.min_iterations
+        )
         self.iteration_controller.personality = self.personality
         self.iteration_controller.emotional_state = self.emotional_state
         self._current_user_id = "default"

--- a/src/core/neyra_config.py
+++ b/src/core/neyra_config.py
@@ -90,7 +90,16 @@ class MemoryConfig:
 
 @dataclass
 class NeyraConfig:
-    """Общие переключатели функций Нейры."""
+    """Общие переключатели функций Нейры.
+
+    Attributes
+    ----------
+    enable_grammar_check:
+        Включать ли автоматическую проверку грамматики на второй итерации.
+    min_iterations:
+        Минимальное количество циклов улучшения, выполняемых даже при
+        отсутствии обнаруженных недочётов.
+    """
 
     enable_grammar_check: bool = True
     min_iterations: int = 2

--- a/src/tags/enhanced_parser.py
+++ b/src/tags/enhanced_parser.py
@@ -32,6 +32,7 @@ class EnhancedTagParser:
         # ``generate_content`` also exposes the topic via params
         "generate_content": r"@Сгенерируй:\s*(?P<topic>[^@]+)@",
         "iteration_strategy": r"@Итерация:\s*([^@]+)@",
+        "min_iterations": r"@Минимум:\s*(\d+)@",
     }
 
     #: block patterns like ``[Пример стиля автора, X]\n...\n[Пример окончен]``

--- a/src/tags/manager.py
+++ b/src/tags/manager.py
@@ -95,3 +95,26 @@ register_tag(
     iteration_strategy_handler,
     pattern=r"@Итерация:\s*([^@]+)@",
 )
+
+
+def min_iterations_handler(value: str, context: Dict[str, Any]) -> str:
+    """Handle tag to set minimum iteration count dynamically."""
+
+    neyra = context.get("neyra")
+    try:
+        count = int(value.strip())
+    except ValueError:
+        return "⚠️ Некорректное значение минимума итераций."
+
+    if neyra:
+        neyra.config.min_iterations = count
+        if hasattr(neyra, "iteration_controller"):
+            neyra.iteration_controller.min_iterations = count
+    return f"🔁 Минимальное количество итераций установлено: {count}"
+
+
+register_tag(
+    "min_iterations",
+    min_iterations_handler,
+    pattern=r"@Минимум:\s*(\d+)@",
+)

--- a/tests/tags/test_min_iterations_tag.py
+++ b/tests/tags/test_min_iterations_tag.py
@@ -1,0 +1,46 @@
+import sys
+import types
+
+prompt_toolkit = types.SimpleNamespace(
+    PromptSession=lambda *a, **k: None,
+    completion=types.SimpleNamespace(WordCompleter=lambda *a, **k: None),
+    history=types.SimpleNamespace(InMemoryHistory=lambda *a, **k: None),
+)
+sys.modules.setdefault("prompt_toolkit", prompt_toolkit)
+sys.modules.setdefault("prompt_toolkit.completion", prompt_toolkit.completion)
+sys.modules.setdefault("prompt_toolkit.history", prompt_toolkit.history)
+
+rich_console = types.SimpleNamespace(Console=lambda *a, **k: None)
+rich_markdown = types.SimpleNamespace(Markdown=lambda *a, **k: None)
+rich_panel = types.SimpleNamespace(Panel=lambda *a, **k: None)
+sys.modules.setdefault("rich.console", rich_console)
+sys.modules.setdefault("rich.markdown", rich_markdown)
+sys.modules.setdefault("rich.panel", rich_panel)
+sys.modules.setdefault("rich", types.SimpleNamespace(console=rich_console, markdown=rich_markdown, panel=rich_panel))
+
+from src.core.neyra_brain import Neyra
+
+
+def test_min_iterations_tag_applies(monkeypatch):
+    neyra = Neyra()
+    monkeypatch.setattr(neyra.draft_generator, "generate_draft", lambda text, memory: text)
+    monkeypatch.setattr(neyra.gap_analyzer, "analyze", lambda draft: [])
+    monkeypatch.setattr(neyra.deep_searcher, "search", lambda *a, **k: [])
+    monkeypatch.setattr(
+        neyra.response_enhancer,
+        "enhance",
+        lambda text, results, integration, self_correct=True: text,
+    )
+
+    iterations = []
+
+    def fake_update(stage, iteration=None):
+        if stage == "iteration":
+            iterations.append(iteration)
+
+    monkeypatch.setattr("src.core.neyra_brain.update_progress", fake_update)
+
+    neyra.iterative_response("@Минимум:3@")
+    assert neyra.config.min_iterations == 3
+    assert neyra.iteration_controller.min_iterations == 3
+    assert iterations == [1, 2, 3]


### PR DESCRIPTION
## Summary
- document `min_iterations` option and load it into the iteration controller
- allow runtime override via `@Минимум:<n>@` tag
- test iteration count adjustment through the new tag

## Testing
- `PYTHONPATH=. pytest tests/tags/test_min_iterations_tag.py tests/tags/test_iteration_strategy_tag.py tests/iteration/test_min_iterations.py`


------
https://chatgpt.com/codex/tasks/task_e_6894774f75788323a1e693edea9eeede