### PR TITLE
Implement candidate response selection in post-processing

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -2,8 +2,10 @@ from .self_corrector import SelfCorrector, SuggestionChooser
 from .verification_system import VerificationSystem, VerificationResult, verify_fact
 from .uncertainty_manager import UncertaintyManager
 from .timeline_checker import TimelineChecker
-from .post_processor import PostProcessor
+from .post_processor import PostProcessor, run_post_processors
 from .grammar_proofreader import GrammarProofreader
+from .candidate_generator import CandidateGenerator
+from .candidate_selector import CandidateSelector
 
 POST_PROCESSOR_REGISTRY = {
     "GrammarProofreader": GrammarProofreader,
@@ -17,7 +19,10 @@ __all__ = [
     "UncertaintyManager",
     "TimelineChecker",
     "PostProcessor",
+    "run_post_processors",
     "GrammarProofreader",
+    "CandidateGenerator",
+    "CandidateSelector",
     "POST_PROCESSOR_REGISTRY",
     "verify_fact",
 ]

--- a/src/analysis/candidate_generator.py
+++ b/src/analysis/candidate_generator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Generate multiple response candidates using :class:`BaseGenerator`."""
+
+from typing import List, Optional
+
+from src.action.base_generator import BaseGenerator
+from src.llm import BaseLLM
+from src.memory.style_memory import StylePattern
+
+
+class CandidateGenerator(BaseGenerator):
+    """Utility that produces several variations of a response.
+
+    The class reuses the existing :class:`~src.action.base_generator.BaseGenerator`
+    infrastructure to format prompts and call the LLM.  The
+    :meth:`generate_candidates` method simply invokes ``generate`` multiple
+    times, relying on the LLM's stochasticity to provide diverse outputs.
+    When no LLM is available, the ``fallback_text`` is returned for all
+    candidates.
+    """
+
+    def __init__(
+        self,
+        llm: Optional[BaseLLM],
+        template: str,
+        num_candidates: int = 3,
+    ) -> None:
+        super().__init__(llm, template)
+        self.num_candidates = num_candidates
+
+    # ------------------------------------------------------------------
+    def generate_candidates(
+        self,
+        prompt: str,
+        fallback_text: str,
+        max_tokens: int = 512,
+        style: StylePattern | None = None,
+    ) -> List[str]:
+        """Generate ``num_candidates`` variations for ``prompt``.
+
+        Parameters
+        ----------
+        prompt:
+            Input prompt used to format the template.
+        fallback_text:
+            Text returned when no LLM is available.
+        max_tokens:
+            Maximum amount of tokens for each generation.
+        style:
+            Optional style pattern influencing the prompt.
+        """
+
+        return [
+            super().generate(prompt, fallback_text, max_tokens=max_tokens, style=style)
+            for _ in range(self.num_candidates)
+        ]

--- a/src/analysis/candidate_selector.py
+++ b/src/analysis/candidate_selector.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Select the best response candidate based on simple heuristics."""
+
+from typing import List
+
+from .verification_system import VerificationSystem
+
+
+class CandidateSelector:
+    """Score and choose among multiple response candidates.
+
+    The selection combines similarity with stored memory entries and the
+    confidence provided by the :class:`VerificationSystem`.
+    """
+
+    def __init__(self, verifier: VerificationSystem) -> None:
+        self.verifier = verifier
+
+    # ------------------------------------------------------------------
+    def _memory_score(self, text: str) -> float:
+        """Return ``1.0`` if ``text`` resembles known memory, else ``0.0``."""
+
+        return 1.0 if self.verifier.memory.similar(text, 1) else 0.0
+
+    # ------------------------------------------------------------------
+    def score(self, text: str) -> float:
+        """Compute overall score for ``text``."""
+
+        verification = self.verifier.verify_claim(text)
+        memory_score = self._memory_score(text)
+        return (memory_score + verification.confidence) / 2
+
+    # ------------------------------------------------------------------
+    def select_best(self, candidates: List[str]) -> str:
+        """Return the candidate with the highest :meth:`score`."""
+
+        if not candidates:
+            return ""
+        return max(candidates, key=self.score)

--- a/src/analysis/post_processor.py
+++ b/src/analysis/post_processor.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
+from .candidate_generator import CandidateGenerator
+from .candidate_selector import CandidateSelector
+
 
 class PostProcessor(ABC):
     """Interface for response post-processing steps."""
@@ -11,3 +14,31 @@ class PostProcessor(ABC):
     def process(self, text: str) -> Tuple[str, List[Dict[str, str]]]:
         """Process ``text`` and return modified text and list of corrections."""
         raise NotImplementedError
+
+
+def run_post_processors(
+    text: str,
+    processors: List[PostProcessor],
+    candidate_generator: CandidateGenerator | None = None,
+    candidate_selector: CandidateSelector | None = None,
+) -> Tuple[str, List[Dict[str, str]]]:
+    """Run ``processors`` on ``text`` and aggregate corrections.
+
+    The function optionally generates several candidate responses and selects
+    the most suitable one before applying regular post-processors.  This keeps
+    the pipeline flexible while maintaining backward compatibility for cases
+    where candidate generation is not required.
+    """
+
+    corrections: List[Dict[str, str]] = []
+
+    if candidate_generator and candidate_selector:
+        candidates = candidate_generator.generate_candidates(text, text)
+        text = candidate_selector.select_best(candidates)
+
+    for processor in processors:
+        text, corr = processor.process(text)
+        if corr:
+            corrections.extend(corr)
+
+    return text, corrections

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -21,6 +21,9 @@ from src.analysis import (
     UncertaintyManager,
     PostProcessor,
     POST_PROCESSOR_REGISTRY,
+    CandidateGenerator,
+    CandidateSelector,
+    run_post_processors,
 )
 from types import SimpleNamespace
 
@@ -71,6 +74,10 @@ class Neyra:
         self.last_draft: str = ""
         self.verification_system = VerificationSystem()
         self.uncertainty_manager = UncertaintyManager()
+        self.candidate_generator = CandidateGenerator(
+            self.llm, "Переформулируй ответ: {prompt}", num_candidates=3
+        )
+        self.candidate_selector = CandidateSelector(self.verification_system)
         self.gap_analyzer = GapAnalyzer(self.verification_system, self.uncertainty_manager)
         if DeepSearcher:
             self.deep_searcher = DeepSearcher(
@@ -378,10 +385,14 @@ class Neyra:
                 break
             iteration += 1
         if not skip_check:
-            for processor in self.post_processors:
-                response, corrections = processor.process(response)
-                if corrections:
-                    all_corrections.extend(corrections)
+            response, corrections = run_post_processors(
+                response,
+                self.post_processors,
+                candidate_generator=self.candidate_generator,
+                candidate_selector=self.candidate_selector,
+            )
+            if corrections:
+                all_corrections.extend(corrections)
         update_progress("finished", iteration)
         self.logger.info("Iterative response finished at iteration %s", iteration)
         self.iteration_controller._iterations = iteration

--- a/tests/analysis/test_candidate_pipeline.py
+++ b/tests/analysis/test_candidate_pipeline.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+sys.modules.setdefault(
+    "sentence_transformers", types.SimpleNamespace(SentenceTransformer=lambda *a, **k: None)
+)
+
+from src.analysis.post_processor import run_post_processors
+
+
+def test_candidate_selection_pipeline():
+    class StubCandidateGenerator:
+        def generate_candidates(self, prompt: str, fallback: str):
+            return [prompt, prompt.upper()]
+
+    class StubCandidateSelector:
+        def select_best(self, candidates):
+            return candidates[1]
+
+    result, corrections = run_post_processors(
+        "hi", [], StubCandidateGenerator(), StubCandidateSelector()
+    )
+    assert result == "HI"
+    assert corrections == []


### PR DESCRIPTION
## Summary
- add CandidateGenerator to produce multiple response variants using BaseGenerator
- implement CandidateSelector scoring by memory similarity and VerificationSystem confidence
- expand post-processing pipeline to generate/select candidates before running processors and integrate into Neyra core
- add basic test covering candidate selection pipeline

## Testing
- `PYTHONPATH=. pytest tests/analysis/test_candidate_pipeline.py -q`
- `PYTHONPATH=. pytest tests/analysis/test_post_processors.py -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*


------
https://chatgpt.com/codex/tasks/task_e_6895fc734de88323aafe02a9602d4722