### PR TITLE
Persist evolved neuron definitions

### DIFF
--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -198,6 +198,18 @@ class LearningSystem:
                 neuron_type, neuron_cls = result
                 NeuronFactory.register(neuron_type, neuron_cls)
                 self.adaptation_weights[reason] = count
+
+                instance = neuron_cls(id=neuron_type, type=neuron_type)
+                base_cls = neuron_cls.__bases__[0]
+                data = {
+                    "neuron_type": neuron_type,
+                    "base_class": f"{base_cls.__module__}.{base_cls.__name__}",
+                    "strength": getattr(instance, "strength", 0.5),
+                }
+                neuron_dir = Path("data/neurons")
+                neuron_dir.mkdir(parents=True, exist_ok=True)
+                (neuron_dir / f"{neuron_type}.json").write_text(json.dumps(data))
+
                 return neuron_type
         return None
 

--- a/src/neurons/__init__.py
+++ b/src/neurons/__init__.py
@@ -13,6 +13,9 @@ from .patterns import BehaviorPattern
 from .network import NeuronNetwork
 from .factory import NeuronFactory
 from .evolution import EvolutionConfig, evolve
+from .loader import load_neurons
+
+load_neurons()
 
 __all__ = [
     "Neuron",
@@ -25,4 +28,5 @@ __all__ = [
     "NeuronFactory",
     "EvolutionConfig",
     "evolve",
+    "load_neurons",
 ]

--- a/src/neurons/loader.py
+++ b/src/neurons/loader.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+
+from .factory import NeuronFactory
+
+
+def load_neurons(path: Path | str = Path("data/neurons")) -> None:
+    """Load persisted neuron classes from ``path`` and register them."""
+    neuron_dir = Path(path)
+    if not neuron_dir.exists():
+        return
+
+    for file in neuron_dir.glob("*.json"):
+        data = json.loads(file.read_text())
+        neuron_type = data.get("neuron_type") or file.stem
+        base_path = data.get("base_class")
+        if not base_path:
+            continue
+        module_name, class_name = base_path.rsplit(".", 1)
+        module = import_module(module_name)
+        base_cls = getattr(module, class_name)
+        strength = data.get("strength", 0.5)
+
+        def _make_init(base_cls: type, strength: float):
+            def __init__(self, *args: Any, strength: float = strength, **kwargs: Any):
+                base_cls.__init__(self, *args, **kwargs)
+                self.strength = strength
+            return __init__
+
+        init = _make_init(base_cls, strength)
+        neuron_cls = type(neuron_type, (base_cls,), {"__init__": init, "type": neuron_type})
+        NeuronFactory.register(neuron_type, neuron_cls)

--- a/tests/test_neuron_persistence.py
+++ b/tests/test_neuron_persistence.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.learning import LearningSystem
+from src.neurons import NeuronFactory
+from src.neurons.loader import load_neurons
+
+
+def test_neuron_persistence(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    system = LearningSystem()
+    ctx = {"start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("hi", "hello", -1, ctx)
+    neuron_type = system.create_new_neuron_type()
+    file_path = Path("data/neurons") / f"{neuron_type}.json"
+    assert file_path.exists()
+
+    NeuronFactory._registry.clear()  # type: ignore[attr-defined]
+    load_neurons()
+    neuron = NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
+    assert neuron.type == neuron_type


### PR DESCRIPTION
## Summary
- save evolved neuron classes to `data/neurons` for later reuse
- load saved neuron classes on startup via new `neurons.loader`
- verify persistence with a dedicated test

## Testing
- `pytest tests/test_neuron_persistence.py tests/test_learning/test_learning_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b2f12b4c8323af0f37c927d57d37