### PR TITLE
feat(memory): add knowledge graph support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ llama-cpp-python>=0.2.77
 schedule>=1.2.0
 requests>=2.31.0
 language_tool_python>=2.0.0
+networkx>=3.0

--- a/requirements_desktop.txt
+++ b/requirements_desktop.txt
@@ -37,3 +37,4 @@ whoosh>=2.7.4
 
 # Notifications
 plyer>=2.1.0
+networkx>=3.0

--- a/src/analysis/verification_system.py
+++ b/src/analysis/verification_system.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 import re
 from typing import Callable, Iterable, List, Tuple, Dict
 
-from src.memory import MemoryIndex
+from src.memory import MemoryIndex, KnowledgeGraph, knowledge_graph
 
 
 @dataclass
@@ -34,12 +34,14 @@ class VerificationSystem:
         memory: MemoryIndex | None = None,
         external_checkers: List[Callable[[str], Tuple[bool, float]]] | None = None,
         vector_backend: str | None = None,
+        graph: KnowledgeGraph | None = None,
     ) -> None:
         self.memory = memory or MemoryIndex(vector_backend=vector_backend)
         # External checkers are callables returning a tuple of (verdict, confidence)
         self.external_checkers = (
             external_checkers if external_checkers is not None else [self._stub_check]
         )
+        self.graph = graph or knowledge_graph
 
     # ------------------------------------------------------------------
     def add_external_checker(
@@ -68,6 +70,22 @@ class VerificationSystem:
             verdict = bool(memory_value)
             confidence = self.memory.source_reliability.get(used_key, 0.0)
             sources.append("memory")
+
+        graph_verdict, graph_conf = (None, 0.0)
+        if self.graph is not None:
+            graph_verdict, graph_conf = self.graph.check_claim(claim)
+            if graph_verdict is not None:
+                sources.append("graph")
+                if verdict is None:
+                    verdict = graph_verdict
+                    confidence = graph_conf
+                elif verdict != graph_verdict:
+                    confidence = min(confidence, graph_conf) / 2
+                    verdict = graph_verdict
+                else:
+                    confidence = (
+                        (confidence + graph_conf) / 2 if confidence else graph_conf
+                    )
 
         for checker in self.external_checkers:
             try:

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -11,6 +11,7 @@ from .embedding_memory import EmbeddingMemory
 from .weighted import WeightedMemory
 from .multi_grid import MultiGridMemory
 from .lazy_loader import LazyMemoryLoader
+from .knowledge_graph import KnowledgeGraph, knowledge_graph
 
 __all__ = [
     "CharacterMemory",
@@ -24,4 +25,6 @@ __all__ = [
     "WeightedMemory",
     "MultiGridMemory",
     "LazyMemoryLoader",
+    "KnowledgeGraph",
+    "knowledge_graph",
 ]

--- a/src/memory/character_memory.py
+++ b/src/memory/character_memory.py
@@ -14,6 +14,7 @@ import json
 from typing import Dict
 
 from src.models import Character
+from .knowledge_graph import knowledge_graph
 
 
 class CharacterMemory:
@@ -55,6 +56,10 @@ class CharacterMemory:
             json.dumps({name: char.to_dict() for name, char in self._data.items()}, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        for char in self._data.values():
+            knowledge_graph.add_character(char)
+        knowledge_graph.export_json()
+        knowledge_graph.export_graphml()
 
     # Convenience methods to behave a bit like a dictionary -----------------
     def __contains__(self, name: str) -> bool:  # pragma: no cover - trivial

--- a/src/memory/knowledge_graph.py
+++ b/src/memory/knowledge_graph.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+"""Simple knowledge graph for storing relations between entities.
+
+This module relies on :mod:`networkx` to keep track of nodes (characters,
+worlds, etc.) and edges (relationships).  The graph is persisted in both JSON
+and GraphML formats so that it remains compatible with the existing file based
+storage used throughout the project.
+"""
+
+from pathlib import Path
+import json
+from typing import Any, Dict, Tuple
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+try:  # pragma: no cover - networkx may not support GraphML in minimal builds
+    from networkx.readwrite.graphml import write_graphml
+except Exception:  # pragma: no cover - fallback for environments without graphml
+    write_graphml = None  # type: ignore
+
+
+class KnowledgeGraph:
+    """Maintain a directed multigraph of entities and relations."""
+
+    def __init__(
+        self,
+        json_path: str | Path | None = None,
+        graphml_path: str | Path | None = None,
+    ) -> None:
+        self.json_path = Path(json_path or "data/knowledge_graph.json")
+        self.graphml_path = Path(graphml_path or "data/knowledge_graph.graphml")
+        self.graph = nx.MultiDiGraph()
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        """Load previously stored graph if available."""
+        if not self.json_path.exists():
+            return
+        try:
+            data = json.loads(self.json_path.read_text(encoding="utf-8"))
+            self.graph = json_graph.node_link_graph(data, multigraph=True)
+        except Exception:
+            self.graph = nx.MultiDiGraph()
+
+    # ------------------------------------------------------------------
+    def add_world(self, name: str, **attrs: Any) -> None:
+        """Register a world node."""
+        self.graph.add_node(name, type="world", **attrs)
+
+    def add_character(self, character: Any, world: str | None = None) -> None:
+        """Register a character node and its relations."""
+        if hasattr(character, "to_dict"):
+            data = character.to_dict()
+        elif isinstance(character, dict):
+            data = character
+        else:
+            data = {"name": str(character)}
+        name = data.get("name") or getattr(character, "name", None)
+        if not name:
+            return
+        self.graph.add_node(name, type="character")
+        # Optional link to world
+        world = world or data.get("world") or getattr(character, "world", None)
+        if world:
+            self.assign_character_world(name, world)
+        # Relationships between characters
+        relationships = data.get("relationships", {})
+        for other, relation in relationships.items():
+            self.relate_characters(name, other, relation)
+
+    def relate_characters(self, src: str, dst: str, relation: str) -> None:
+        """Add an edge describing a relation between two characters."""
+        self.graph.add_edge(src, dst, relation=relation)
+
+    def assign_character_world(self, character: str, world: str) -> None:
+        """Connect a character node with a world node."""
+        self.graph.add_edge(character, world, relation="belongs_to")
+
+    # ------------------------------------------------------------------
+    def export_json(self) -> None:
+        """Persist graph to JSON using node-link format."""
+        self.json_path.parent.mkdir(parents=True, exist_ok=True)
+        data = json_graph.node_link_data(self.graph)
+        self.json_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    def export_graphml(self) -> None:
+        """Persist graph to GraphML if the writer is available."""
+        if write_graphml is None:
+            return
+        self.graphml_path.parent.mkdir(parents=True, exist_ok=True)
+        write_graphml(self.graph, self.graphml_path)
+
+    # ------------------------------------------------------------------
+    def check_relation(self, src: str, dst: str, relation: str) -> bool:
+        """Check whether a specific relation exists between two nodes."""
+        edges = self.graph.get_edge_data(src, dst) or {}
+        return any(data.get("relation") == relation for data in edges.values())
+
+    def check_claim(self, claim: str) -> Tuple[bool | None, float]:
+        """Naively verify textual claims using the graph.
+
+        The function recognises simple Russian phrases describing relations,
+        for example::
+
+            "Алиса принадлежит миру Wonderland"
+            "Боб связан с Алиса"
+        """
+
+        import re
+
+        pattern_world = re.search(
+            r"(?P<char>[A-Za-zА-Яа-яЁё]+)\s+принадлежит\s+миру\s+(?P<world>[A-Za-zА-Яа-яЁё]+)",
+            claim,
+            re.IGNORECASE,
+        )
+        if pattern_world:
+            char = pattern_world.group("char")
+            world = pattern_world.group("world")
+            return self.check_relation(char, world, "belongs_to"), 1.0
+
+        pattern_rel = re.search(
+            r"(?P<src>[A-Za-zА-Яа-яЁё]+)\s+связан\s+с\s+(?P<dst>[A-Za-zА-Яа-яЁё]+)",
+            claim,
+            re.IGNORECASE,
+        )
+        if pattern_rel:
+            src = pattern_rel.group("src")
+            dst = pattern_rel.group("dst")
+            exists = self.graph.has_edge(src, dst) or self.graph.has_edge(dst, src)
+            return exists, 1.0
+
+        return None, 0.0
+
+
+# Shared instance used across the project
+knowledge_graph = KnowledgeGraph()
+
+__all__ = ["KnowledgeGraph", "knowledge_graph"]

--- a/src/memory/world_memory.py
+++ b/src/memory/world_memory.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List
 
+from .knowledge_graph import knowledge_graph
 
 @dataclass
 class WorldRule:
@@ -122,6 +123,10 @@ class WorldMemory:
             json.dumps(serialised, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        for world in serialised.keys():
+            knowledge_graph.add_world(world)
+        knowledge_graph.export_json()
+        knowledge_graph.export_graphml()
 
     def load(self) -> None:
         """Load memory from disk."""


### PR DESCRIPTION
## Summary
- add `KnowledgeGraph` using networkx with export to JSON/GraphML
- integrate character and world memories with the graph
- check claims for graph consistency in verification system
- add networkx dependency

## Testing
- `PYTHONPATH=. pytest tests/test_memory/test_deduplication.py -q`
- `PYTHONPATH=. pytest tests/test_memory/test_memory_index.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689600cd58ac8323aa9ca9e7f0a45da9