### PR TITLE
Log developer requests for unresolved failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 # Logs
 logs/*
 !logs/.gitkeep
+!logs/developer_requests.md
 *.log
 
 # Test and coverage outputs

--- a/logs/developer_requests.md
+++ b/logs/developer_requests.md
@@ -1,0 +1,3 @@
+# Developer Requests
+
+Entries in this file indicate failures that exceeded automated adaptation thresholds.

--- a/scripts/list_developer_requests.py
+++ b/scripts/list_developer_requests.py
@@ -1,0 +1,37 @@
+"""Summarize outstanding developer requests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+
+def main() -> None:
+    """Print the contents of ``logs/developer_requests.md``."""
+    path = ROOT / "logs" / "developer_requests.md"
+    if not path.exists():
+        print("No developer requests found.")
+        return
+
+    lines = [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith(("-", "*"))
+    ]
+    if not lines:
+        print("No developer requests found.")
+        return
+
+    print("Outstanding developer requests:")
+    for line in lines:
+        if line[0] in {"-", "*"}:
+            line = line[1:].strip()
+        print(f"- {line}")
+
+
+if __name__ == "__main__":  # pragma: no cover - helper script
+    main()

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -141,6 +141,24 @@ class LearningSystem:
         self.knowledge_base.add(entry)
         self.knowledge_base.save()
 
+        error_count = sum(
+            1 for e in self.failure_analysis if e.get("error_type") == error_type
+        )
+        weight = self.adaptation_weights.get(error_type, 0)
+        if error_count > weight:
+            neuron_type = self.create_new_neuron_type()
+            if neuron_type is None:
+                log_path = Path("logs/developer_requests.md")
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                with log_path.open("a", encoding="utf-8") as fh:
+                    fh.write(
+                        "- {err} failure on request `{req}`; consider tool/neuron: {rec}\n".format(
+                            err=error_type,
+                            req=interaction.get("request"),
+                            rec=entry["recommendation"],
+                        )
+                    )
+
     # ------------------------------------------------------------------
     def check_previous_failures(self, user_request: str) -> Optional[Dict[str, Any]]:
         """Return previous failure entry if the request was seen before."""


### PR DESCRIPTION
## Summary
- log unresolved error categories in developer_requests.md when automatic neuron creation fails
- add script to list outstanding developer requests
- track developer request log in repository

## Testing
- `pytest` *(fails: tests/test_neurons/test_evolution.py::test_evolve_creates_specialised_neuron_and_links)*


------
https://chatgpt.com/codex/tasks/task_e_6894b5e55d4083238916ca58206dbc4c