### PR TITLE
Add resource manager for iteration configuration

### DIFF
--- a/src/iteration/__init__.py
+++ b/src/iteration/__init__.py
@@ -14,6 +14,7 @@ from .strategy_manager import AdaptiveIterationManager, IterationStrategy
 from .resource_iterator import ResourceAwareIterator
 from .low_resource_optimizer import LowResourceOptimizer
 from .smart_cache import SmartCache
+from .resource_manager import ResourceManager, IterationConfig
 from .metrics import similarity, length, corrected_errors, log_metrics
 from .memory_inspector import MemoryInspector
 from .token_budget_manager import TokenBudgetManager
@@ -33,6 +34,8 @@ __all__ = [
     "ResourceAwareIterator",
     "LowResourceOptimizer",
     "SmartCache",
+    "ResourceManager",
+    "IterationConfig",
     "MemoryInspector",
     "TokenBudgetManager",
     "similarity",

--- a/src/iteration/iterative_generator.py
+++ b/src/iteration/iterative_generator.py
@@ -15,6 +15,7 @@ except Exception:  # noqa: BLE001 - fallback when requests is missing
     DeepSearcher = None  # type: ignore
 from .response_enhancer import ResponseEnhancer, IntegrationType
 from .iteration_controller import IterationController
+from .resource_manager import ResourceManager
 
 
 class IterativeGenerator:
@@ -38,6 +39,7 @@ class IterativeGenerator:
         iteration_controller: IterationController | None = None,
         source_manager: SourceManager | None = None,
         mode: ResponseMode | None = None,
+        resource_manager: ResourceManager | None = None,
     ) -> None:
         self.draft_generator = draft_generator or DraftGenerator()
         self.gap_analyzer = gap_analyzer or GapAnalyzer()
@@ -46,7 +48,14 @@ class IterativeGenerator:
         else:
             self.deep_searcher = DeepSearcher() if DeepSearcher else None
         self.response_enhancer = response_enhancer or ResponseEnhancer()
-        self.iteration_controller = iteration_controller or IterationController()
+        self.resource_manager = resource_manager or ResourceManager()
+        if iteration_controller is not None:
+            self.iteration_controller = iteration_controller
+        else:
+            cfg = self.resource_manager.get_config()
+            self.iteration_controller = IterationController(
+                max_iterations=cfg.max_iterations
+            )
         self.source_manager = source_manager or SourceManager()
         self.mode = mode or HiddenSourcesMode()
 

--- a/src/iteration/resource_iterator.py
+++ b/src/iteration/resource_iterator.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Mapping, Any
 
 from .low_resource_optimizer import LowResourceOptimizer
+from .resource_manager import ResourceManager, IterationConfig
 
 
 class ResourceAwareIterator:
@@ -18,10 +19,36 @@ class ResourceAwareIterator:
         the time budget in seconds.
     """
 
-    def __init__(self, resources: Mapping[str, float]) -> None:
-        self.resources = dict(resources)
-        self.optimizer = LowResourceOptimizer(self.resources)
-        self.config = self.optimizer.suggest()
+    def __init__(
+        self,
+        resources: Mapping[str, float] | None = None,
+        resource_manager: ResourceManager | None = None,
+    ) -> None:
+        """Create iterator from explicit resources or a ``ResourceManager``.
+
+        When ``resources`` are provided the behaviour mirrors the legacy
+        implementation and :class:`LowResourceOptimizer` is used to create a
+        configuration.  Otherwise the supplied ``resource_manager`` (or a new
+        instance) determines both available resources and the
+        :class:`IterationConfig`.
+        """
+
+        if resources is not None:
+            self.resources = dict(resources)
+            optimizer = LowResourceOptimizer(self.resources)
+            suggestion = optimizer.suggest()
+            self.config = IterationConfig(
+                max_iterations=4,
+                parallel=suggestion.get("parallel", True),
+                cache=suggestion.get("cache", {}),
+            )
+        else:
+            self.resource_manager = resource_manager or ResourceManager()
+            self.config = self.resource_manager.get_config()
+            self.resources: dict[str, Any] = {
+                "gpu": self.resource_manager.gpu_memory,
+                "cpu": self.resource_manager.cpu_cores,
+            }
 
     # ------------------------------------------------------------------
     def plan(self, per_iteration: Mapping[str, float]) -> list[int]:

--- a/src/iteration/resource_manager.py
+++ b/src/iteration/resource_manager.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Simple resource detection and iteration configuration utilities."""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+import os
+
+
+@dataclass
+class IterationConfig:
+    """Configuration describing how iterative components should behave.
+
+    Attributes
+    ----------
+    max_iterations:
+        Upper bound for the number of refinement iterations.
+    parallel:
+        Whether expensive operations are allowed to run concurrently.
+    cache:
+        Dictionary describing cache limits. ``"hot_limit"`` and ``"warm_limit"``
+        are the primary keys used by :class:`SmartCache`.
+    """
+
+    max_iterations: int
+    parallel: bool
+    cache: Dict[str, int]
+
+    # Provide dictionary-like access used in existing code base
+    def __getitem__(self, key: str) -> Any:  # pragma: no cover - trivial
+        return getattr(self, key)
+
+    def get(self, key: str, default: Any | None = None) -> Any:  # pragma: no cover
+        return getattr(self, key, default)
+
+
+class ResourceManager:
+    """Evaluate available resources and derive :class:`IterationConfig`."""
+
+    def __init__(self, gpu_memory: float | None = None, cpu_cores: int | None = None) -> None:
+        self.gpu_memory = gpu_memory if gpu_memory is not None else self._detect_gpu_memory()
+        self.cpu_cores = cpu_cores if cpu_cores is not None else self._detect_cpu_cores()
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _detect_gpu_memory() -> float:
+        """Return total memory of the first CUDA device in GB.
+
+        When CUDA or the ``torch`` package is unavailable ``0`` is returned. The
+        implementation intentionally remains lightweight as unit tests provide
+        explicit values.
+        """
+
+        try:  # pragma: no cover - hardware specific
+            import torch
+
+            if torch.cuda.is_available():
+                # ``mem_get_info`` returns ``(free, total)`` in bytes
+                _, total = torch.cuda.mem_get_info()  # type: ignore[call-arg]
+                return total / (1024 ** 3)
+        except Exception:  # pragma: no cover - optional dependency
+            return 0.0
+        return 0.0
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _detect_cpu_cores() -> int:
+        """Return the number of available CPU cores."""
+
+        return os.cpu_count() or 1
+
+    # ------------------------------------------------------------------
+    def get_config(self) -> IterationConfig:
+        """Return a configuration tuned to detected resources."""
+
+        gpu = self.gpu_memory
+        cpu = self.cpu_cores
+
+        if gpu < 4 or cpu < 4:
+            config = IterationConfig(
+                max_iterations=2,
+                parallel=False,
+                cache={"hot_limit": 4, "warm_limit": 16},
+            )
+        elif gpu < 8 or cpu < 8:
+            config = IterationConfig(
+                max_iterations=4,
+                parallel=False,
+                cache={"hot_limit": 8, "warm_limit": 32},
+            )
+        else:
+            config = IterationConfig(
+                max_iterations=8,
+                parallel=True,
+                cache={"hot_limit": 32, "warm_limit": 128},
+            )
+        return config
+
+
+__all__ = ["ResourceManager", "IterationConfig"]

--- a/tests/iteration/test_resource_manager.py
+++ b/tests/iteration/test_resource_manager.py
@@ -1,0 +1,31 @@
+from src.iteration.resource_manager import ResourceManager
+from src.iteration import ResourceAwareIterator, IterativeGenerator
+
+
+def test_low_resource_config() -> None:
+    manager = ResourceManager(gpu_memory=2, cpu_cores=2)
+    cfg = manager.get_config()
+    assert cfg.max_iterations == 2
+    assert cfg.parallel is False
+    assert cfg.cache["hot_limit"] == 4
+
+
+def test_high_resource_config() -> None:
+    manager = ResourceManager(gpu_memory=16, cpu_cores=16)
+    cfg = manager.get_config()
+    assert cfg.max_iterations == 8
+    assert cfg.parallel is True
+    assert cfg.cache["hot_limit"] == 32
+
+
+def test_integration_with_iterator() -> None:
+    manager = ResourceManager(gpu_memory=2, cpu_cores=2)
+    iterator = ResourceAwareIterator(resource_manager=manager)
+    assert iterator.config.max_iterations == 2
+    assert iterator.config.parallel is False
+
+
+def test_iterative_generator_uses_manager() -> None:
+    manager = ResourceManager(gpu_memory=2, cpu_cores=2)
+    generator = IterativeGenerator(resource_manager=manager)
+    assert generator.iteration_controller.max_iterations == 2


### PR DESCRIPTION
## Summary
- add `ResourceManager` and `IterationConfig` to derive iteration limits, parallelism and cache sizes from GPU memory and CPU cores
- integrate `ResourceManager` with `ResourceAwareIterator` and `IterativeGenerator`
- cover resource-based configuration with new tests

## Testing
- `pytest tests/iteration/test_resource_manager.py tests/iteration/test_low_resource_optimizer.py tests/iteration/test_resource_iterator.py tests/iteration/test_parallel_search.py tests/iteration/test_iterative_generator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689584e50bd08323bb1ce9b79efbb8b1