### PR TITLE
Add explicit UTF-8 encoding to file operations

### DIFF
--- a/logs/developer_requests.md
+++ b/logs/developer_requests.md
@@ -1,3 +1,1 @@
-# Developer Requests
-
-Entries in this file indicate failures that exceeded automated adaptation thresholds.
+- Neuron `memory_logical_1` decommissioned after 3 uses (success rate 0.00); redesign recommended

--- a/personalities/master.py
+++ b/personalities/master.py
@@ -10,7 +10,9 @@ from typing import ClassVar, Dict, List
 from src.core.ai_personality import AIPersonality
 
 TRAITS_PATH = Path(__file__).with_name("default_traits.json")
-DEFAULT_TRAITS: Dict[str, float] = json.loads(TRAITS_PATH.read_text())
+DEFAULT_TRAITS: Dict[str, float] = json.loads(
+    TRAITS_PATH.read_text(encoding="utf-8")
+)
 
 
 @dataclass

--- a/personalities/player.py
+++ b/personalities/player.py
@@ -10,7 +10,9 @@ from typing import ClassVar, Dict, List
 from src.core.ai_personality import AIPersonality
 
 TRAITS_PATH = Path(__file__).with_name("default_traits.json")
-DEFAULT_TRAITS: Dict[str, float] = json.loads(TRAITS_PATH.read_text())
+DEFAULT_TRAITS: Dict[str, float] = json.loads(
+    TRAITS_PATH.read_text(encoding="utf-8")
+)
 
 
 @dataclass

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     python_requires=">=3.8",
-    install_requires=open("requirements.txt").read().splitlines(),
+    install_requires=open("requirements.txt", encoding="utf-8").read().splitlines(),
     entry_points={
         "console_scripts": [
             "neyra=main:main",

--- a/src/learning/knowledge_base.py
+++ b/src/learning/knowledge_base.py
@@ -13,7 +13,9 @@ class KnowledgeBase:
         self._entries: List[Dict[str, Any]] = []
         if self.path and self.path.exists():
             try:
-                self._entries = json.loads(self.path.read_text())
+                self._entries = json.loads(
+                    self.path.read_text(encoding="utf-8")
+                )
             except json.JSONDecodeError:
                 self._entries = []
 
@@ -35,7 +37,9 @@ class KnowledgeBase:
         """Persist entries to disk when a path is configured."""
         if not self.path:
             return
-        self.path.write_text(json.dumps(self._entries))
+        self.path.write_text(
+            json.dumps(self._entries), encoding="utf-8"
+        )
 
 
 __all__ = ["KnowledgeBase"]

--- a/src/learning/learning_system.py
+++ b/src/learning/learning_system.py
@@ -255,7 +255,9 @@ class LearningSystem:
                 }
                 neuron_dir = Path("data/neurons")
                 neuron_dir.mkdir(parents=True, exist_ok=True)
-                (neuron_dir / f"{neuron_type}.json").write_text(json.dumps(data))
+                (neuron_dir / f"{neuron_type}.json").write_text(
+                    json.dumps(data), encoding="utf-8"
+                )
                 self.neuron_metrics[neuron_type] = {
                     "activations": 0,
                     "positive": 0,
@@ -277,14 +279,14 @@ class LearningSystem:
             "neuron_use_limit": self.neuron_use_limit,
             "neuron_success_threshold": self.neuron_success_threshold,
         }
-        Path(path).write_text(json.dumps(data))
+        Path(path).write_text(json.dumps(data), encoding="utf-8")
 
     # ------------------------------------------------------------------
     @classmethod
     def load_state(cls, path: Path | str) -> "LearningSystem":
         """Load learning state from ``path``."""
 
-        data = json.loads(Path(path).read_text())
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
         instance = cls()
         instance.experience_buffer = data.get("experience_buffer", [])
         instance.success_metrics = data.get("success_metrics", {})

--- a/src/neurons/loader.py
+++ b/src/neurons/loader.py
@@ -15,7 +15,7 @@ def load_neurons(path: Path | str = Path("data/neurons")) -> None:
         return
 
     for file in neuron_dir.glob("*.json"):
-        data = json.loads(file.read_text())
+        data = json.loads(file.read_text(encoding="utf-8"))
         neuron_type = data.get("neuron_type") or file.stem
         base_path = data.get("base_class")
         if not base_path:

--- a/tests/iteration/test_deep_searcher.py
+++ b/tests/iteration/test_deep_searcher.py
@@ -12,7 +12,7 @@ def test_search_aggregates_sources_with_priorities(tmp_path):
     style_mem.add("u1", "Bob", description="whimsical tales about dragons")
 
     cold_file = tmp_path / "cold.txt"
-    cold_file.write_text("Ancient dragons slumber.")
+    cold_file.write_text("Ancient dragons slumber.", encoding="utf-8")
 
     def fake_fetch(query: str, limit: int):
         return [{"url": "https://example.com", "snippet": f"{query} on web"}]

--- a/tests/iteration/test_memory_inspector.py
+++ b/tests/iteration/test_memory_inspector.py
@@ -24,7 +24,7 @@ def test_linked_sources_and_report(tmp_path):
     memory = ReferenceMemory(manager=manager, searcher=searcher)
 
     file = tmp_path / "file.txt"
-    file.write_text("hello")
+    file.write_text("hello", encoding="utf-8")
 
     memory.create_reference_link("internal", str(file), 0.9)
     url = "https://example.com"
@@ -49,7 +49,7 @@ def test_reference_memory_report(tmp_path):
     memory = ReferenceMemory(manager=manager, searcher=searcher)
 
     file = tmp_path / "note.txt"
-    file.write_text("hi")
+    file.write_text("hi", encoding="utf-8")
 
     memory.create_reference_link("note", str(file), 0.7)
 

--- a/tests/iteration/test_reference_memory.py
+++ b/tests/iteration/test_reference_memory.py
@@ -23,7 +23,7 @@ def test_create_reference_link_internal(tmp_path):
     memory = ReferenceMemory(manager=manager, searcher=searcher)
 
     file = tmp_path / "file.txt"
-    file.write_text("hello")
+    file.write_text("hello", encoding="utf-8")
 
     link = memory.create_reference_link("test summary", str(file), 0.9)
 

--- a/tests/monitoring/test_iteration_logger.py
+++ b/tests/monitoring/test_iteration_logger.py
@@ -41,7 +41,7 @@ def test_iteration_logger_writes_files(tmp_path):
     logger.log_iteration(1, "draft", gaps, sources=["src"], enhancements={"x": 1})
     log_file = log_dir / "run_a" / "iteration_1.json"
     assert log_file.exists()
-    data = json.loads(log_file.read_text())
+    data = json.loads(log_file.read_text(encoding="utf-8"))
     assert data["iteration"] == 1
     assert data["draft"] == "draft"
     assert data["gaps"][0]["claim"] == "claim"
@@ -77,5 +77,5 @@ def test_logger_creates_separate_files_for_same_iter_idx(tmp_path):
     file2 = log_dir / "run2" / "iteration_1.json"
     assert file1.exists()
     assert file2.exists()
-    assert json.loads(file1.read_text())["draft"] == "draft1"
-    assert json.loads(file2.read_text())["draft"] == "draft2"
+    assert json.loads(file1.read_text(encoding="utf-8"))["draft"] == "draft1"
+    assert json.loads(file2.read_text(encoding="utf-8"))["draft"] == "draft2"

--- a/tests/monitoring/test_metrics_monitor.py
+++ b/tests/monitoring/test_metrics_monitor.py
@@ -48,7 +48,7 @@ def test_metrics_monitor_logs(tmp_path, capsys):
     assert "performance" in captured
     assert "quality" in captured
 
-    lines = log_file.read_text().strip().splitlines()
+    lines = log_file.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
     perf = json.loads(lines[0])
     qual = json.loads(lines[1])
@@ -73,7 +73,7 @@ def test_iterative_generator_logs_metrics(tmp_path):
 
     generator.generate_response("question", {})
 
-    lines = log_file.read_text().strip().splitlines()
+    lines = log_file.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
     perf = json.loads(lines[0])
     qual = json.loads(lines[1])

--- a/tests/plugins/test_plugin_manager_error.py
+++ b/tests/plugins/test_plugin_manager_error.py
@@ -14,14 +14,16 @@ def test_plugin_manager_continues_on_plugin_error(tmp_path, caplog):
         "from src.plugins import Plugin\n"
         "class FailPlugin(Plugin):\n"
         "    def on_draft(self, draft, context):\n"
-        "        raise RuntimeError('boom')\n"
+        "        raise RuntimeError('boom')\n",
+        encoding="utf-8",
     )
 
     (plugin_dir / "b_ok.py").write_text(
         "from src.plugins import Plugin\n"
         "class OkPlugin(Plugin):\n"
         "    def on_draft(self, draft, context):\n"
-        "        context.append('ok')\n"
+        "        context.append('ok')\n",
+        encoding="utf-8",
     )
 
     manager = PluginManager(plugin_dir)

--- a/tests/test_learning/test_learning_system.py
+++ b/tests/test_learning/test_learning_system.py
@@ -78,7 +78,7 @@ def test_neuron_decommission_logs_and_removes() -> None:
     with pytest.raises(ValueError):
         NeuronFactory.create(neuron_type, id="n1", type=neuron_type)
     assert log_path.exists()
-    assert neuron_type in log_path.read_text()
+    assert neuron_type in log_path.read_text(encoding="utf-8")
 
 
 def test_positive_feedback_saves_user_style(tmp_path) -> None:

--- a/tests/test_search/test_api_client.py
+++ b/tests/test_search/test_api_client.py
@@ -33,7 +33,8 @@ def test_domain_filtering(tmp_path):
                 "allowed_domains": ["good.com"],
                 "blocked_domains": ["bad.com"],
             }
-        )
+        ),
+        encoding="utf-8",
     )
 
     def fake_fetch(query: str, limit: int):

--- a/tests/test_search/test_license_check.py
+++ b/tests/test_search/test_license_check.py
@@ -9,7 +9,7 @@ class DummyResponse:
 
 def test_check_license_header(monkeypatch, tmp_path):
     cfg = tmp_path / "licenses.yml"
-    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n", encoding="utf-8")
     client = SearchAPIClient(license_config_path=cfg)
     monkeypatch.setattr(
         client.session,
@@ -21,7 +21,7 @@ def test_check_license_header(monkeypatch, tmp_path):
 
 def test_check_license_meta(monkeypatch, tmp_path):
     cfg = tmp_path / "licenses.yml"
-    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n", encoding="utf-8")
     client = SearchAPIClient(license_config_path=cfg)
     html = '<html><head><meta name="license" content="CC-BY"></head></html>'
     monkeypatch.setattr(
@@ -34,7 +34,7 @@ def test_check_license_meta(monkeypatch, tmp_path):
 
 def test_search_and_update_skips_unlicensed(monkeypatch, tmp_path):
     cfg = tmp_path / "licenses.yml"
-    cfg.write_text("allowed_licenses:\n  - CC-BY\n")
+    cfg.write_text("allowed_licenses:\n  - CC-BY\n", encoding="utf-8")
 
     def fake_fetch(query: str, limit: int):
         return [{"url": "https://example.com", "snippet": "Fact"}]


### PR DESCRIPTION
## Summary
- ensure default trait loading for master and player personalities uses UTF-8
- read/write learning state and knowledge base files with UTF-8
- specify UTF-8 when loading neuron definitions and in related tests

## Testing
- `pytest` *(fails: RuntimeError: ebooklib is required; AttributeError: 'NoneType' object has no attribute 'print')*

------
https://chatgpt.com/codex/tasks/task_e_6895c8f10aec8323a61c7c72d74a5bee