### PR TITLE
Track neuron metrics and decommission underperforming neurons

### DIFF
--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -41,6 +41,9 @@ class LearningSystem:
     style_memory: StyleMemory = field(default_factory=StyleMemory)
     response_cache: Dict[str, str] = field(default_factory=dict)
     knowledge_base: KnowledgeBase = field(default_factory=KnowledgeBase)
+    neuron_metrics: Dict[str, Dict[str, int]] = field(default_factory=dict)
+    neuron_use_limit: int = 5
+    neuron_success_threshold: float = 0.3
 
     # ------------------------------------------------------------------
     def learn_from_interaction(
@@ -187,6 +190,32 @@ class LearningSystem:
         return self.response_cache.get(user_request)
 
     # ------------------------------------------------------------------
+    def record_neuron_usage(self, neuron_type: str, success: bool) -> None:
+        """Update metrics for ``neuron_type`` and decommission if underperforming."""
+
+        metrics = self.neuron_metrics.setdefault(
+            neuron_type, {"activations": 0, "positive": 0, "negative": 0}
+        )
+        metrics["activations"] += 1
+        if success:
+            metrics["positive"] += 1
+        else:
+            metrics["negative"] += 1
+
+        uses = metrics["activations"]
+        if uses >= self.neuron_use_limit:
+            rate = metrics["positive"] / uses if uses else 0.0
+            if rate < self.neuron_success_threshold:
+                NeuronFactory.deregister(neuron_type)
+                log_path = Path("logs/developer_requests.md")
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                with log_path.open("a", encoding="utf-8") as fh:
+                    fh.write(
+                        f"- Neuron `{neuron_type}` decommissioned after {uses} uses (success rate {rate:.2f}); redesign recommended\n"
+                    )
+                del self.neuron_metrics[neuron_type]
+
+    # ------------------------------------------------------------------
     def create_new_neuron_type(self) -> Optional[str]:
         """Create and register a new neuron type if needed.
 
@@ -227,7 +256,11 @@ class LearningSystem:
                 neuron_dir = Path("data/neurons")
                 neuron_dir.mkdir(parents=True, exist_ok=True)
                 (neuron_dir / f"{neuron_type}.json").write_text(json.dumps(data))
-
+                self.neuron_metrics[neuron_type] = {
+                    "activations": 0,
+                    "positive": 0,
+                    "negative": 0,
+                }
                 return neuron_type
         return None
 
@@ -240,6 +273,9 @@ class LearningSystem:
             "success_metrics": self.success_metrics,
             "failure_analysis": self.failure_analysis,
             "adaptation_weights": self.adaptation_weights,
+            "neuron_metrics": self.neuron_metrics,
+            "neuron_use_limit": self.neuron_use_limit,
+            "neuron_success_threshold": self.neuron_success_threshold,
         }
         Path(path).write_text(json.dumps(data))
 
@@ -254,6 +290,9 @@ class LearningSystem:
         instance.success_metrics = data.get("success_metrics", {})
         instance.failure_analysis = data.get("failure_analysis", [])
         instance.adaptation_weights = data.get("adaptation_weights", {})
+        instance.neuron_metrics = data.get("neuron_metrics", {})
+        instance.neuron_use_limit = data.get("neuron_use_limit", 5)
+        instance.neuron_success_threshold = data.get("neuron_success_threshold", 0.3)
         return instance
 
 

--- a/src/neurons/factory.py
+++ b/src/neurons/factory.py
@@ -50,6 +50,12 @@ class NeuronFactory:
         cls._registry[neuron_type] = neuron_cls
 
     @classmethod
+    def deregister(cls, neuron_type: str) -> None:
+        """Remove ``neuron_type`` from the registry if present."""
+
+        cls._registry.pop(neuron_type, None)
+
+    @classmethod
     def create(cls, neuron_type: str, *args: Any, **kwargs: Any) -> Neuron:
         """Instantiate the neuron associated with ``neuron_type``."""
 

--- a/tests/test_learning/test_learning_system.py
+++ b/tests/test_learning/test_learning_system.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from src.learning import LearningSystem
 from src.neurons import NeuronFactory
 from src.memory import StyleMemory
@@ -36,6 +40,11 @@ def test_create_new_neuron_type_registers() -> None:
     neuron_type = system.create_new_neuron_type()
     neuron = NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
     assert neuron.type == neuron_type
+    assert system.neuron_metrics[neuron_type] == {
+        "activations": 0,
+        "positive": 0,
+        "negative": 0,
+    }
 
 
 def test_save_and_load_state_roundtrip(tmp_path) -> None:
@@ -48,6 +57,28 @@ def test_save_and_load_state_roundtrip(tmp_path) -> None:
     assert loaded.experience_buffer == system.experience_buffer
     assert loaded.success_metrics == system.success_metrics
     assert loaded.failure_analysis == system.failure_analysis
+    assert loaded.neuron_metrics == system.neuron_metrics
+
+
+def test_neuron_decommission_logs_and_removes() -> None:
+    system = LearningSystem()
+    ctx = {"start_time": 0.0, "end_time": 0.1}
+    system.learn_from_interaction("hi", "hello", -1, ctx)
+    neuron_type = system.create_new_neuron_type()
+    system.neuron_use_limit = 3
+    system.neuron_success_threshold = 0.5
+
+    log_path = Path("logs/developer_requests.md")
+    if log_path.exists():
+        log_path.unlink()
+
+    for _ in range(3):
+        system.record_neuron_usage(neuron_type, False)
+
+    with pytest.raises(ValueError):
+        NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
+    assert log_path.exists()
+    assert neuron_type in log_path.read_text()
 
 
 def test_positive_feedback_saves_user_style(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- track per-neuron activations and success metrics in `LearningSystem`
- auto-decommission neurons that miss success thresholds and log developer requests
- expose `NeuronFactory.deregister` and add tests for neuron tracking and removal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c1185f288323aa8df05547135a6b