### PR TITLE
feat: separate iteration logs per run

### DIFF
--- a/src/monitoring/iteration_logger.py
+++ b/src/monitoring/iteration_logger.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 """Utilities for logging each iteration of the response generation process."""
-from dataclasses import dataclass, asdict, is_dataclass
+from dataclasses import dataclass, asdict, is_dataclass, field
+from datetime import datetime
 import json
 from pathlib import Path
 from typing import Any
@@ -23,6 +24,9 @@ class IterationLogger:
     """Persist information about each iteration to separate JSON files."""
 
     log_dir: Path = Path("logs/iterations")
+    run_id: str = field(
+        default_factory=lambda: datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    )
 
     def log_iteration(
         self,
@@ -48,7 +52,8 @@ class IterationLogger:
             Result returned by the response enhancer.
         """
 
-        self.log_dir.mkdir(parents=True, exist_ok=True)
+        run_dir = self.log_dir / self.run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
         entry = {
             "iteration": iter_idx,
             "draft": draft,
@@ -56,7 +61,7 @@ class IterationLogger:
             "sources": _serialize(sources),
             "enhancements": _serialize(enhancements),
         }
-        file_path = self.log_dir / f"iteration_{iter_idx}.json"
+        file_path = run_dir / f"iteration_{iter_idx}.json"
         with file_path.open("w", encoding="utf-8") as fh:
             json.dump(entry, fh, ensure_ascii=False, indent=2)
 

--- a/tests/monitoring/test_iteration_logger.py
+++ b/tests/monitoring/test_iteration_logger.py
@@ -36,10 +36,10 @@ class DummyResponseEnhancer:
 
 def test_iteration_logger_writes_files(tmp_path):
     log_dir = tmp_path / "iterations"
-    logger = IterationLogger(log_dir=log_dir)
+    logger = IterationLogger(log_dir=log_dir, run_id="run_a")
     gaps = [KnowledgeGap(claim="claim", questions=[], confidence=0.5)]
     logger.log_iteration(1, "draft", gaps, sources=["src"], enhancements={"x": 1})
-    log_file = log_dir / "iteration_1.json"
+    log_file = log_dir / "run_a" / "iteration_1.json"
     assert log_file.exists()
     data = json.loads(log_file.read_text())
     assert data["iteration"] == 1
@@ -49,7 +49,7 @@ def test_iteration_logger_writes_files(tmp_path):
 
 def test_iterative_generator_logs_iterations(tmp_path):
     log_dir = tmp_path / "iterations"
-    logger = IterationLogger(log_dir=log_dir)
+    logger = IterationLogger(log_dir=log_dir, run_id="run_b")
     controller = IterationController(max_iterations=3, max_critical_spaces=0)
     generator = IterativeGenerator(
         draft_generator=DummyDraftGenerator(),
@@ -62,5 +62,20 @@ def test_iterative_generator_logs_iterations(tmp_path):
 
     generator.generate_response("question", {})
 
-    log_file = log_dir / "iteration_1.json"
+    log_file = log_dir / "run_b" / "iteration_1.json"
     assert log_file.exists()
+
+
+def test_logger_creates_separate_files_for_same_iter_idx(tmp_path):
+    log_dir = tmp_path / "iterations"
+    gaps = [KnowledgeGap(claim="claim", questions=[], confidence=0.5)]
+    logger1 = IterationLogger(log_dir=log_dir, run_id="run1")
+    logger2 = IterationLogger(log_dir=log_dir, run_id="run2")
+    logger1.log_iteration(1, "draft1", gaps, sources=["src1"], enhancements={"x": 1})
+    logger2.log_iteration(1, "draft2", gaps, sources=["src2"], enhancements={"x": 2})
+    file1 = log_dir / "run1" / "iteration_1.json"
+    file2 = log_dir / "run2" / "iteration_1.json"
+    assert file1.exists()
+    assert file2.exists()
+    assert json.loads(file1.read_text())["draft"] == "draft1"
+    assert json.loads(file2.read_text())["draft"] == "draft2"


### PR DESCRIPTION
## Summary
- create run-specific subdirectory for iteration logs using a timestamp run_id
- update iteration logging path and tests to verify unique files per run

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895a3092e048323b5f96fec95ef5c50