### PR TITLE
Add iteration logger for response refinement cycles

### DIFF
--- a/src/iteration/iterative_generator.py
+++ b/src/iteration/iterative_generator.py
@@ -6,6 +6,7 @@ from typing import Any, List
 import time
 
 from src.monitoring.metrics_monitor import MetricsMonitor
+from src.monitoring.iteration_logger import IterationLogger
 
 from src.utils.source_manager import SourceManager
 from src.interaction.mode_controller import HiddenSourcesMode, ResponseMode
@@ -46,6 +47,7 @@ class IterativeGenerator:
         mode: ResponseMode | None = None,
         resource_manager: ResourceManager | None = None,
         metrics_monitor: MetricsMonitor | None = None,
+        iteration_logger: IterationLogger | None = None,
         plugin_manager: PluginManager | None = None,
     ) -> None:
         self.draft_generator = draft_generator or DraftGenerator()
@@ -66,6 +68,7 @@ class IterativeGenerator:
         self.source_manager = source_manager or SourceManager()
         self.mode = mode or HiddenSourcesMode()
         self.metrics_monitor = metrics_monitor
+        self.iteration_logger = iteration_logger
         self.plugin_manager = plugin_manager or PluginManager()
 
     # ------------------------------------------------------------------
@@ -111,6 +114,15 @@ class IterativeGenerator:
                 draft = result
                 rules_refs = []
             iterations += 1
+
+            if self.iteration_logger:
+                self.iteration_logger.log_iteration(
+                    iterations,
+                    draft,
+                    gaps,
+                    search_results,
+                    result,
+                )
 
         sources = self.source_manager.all()
         style = adapt_response_style(context, iterations)

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,5 +1,6 @@
 """Monitoring utilities."""
 
 from .metrics_monitor import MetricsMonitor
+from .iteration_logger import IterationLogger
 
-__all__ = ["MetricsMonitor"]
+__all__ = ["MetricsMonitor", "IterationLogger"]

--- a/src/monitoring/iteration_logger.py
+++ b/src/monitoring/iteration_logger.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Utilities for logging each iteration of the response generation process."""
+from dataclasses import dataclass, asdict, is_dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _serialize(obj: Any) -> Any:
+    """Recursively convert dataclasses and other objects to JSON-serialisable data."""
+    if is_dataclass(obj):
+        return asdict(obj)
+    if isinstance(obj, list):
+        return [_serialize(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _serialize(v) for k, v in obj.items()}
+    return obj
+
+
+@dataclass
+class IterationLogger:
+    """Persist information about each iteration to separate JSON files."""
+
+    log_dir: Path = Path("logs/iterations")
+
+    def log_iteration(
+        self,
+        iter_idx: int,
+        draft: str,
+        gaps: Any,
+        sources: Any,
+        enhancements: Any,
+    ) -> None:
+        """Record details for a single iteration.
+
+        Parameters
+        ----------
+        iter_idx:
+            Index of the current iteration (starting from 1).
+        draft:
+            The draft text after enhancement.
+        gaps:
+            Detected knowledge gaps before enhancement.
+        sources:
+            Sources retrieved to address the gaps.
+        enhancements:
+            Result returned by the response enhancer.
+        """
+
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "iteration": iter_idx,
+            "draft": draft,
+            "gaps": _serialize(gaps),
+            "sources": _serialize(sources),
+            "enhancements": _serialize(enhancements),
+        }
+        file_path = self.log_dir / f"iteration_{iter_idx}.json"
+        with file_path.open("w", encoding="utf-8") as fh:
+            json.dump(entry, fh, ensure_ascii=False, indent=2)
+
+
+__all__ = ["IterationLogger"]

--- a/tests/monitoring/test_iteration_logger.py
+++ b/tests/monitoring/test_iteration_logger.py
@@ -1,0 +1,64 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.monitoring.iteration_logger import IterationLogger
+from src.iteration.iterative_generator import IterativeGenerator
+from src.iteration.gap_analyzer import KnowledgeGap
+from src.iteration.iteration_controller import IterationController
+
+
+class DummyDraftGenerator:
+    def generate_draft(self, query, context):
+        return "draft ___"
+
+
+class DummyGapAnalyzer:
+    def analyze(self, draft):
+        if "___" in draft:
+            return [KnowledgeGap(claim="info", questions=[], confidence=0.0)]
+        return []
+
+
+class DummyDeepSearcher:
+    def search(self, query, user_id=None, limit=None):
+        return [{"content": "resolved"}]
+
+
+class DummyResponseEnhancer:
+    def enhance(self, draft, search_results, integration, self_correct=True):
+        return draft.replace("___", search_results[0]["content"])
+
+
+def test_iteration_logger_writes_files(tmp_path):
+    log_dir = tmp_path / "iterations"
+    logger = IterationLogger(log_dir=log_dir)
+    gaps = [KnowledgeGap(claim="claim", questions=[], confidence=0.5)]
+    logger.log_iteration(1, "draft", gaps, sources=["src"], enhancements={"x": 1})
+    log_file = log_dir / "iteration_1.json"
+    assert log_file.exists()
+    data = json.loads(log_file.read_text())
+    assert data["iteration"] == 1
+    assert data["draft"] == "draft"
+    assert data["gaps"][0]["claim"] == "claim"
+
+
+def test_iterative_generator_logs_iterations(tmp_path):
+    log_dir = tmp_path / "iterations"
+    logger = IterationLogger(log_dir=log_dir)
+    controller = IterationController(max_iterations=3, max_critical_spaces=0)
+    generator = IterativeGenerator(
+        draft_generator=DummyDraftGenerator(),
+        gap_analyzer=DummyGapAnalyzer(),
+        deep_searcher=DummyDeepSearcher(),
+        response_enhancer=DummyResponseEnhancer(),
+        iteration_controller=controller,
+        iteration_logger=logger,
+    )
+
+    generator.generate_response("question", {})
+
+    log_file = log_dir / "iteration_1.json"
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- add `IterationLogger` to persist iteration drafts, gaps, sources and enhancements to `logs/iterations`
- expose `IterationLogger` via monitoring package and call it from `IterativeGenerator`
- test iteration logging and integration with response generator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959654c1b4832382457f032170402b