### PR TITLE
Handle plugin hook errors without stopping other plugins

### DIFF
--- a/src/plugins/plugin_manager.py
+++ b/src/plugins/plugin_manager.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 import importlib.util
 import inspect
+import logging
 from typing import List
 
 from .plugin_base import Plugin
+
+logger = logging.getLogger(__name__)
 
 
 class PluginManager:
@@ -44,7 +47,16 @@ class PluginManager:
         for plugin in self.plugins:
             func = getattr(plugin, hook, None)
             if callable(func):
-                func(*args, **kwargs)
+                try:
+                    func(*args, **kwargs)
+                except Exception as e:
+                    logger.warning(
+                        "Error in plugin %s for hook %s: %s",
+                        plugin.__class__.__name__,
+                        hook,
+                        e,
+                        exc_info=True,
+                    )
 
     # Convenience wrappers ------------------------------------------------
     def on_draft(self, draft: str, context) -> None:

--- a/tests/plugins/test_plugin_manager_error.py
+++ b/tests/plugins/test_plugin_manager_error.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+import logging
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.plugins import PluginManager
+
+
+def test_plugin_manager_continues_on_plugin_error(tmp_path, caplog):
+    plugin_dir = tmp_path
+
+    (plugin_dir / "a_fail.py").write_text(
+        "from src.plugins import Plugin\n"
+        "class FailPlugin(Plugin):\n"
+        "    def on_draft(self, draft, context):\n"
+        "        raise RuntimeError('boom')\n"
+    )
+
+    (plugin_dir / "b_ok.py").write_text(
+        "from src.plugins import Plugin\n"
+        "class OkPlugin(Plugin):\n"
+        "    def on_draft(self, draft, context):\n"
+        "        context.append('ok')\n"
+    )
+
+    manager = PluginManager(plugin_dir)
+    manager.plugins = sorted(manager.plugins, key=lambda p: p.__class__.__name__)
+    context = []
+    with caplog.at_level(logging.WARNING):
+        manager.on_draft("draft", context)
+
+    assert context == ["ok"]
+    assert any("FailPlugin" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- log plugin hook failures in `PluginManager` and continue executing remaining hooks
- add regression test ensuring a failing plugin doesn't stop other plugins

## Testing
- `pytest tests/plugins -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b0a3fe60832388de2a53dc11c480