### PR TITLE
Add personality style adapter

### DIFF
--- a/src/interaction/personality_adapter.py
+++ b/src/interaction/personality_adapter.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Adapt response tone based on context and iteration count."""
+
+from typing import Any
+
+# Predefined response styles.
+STYLES: dict[str, str] = {
+    "confident_but_open": "I am confident in this information, but open to feedback.",
+    "curious_investigator": "Let's explore this further with curiosity.",
+    "respectful_collaboration": "Working together respectfully for the best answer.",
+    "default_helpful": "Here's what I found.",
+}
+
+
+def adapt_response_style(context: Any, iteration_count: int) -> str:
+    """Return a style label for a response.
+
+    Parameters
+    ----------
+    context:
+        Arbitrary context data that may include a ``tone`` hint.
+    iteration_count:
+        Number of refinement iterations performed during generation.
+    """
+
+    tone = getattr(context, "get", lambda key, default=None: default)("tone", None)
+
+    if tone == "curious":
+        return "curious_investigator"
+    if tone == "collaborative":
+        return "respectful_collaboration"
+    if iteration_count > 0:
+        return "confident_but_open"
+    return "default_helpful"
+
+
+__all__ = ["adapt_response_style", "STYLES"]

--- a/src/iteration/iterative_generator.py
+++ b/src/iteration/iterative_generator.py
@@ -6,6 +6,7 @@ from typing import Any, List
 
 from src.utils.source_manager import SourceManager
 from src.interaction.mode_controller import HiddenSourcesMode, ResponseMode
+from src.interaction.personality_adapter import adapt_response_style
 
 from .draft_generator import DraftGenerator
 from .gap_analyzer import GapAnalyzer, KnowledgeGap
@@ -68,6 +69,7 @@ class IterativeGenerator:
         if hasattr(self.iteration_controller, "reset"):
             self.iteration_controller.reset()
 
+        iterations = 0
         while self.iteration_controller.should_iterate(draft):
             gaps: List[KnowledgeGap] = self.gap_analyzer.analyze(draft)
 
@@ -88,9 +90,12 @@ class IterativeGenerator:
                 search_results,
                 IntegrationType.IMPORTANT_ADDITION,
             )
+            iterations += 1
 
         sources = self.source_manager.all()
-        return self.mode.format_response(draft, sources)
+        style = adapt_response_style(context, iterations)
+        response = self.mode.format_response(draft, sources)
+        return f"[{style}] {response}"
 
 
 __all__ = ["IterativeGenerator"]

--- a/tests/interaction/test_mode_controller.py
+++ b/tests/interaction/test_mode_controller.py
@@ -71,4 +71,4 @@ def test_iterative_generator_uses_provided_mode() -> None:
     )
 
     result = generator.generate_response("q", {})
-    assert result == "answer\n\nSources:\n[1] a (http://a)"
+    assert result == "[default_helpful] answer\n\nSources:\n[1] a (http://a)"

--- a/tests/interaction/test_personality_adapter.py
+++ b/tests/interaction/test_personality_adapter.py
@@ -1,0 +1,44 @@
+from src.interaction.personality_adapter import adapt_response_style
+from src.iteration.iterative_generator import IterativeGenerator
+from src.iteration.iteration_controller import IterationController
+
+
+def test_adapt_response_style_basic() -> None:
+    assert adapt_response_style({}, 0) == "default_helpful"
+    assert adapt_response_style({}, 1) == "confident_but_open"
+    assert adapt_response_style({"tone": "curious"}, 1) == "curious_investigator"
+    assert adapt_response_style({"tone": "collaborative"}, 3) == "respectful_collaboration"
+
+
+def test_iterative_generator_includes_style(monkeypatch) -> None:
+    class DummyDraftGenerator:
+        def generate_draft(self, query, context):
+            return "draft ___"
+
+    class DummyGapAnalyzer:
+        def analyze(self, draft):
+            if "___" in draft:
+                from src.iteration.gap_analyzer import KnowledgeGap
+
+                return [KnowledgeGap(claim="info", questions=[], confidence=0.0)]
+            return []
+
+    class DummyDeepSearcher:
+        def search(self, query, user_id=None, limit=None):
+            return [{"content": "resolved"}]
+
+    class DummyEnhancer:
+        def enhance(self, draft, search_results, integration, self_correct=True):
+            return draft.replace("___", search_results[0]["content"])
+
+    controller = IterationController(max_iterations=3, max_critical_spaces=0)
+    generator = IterativeGenerator(
+        draft_generator=DummyDraftGenerator(),
+        gap_analyzer=DummyGapAnalyzer(),
+        deep_searcher=DummyDeepSearcher(),
+        response_enhancer=DummyEnhancer(),
+        iteration_controller=controller,
+    )
+
+    result = generator.generate_response("question", {})
+    assert result == "[confident_but_open] draft resolved"

--- a/tests/iteration/test_iterative_generator.py
+++ b/tests/iteration/test_iterative_generator.py
@@ -41,5 +41,5 @@ def test_iterative_generator_resolves_gap_and_stops():
 
     result = generator.generate_response("question", {})
 
-    assert result == "draft resolved"
+    assert result == "[confident_but_open] draft resolved"
     assert generator.deep_searcher.queries == ["info"]


### PR DESCRIPTION
## Summary
- add personality adapter to select response styles
- integrate adapter into iterative generator
- cover behavior with new tests

## Testing
- `pytest tests/interaction/test_personality_adapter.py tests/interaction/test_mode_controller.py tests/iteration/test_iterative_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_689588ad63808323b1c32c4abf4ba61e