### PR TITLE
Add contradiction detection and diplomatic dialogue

### DIFF
--- a/src/interaction/dialog_controller.py
+++ b/src/interaction/dialog_controller.py
@@ -77,5 +77,14 @@ class DialogController:
         else:
             self.console.print(message)
 
+    #: маркеры, указывающие на противоречие между вводом и ответом
+    CONTRADICTION_MARKERS = ("[contradiction]", "[противоречие]", "<!>")
+
+    def detect_contradiction(self, user_input: str, response: str) -> bool:
+        """Проверяет текст на наличие маркеров противоречия."""
+
+        text = f"{user_input} {response}".lower()
+        return any(marker in text for marker in self.CONTRADICTION_MARKERS)
+
 
 __all__ = ["DialogController"]

--- a/src/interaction/diplomatic_dialogue.py
+++ b/src/interaction/diplomatic_dialogue.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from src.utils.source_manager import SourceManager
+
+
+class DiplomaticDialogue:
+    """Диалог расследования с обменом источниками."""
+
+    start_template = "Начато расследование: {topic}"
+    progress_template = "Источники:\n{sources}"
+
+    def __init__(self, source_manager: SourceManager | None = None) -> None:
+        self.source_manager = source_manager or SourceManager()
+
+    def start_investigation(
+        self,
+        topic: str,
+        sources: Iterable[Tuple[str, str, float]] = (),
+    ) -> str:
+        """Регистрирует источники и запускает расследование."""
+
+        for summary, path, reliability in sources:
+            self.source_manager.register(summary, path, reliability)
+        return self.start_template.format(topic=topic)
+
+    def continue_research(self) -> str:
+        """Возвращает список известных источников."""
+
+        entries = self.source_manager.all()
+        if not entries:
+            return "Источники не найдены"
+        lines = [f"[{i + 1}] {s.summary} ({s.path})" for i, s in enumerate(entries)]
+        return self.progress_template.format(sources="\n".join(lines))
+
+
+__all__ = ["DiplomaticDialogue"]

--- a/tests/interaction/test_dialogue_investigation.py
+++ b/tests/interaction/test_dialogue_investigation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from src.interaction.dialog_controller import DialogController
+from src.interaction.diplomatic_dialogue import DiplomaticDialogue
+from src.utils.source_manager import SourceManager
+
+
+def test_detect_contradiction_marker() -> None:
+    controller = DialogController(neyra=object())
+    assert controller.detect_contradiction("вопрос", "ответ [contradiction]")
+
+
+def test_detect_contradiction_absent() -> None:
+    controller = DialogController(neyra=object())
+    assert not controller.detect_contradiction("вопрос", "обычный ответ")
+
+
+def test_diplomatic_dialogue_registers_sources() -> None:
+    manager = SourceManager()
+    dialogue = DiplomaticDialogue(source_manager=manager)
+    dialogue.start_investigation("тема", [("a", "http://a", 1.0)])
+    result = dialogue.continue_research()
+    assert "a" in result and "http://a" in result


### PR DESCRIPTION
## Summary
- detect contradictions via simple markers in dialog controller
- add DiplomaticDialogue for investigations with source sharing
- cover new interaction flow with tests

## Testing
- `pytest tests/interaction/test_dialogue_investigation.py`
- `pytest` *(fails: RuntimeError: ebooklib is required; RuntimeError: python-docx is required; RuntimeError: PyPDF2 is required; TypeError: 'NoneType' object is not callable; AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68957d8158e88323bd0253e92565ee4e