### PR TITLE
feat: add grammar rule explanations to responses

### DIFF
--- a/src/interaction/personality_adapter.py
+++ b/src/interaction/personality_adapter.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 """Adapt response tone based on context and iteration count."""
 
-from typing import Any
+from typing import Any, Iterable, List
+
+from src.quality import GrammarIssue
 
 # Predefined response styles.
 STYLES: dict[str, str] = {
@@ -35,4 +37,35 @@ def adapt_response_style(context: Any, iteration_count: int) -> str:
     return "default_helpful"
 
 
-__all__ = ["adapt_response_style", "STYLES"]
+class PersonalityAdapter:
+    """Format grammar rule references for responses.
+
+    Parameters
+    ----------
+    explain_rules:
+        When ``True``, include rule suggestions from
+        :class:`~src.quality.grammar_rule_checker.GrammarRuleChecker` in the
+        formatted references.
+    """
+
+    def __init__(self, *, explain_rules: bool = False) -> None:
+        self.explain_rules = explain_rules
+
+    def format_rules(self, issues: Iterable[GrammarIssue]) -> List[str]:
+        """Return formatted references for ``issues``.
+
+        Each rule is rendered as ``"см. правило §<rule_id>"``. If
+        :attr:`explain_rules` is ``True`` and a suggestion is available, it is
+        appended after the rule identifier.
+        """
+
+        refs: List[str] = []
+        for issue in issues:
+            ref = f"см. правило §{issue.rule_id}"
+            if self.explain_rules and issue.suggestion:
+                ref = f"{ref}: {issue.suggestion}"
+            refs.append(ref)
+        return refs
+
+
+__all__ = ["adapt_response_style", "STYLES", "PersonalityAdapter"]

--- a/src/iteration/iterative_generator.py
+++ b/src/iteration/iterative_generator.py
@@ -10,7 +10,11 @@ from src.monitoring.iteration_logger import IterationLogger
 
 from src.utils.source_manager import SourceManager
 from src.interaction.mode_controller import HiddenSourcesMode, ResponseMode
-from src.interaction.personality_adapter import adapt_response_style
+from src.interaction.personality_adapter import (
+    PersonalityAdapter,
+    adapt_response_style,
+)
+from src.quality import GrammarIssue
 from src.plugins import PluginManager
 
 from .draft_generator import DraftGenerator
@@ -49,6 +53,7 @@ class IterativeGenerator:
         metrics_monitor: MetricsMonitor | None = None,
         iteration_logger: IterationLogger | None = None,
         plugin_manager: PluginManager | None = None,
+        personality_adapter: PersonalityAdapter | None = None,
     ) -> None:
         self.draft_generator = draft_generator or DraftGenerator()
         self.gap_analyzer = gap_analyzer or GapAnalyzer()
@@ -70,6 +75,7 @@ class IterativeGenerator:
         self.metrics_monitor = metrics_monitor
         self.iteration_logger = iteration_logger
         self.plugin_manager = plugin_manager or PluginManager()
+        self.personality_adapter = personality_adapter or PersonalityAdapter()
 
     # ------------------------------------------------------------------
     def generate_response(self, query: str, context: Any) -> str:
@@ -84,7 +90,7 @@ class IterativeGenerator:
             self.iteration_controller.reset()
 
         iterations = 0
-        rules_refs: List[str] = []
+        rules_refs: List[GrammarIssue] = []
         while self.iteration_controller.should_iterate(draft):
             gaps: List[KnowledgeGap] = self.gap_analyzer.analyze(draft)
             if self.plugin_manager:
@@ -126,7 +132,8 @@ class IterativeGenerator:
 
         sources = self.source_manager.all()
         style = adapt_response_style(context, iterations)
-        response = self.mode.format_response(draft, sources, rules_refs)
+        formatted_rules = self.personality_adapter.format_rules(rules_refs)
+        response = self.mode.format_response(draft, sources, formatted_rules)
         if self.plugin_manager:
             self.plugin_manager.on_finalize(response)
 

--- a/src/iteration/response_enhancer.py
+++ b/src/iteration/response_enhancer.py
@@ -82,17 +82,16 @@ class ResponseEnhancer:
         if self_correct:
             text, _ = self.corrector.correct_errors(text)
 
-        text, rules_refs = self.apply_grammar_check(text)
+        text, issues = self.apply_grammar_check(text)
 
-        return {"text": text, "rules_refs": rules_refs}
+        return {"text": text, "rules_refs": issues}
 
     # ------------------------------------------------------------------
-    def apply_grammar_check(self, text: str) -> Tuple[str, List[str]]:
-        """Apply grammar rules and return references to triggered rules."""
+    def apply_grammar_check(self, text: str) -> Tuple[str, List[GrammarIssue]]:
+        """Apply grammar rules and return detected issues."""
 
         issues: List[GrammarIssue] = self.grammar_checker.check(text)
-        refs = [issue.rule_id for issue in issues]
-        return text, refs
+        return text, issues
 
 
 __all__ = ["ResponseEnhancer", "IntegrationType"]

--- a/tests/interaction/test_personality_adapter.py
+++ b/tests/interaction/test_personality_adapter.py
@@ -1,6 +1,8 @@
-from src.interaction.personality_adapter import adapt_response_style
+from src.interaction.mode_controller import VisibleSourcesMode
+from src.interaction.personality_adapter import PersonalityAdapter, adapt_response_style
 from src.iteration.iterative_generator import IterativeGenerator
 from src.iteration.iteration_controller import IterationController
+from src.quality import GrammarRuleChecker
 
 
 def test_adapt_response_style_basic() -> None:
@@ -10,10 +12,10 @@ def test_adapt_response_style_basic() -> None:
     assert adapt_response_style({"tone": "collaborative"}, 3) == "respectful_collaboration"
 
 
-def test_iterative_generator_includes_style(monkeypatch) -> None:
+def test_iterative_generator_includes_style_and_rules(monkeypatch) -> None:
     class DummyDraftGenerator:
         def generate_draft(self, query, context):
-            return "draft ___"
+            return "draft  ___"  # double space triggers rule
 
     class DummyGapAnalyzer:
         def analyze(self, draft):
@@ -28,17 +30,28 @@ def test_iterative_generator_includes_style(monkeypatch) -> None:
             return [{"content": "resolved"}]
 
     class DummyEnhancer:
+        def __init__(self) -> None:
+            self.checker = GrammarRuleChecker()
+
         def enhance(self, draft, search_results, integration, self_correct=True):
-            return draft.replace("___", search_results[0]["content"])
+            text = draft.replace("___", search_results[0]["content"])
+            issues = self.checker.check(text)
+            return {"text": text, "rules_refs": issues}
 
     controller = IterationController(max_iterations=3, max_critical_spaces=0)
+    adapter = PersonalityAdapter(explain_rules=True)
     generator = IterativeGenerator(
         draft_generator=DummyDraftGenerator(),
         gap_analyzer=DummyGapAnalyzer(),
         deep_searcher=DummyDeepSearcher(),
         response_enhancer=DummyEnhancer(),
         iteration_controller=controller,
+        mode=VisibleSourcesMode(),
+        personality_adapter=adapter,
     )
 
     result = generator.generate_response("question", {})
-    assert result == "[confident_but_open] draft resolved"
+    assert "[confident_but_open]" in result
+    assert "draft  resolved" in result
+    assert "см. правило §double_space" in result
+    assert "замените несколько пробелов одним" in result


### PR DESCRIPTION
## Summary
- allow `PersonalityAdapter` to format grammar rule references and optional explanations
- propagate `GrammarRuleChecker` issues through `ResponseEnhancer` and `IterativeGenerator`
- test integration of rule explanations in personality adapter

## Testing
- `pytest tests/interaction/test_personality_adapter.py`
- `pytest` *(fails: TypeError in chat_session tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_689598bfb4cc832381e58c86705561ef