### PR TITLE
feat: add neuron plugin loading

### DIFF
--- a/neurons/plugins/sample_plugin.py
+++ b/neurons/plugins/sample_plugin.py
@@ -1,0 +1,18 @@
+"""Sample neuron plugin for Neira.
+
+This module demonstrates how to extend Neira with custom neuron types.
+Plugins placed in ``neurons/plugins`` are automatically discovered and
+registered by :class:`src.neurons.factory.NeuronFactory`.
+"""
+
+from src.neurons import Neuron
+
+
+class SamplePluginNeuron(Neuron):
+    """Simple neuron example used for plugin documentation."""
+
+    type = "sample_plugin"
+
+    def process(self, *args, **kwargs):
+        """No-op process method for demonstration purposes."""
+        return None

--- a/src/neurons/factory.py
+++ b/src/neurons/factory.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from typing import Any, Dict, Type
+from pathlib import Path
+import importlib.util
+import inspect
 
 from .base import Neuron
 
@@ -9,6 +12,36 @@ class NeuronFactory:
     """Factory for registering and creating neuron classes."""
 
     _registry: Dict[str, Type[Neuron]] = {}
+    plugins_dir: str = "neurons/plugins"
+
+    @classmethod
+    def load_plugins(cls, plugins_dir: str | None = None) -> None:
+        """Load neuron plugins from ``plugins_dir``.
+
+        Parameters
+        ----------
+        plugins_dir:
+            Directory containing plugin modules. Uses
+            :pyattr:`NeuronFactory.plugins_dir` by default.
+        """
+
+        directory = Path(plugins_dir or cls.plugins_dir)
+        if not directory.is_absolute():
+            directory = Path(__file__).resolve().parents[2] / directory
+        if not directory.exists():
+            return
+
+        for file in directory.glob("*.py"):
+            spec = importlib.util.spec_from_file_location(
+                f"neuron_plugin_{file.stem}", file
+            )
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                for _, obj in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(obj, Neuron) and obj is not Neuron:
+                        neuron_type = getattr(obj, "type", obj.__name__)
+                        cls.register(neuron_type, obj)
 
     @classmethod
     def register(cls, neuron_type: str, neuron_cls: Type[Neuron]) -> None:
@@ -25,5 +58,6 @@ class NeuronFactory:
             raise ValueError(f"Unknown neuron_type: {neuron_type}")
         return neuron_cls(*args, **kwargs)
 
+NeuronFactory.load_plugins()
 
 __all__ = ["NeuronFactory"]


### PR DESCRIPTION
## Summary
- allow NeuronFactory to auto-load neuron plugins from a configurable directory
- add sample neuron plugin demonstrating extension point

## Testing
- `pytest tests/test_neuron_persistence.py tests/test_learning/test_learning_system.py`


------
https://chatgpt.com/codex/tasks/task_e_6894bd0ad198832398030e974e5a808e