### PR TITLE
Add pluggable hook system for iterative generation

### DIFF
--- a/plugins/example_plugin.py
+++ b/plugins/example_plugin.py
@@ -1,0 +1,17 @@
+from src.plugins import Plugin
+
+
+class ExamplePlugin(Plugin):
+    """Small plugin used in tests to record hook execution."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, object]] = []
+
+    def on_draft(self, draft, context):  # pragma: no cover - exercised in tests
+        self.events.append(("draft", draft))
+
+    def on_gap_analysis(self, draft, gaps):  # pragma: no cover - exercised in tests
+        self.events.append(("gap", len(gaps)))
+
+    def on_finalize(self, response):  # pragma: no cover - exercised in tests
+        self.events.append(("final", response))

--- a/src/iteration/iterative_generator.py
+++ b/src/iteration/iterative_generator.py
@@ -10,6 +10,7 @@ from src.monitoring.metrics_monitor import MetricsMonitor
 from src.utils.source_manager import SourceManager
 from src.interaction.mode_controller import HiddenSourcesMode, ResponseMode
 from src.interaction.personality_adapter import adapt_response_style
+from src.plugins import PluginManager
 
 from .draft_generator import DraftGenerator
 from .gap_analyzer import GapAnalyzer, KnowledgeGap
@@ -45,6 +46,7 @@ class IterativeGenerator:
         mode: ResponseMode | None = None,
         resource_manager: ResourceManager | None = None,
         metrics_monitor: MetricsMonitor | None = None,
+        plugin_manager: PluginManager | None = None,
     ) -> None:
         self.draft_generator = draft_generator or DraftGenerator()
         self.gap_analyzer = gap_analyzer or GapAnalyzer()
@@ -64,6 +66,7 @@ class IterativeGenerator:
         self.source_manager = source_manager or SourceManager()
         self.mode = mode or HiddenSourcesMode()
         self.metrics_monitor = metrics_monitor
+        self.plugin_manager = plugin_manager or PluginManager()
 
     # ------------------------------------------------------------------
     def generate_response(self, query: str, context: Any) -> str:
@@ -71,6 +74,8 @@ class IterativeGenerator:
 
         start_time = time.perf_counter()
         draft = self.draft_generator.generate_draft(query, context)
+        if self.plugin_manager:
+            self.plugin_manager.on_draft(draft, context)
 
         if hasattr(self.iteration_controller, "reset"):
             self.iteration_controller.reset()
@@ -79,6 +84,8 @@ class IterativeGenerator:
         rules_refs: List[str] = []
         while self.iteration_controller.should_iterate(draft):
             gaps: List[KnowledgeGap] = self.gap_analyzer.analyze(draft)
+            if self.plugin_manager:
+                self.plugin_manager.on_gap_analysis(draft, gaps)
 
             search_results = []
             if self.deep_searcher is not None:
@@ -108,6 +115,8 @@ class IterativeGenerator:
         sources = self.source_manager.all()
         style = adapt_response_style(context, iterations)
         response = self.mode.format_response(draft, sources, rules_refs)
+        if self.plugin_manager:
+            self.plugin_manager.on_finalize(response)
 
         if self.metrics_monitor:
             duration = time.perf_counter() - start_time

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,4 @@
+from .plugin_base import Plugin
+from .plugin_manager import PluginManager
+
+__all__ = ["Plugin", "PluginManager"]

--- a/src/plugins/plugin_base.py
+++ b/src/plugins/plugin_base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Base class for simple hook-based plugins."""
+
+from typing import Any, List
+
+
+class Plugin:
+    """Minimal plugin interface used by :class:`PluginManager`.
+
+    Subclasses can override any of the hook methods to participate in
+    the different stages of :class:`IterativeGenerator`.
+    """
+
+    def on_draft(self, draft: str, context: Any) -> None:  # pragma: no cover - default noop
+        """Called after the initial draft has been generated."""
+
+    def on_gap_analysis(self, draft: str, gaps: List[Any]) -> None:  # pragma: no cover
+        """Called after gaps have been analysed for ``draft``."""
+
+    def on_finalize(self, response: str) -> None:  # pragma: no cover
+        """Called with the final response before it is returned."""

--- a/src/plugins/plugin_manager.py
+++ b/src/plugins/plugin_manager.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Simple manager that loads and executes plugin hooks."""
+
+from pathlib import Path
+import importlib.util
+import inspect
+from typing import List
+
+from .plugin_base import Plugin
+
+
+class PluginManager:
+    """Discover and manage plugins located in a directory."""
+
+    def __init__(self, plugin_dir: str | Path = "plugins") -> None:
+        self.plugin_dir = Path(plugin_dir)
+        self.plugins: List[Plugin] = []
+        self.load_plugins()
+
+    # ------------------------------------------------------------------
+    def load_plugins(self) -> None:
+        """Import all plugin modules from ``self.plugin_dir``."""
+
+        if not self.plugin_dir.exists():
+            return
+
+        for path in self.plugin_dir.glob("*.py"):
+            if path.name.startswith("_"):
+                continue
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)  # type: ignore[call-arg]
+                for _, obj in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(obj, Plugin) and obj is not Plugin:
+                        try:
+                            self.plugins.append(obj())
+                        except Exception:
+                            continue
+
+    # ------------------------------------------------------------------
+    def run_hook(self, hook: str, *args, **kwargs) -> None:
+        for plugin in self.plugins:
+            func = getattr(plugin, hook, None)
+            if callable(func):
+                func(*args, **kwargs)
+
+    # Convenience wrappers ------------------------------------------------
+    def on_draft(self, draft: str, context) -> None:
+        self.run_hook("on_draft", draft, context)
+
+    def on_gap_analysis(self, draft: str, gaps) -> None:
+        self.run_hook("on_gap_analysis", draft, gaps)
+
+    def on_finalize(self, response: str) -> None:
+        self.run_hook("on_finalize", response)
+
+
+__all__ = ["PluginManager", "Plugin"]

--- a/tests/plugins/test_plugin_system.py
+++ b/tests/plugins/test_plugin_system.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+import sys
+
+# Ensure project root is importable
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.plugins import PluginManager
+from src.iteration.iterative_generator import IterativeGenerator
+
+
+class DummyDraftGenerator:
+    def generate_draft(self, query, context):
+        return "draft"
+
+
+class DummyGapAnalyzer:
+    def analyze(self, draft):
+        return []
+
+
+class DummyIterationController:
+    def __init__(self):
+        self._called = 0
+
+    def should_iterate(self, draft):
+        self._called += 1
+        return self._called == 1
+
+    def reset(self):
+        self._called = 0
+
+    def assess_quality(self, draft):
+        return 1
+
+
+class DummyResponseEnhancer:
+    def enhance(self, draft, search_results, integration_type):
+        return draft
+
+
+def test_plugin_manager_loads_and_runs_hooks():
+    plugin_dir = Path(__file__).resolve().parents[2] / "plugins"
+    manager = PluginManager(plugin_dir)
+    assert manager.plugins, "plugin was not loaded"
+    plugin = manager.plugins[0]
+
+    manager.on_draft("d", {})
+    manager.on_gap_analysis("d", [])
+    manager.on_finalize("r")
+
+    assert [e[0] for e in plugin.events] == ["draft", "gap", "final"]
+
+
+def test_iterative_generator_triggers_plugin_hooks():
+    plugin_dir = Path(__file__).resolve().parents[2] / "plugins"
+    manager = PluginManager(plugin_dir)
+    plugin = manager.plugins[0]
+
+    generator = IterativeGenerator(
+        draft_generator=DummyDraftGenerator(),
+        gap_analyzer=DummyGapAnalyzer(),
+        response_enhancer=DummyResponseEnhancer(),
+        iteration_controller=DummyIterationController(),
+        deep_searcher=None,
+        plugin_manager=manager,
+    )
+
+    generator.generate_response("q", {})
+    events = [e[0] for e in plugin.events]
+    assert events.count("draft") == 1
+    assert events.count("gap") == 1
+    assert events.count("final") == 1


### PR DESCRIPTION
## Summary
- introduce generic `Plugin` base and `PluginManager` for hook-based extensions
- load example plugin and expose hooks during draft, gap analysis and finalization
- integrate plugin manager into `IterativeGenerator`
- cover plugin workflow with unit tests

## Testing
- `pytest tests/plugins/test_plugin_system.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6895934b90b48323a848e04a6eb41ccf