### PR TITLE
feat: model capability aware code routing

### DIFF
--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -8,7 +8,7 @@ ensemble aggregation.  The manager can also forward interaction results to
 :class:`~src.learning.learning_system.LearningSystem` for adaptive feedback.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
@@ -25,6 +25,7 @@ class ModelSpec:
     speed: float
     cost: float
     accuracy: float
+    capabilities: set[str] = field(default_factory=set)
     prompt_adapter: Optional[Callable[[str], str]] = None
 
     def adapt_prompt(self, prompt: str) -> str:
@@ -64,6 +65,7 @@ class LLMManager:
         cost: float,
         accuracy: float,
         prompt_adapter: Optional[Callable[[str], str]] = None,
+        capabilities: set[str] | None = None,
     ) -> None:
         """Register an ``llm`` with its performance characteristics."""
 
@@ -72,6 +74,7 @@ class LLMManager:
             speed=speed,
             cost=cost,
             accuracy=accuracy,
+            capabilities=capabilities or set(),
             prompt_adapter=prompt_adapter,
         )
 
@@ -98,6 +101,15 @@ class LLMManager:
                 if name == preferred:
                     adapted = spec.adapt_prompt(task.prompt)
                     return name, spec.llm, adapted
+
+        if task.request_type == "code":
+            code_models = [
+                (name, spec)
+                for name, spec in available
+                if "code" in spec.capabilities
+            ]
+            if code_models:
+                available = code_models
 
         def success_rate(model_name: str) -> float:
             metrics = self.model_metrics.get(model_name, {})

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from src.llm.manager import LLMManager, Task
 from src.llm.base_llm import BaseLLM
+from src.llm.qwen_coder_interface import QwenCoderLLM
 
 
 class DummyLLM(BaseLLM):
@@ -66,3 +67,27 @@ def test_ensemble_and_learning_integration() -> None:
     interaction = manager.learning_system.experience_buffer[0]
     assert interaction["context"]["model"] == "accurate"
     assert interaction["response"] == "accurate:prompt"
+
+
+def test_code_request_prefers_code_model() -> None:
+    manager = LLMManager()
+
+    general = DummyLLM("general")
+    coder = QwenCoderLLM("model.gguf")
+    coder.model = object()
+    coder._load_error = None
+
+    manager.register_model("general", general, speed=5, cost=1, accuracy=0.6)
+    manager.register_model(
+        "qwen_coder",
+        coder,
+        speed=5,
+        cost=1,
+        accuracy=0.5,
+        capabilities={"code"},
+    )
+
+    task = Task(prompt="print('hi')", request_type="code")
+    name, model, _ = manager.select_model(task)
+    assert name == "qwen_coder"
+    assert model is coder


### PR DESCRIPTION
## Summary
- allow `ModelSpec` to describe model capabilities
- prefer code-capable models for `request_type="code"`
- register Qwen coder with `capabilities={"code"}` and test code task routing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a798871883239e7cf2c14c0e1adb