### PR TITLE
feat: add context retriever and draft reconciliation

### DIFF
--- a/src/action/base_generator.py
+++ b/src/action/base_generator.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from src.search import Retriever
+
 from src.llm import BaseLLM
 from src.memory.style_memory import StylePattern
 
@@ -15,9 +17,27 @@ class BaseGenerator:
     fallback when the LLM is not available.
     """
 
-    def __init__(self, llm: Optional[BaseLLM], template: str) -> None:
+    def __init__(
+        self,
+        llm: Optional[BaseLLM],
+        template: str,
+        retriever: Retriever | None = None,
+    ) -> None:
         self.llm = llm
         self.template = template
+        self.retriever = retriever
+
+    # ------------------------------------------------------------------
+    def retrieve_context(self, query: str) -> str:
+        """Return additional context for ``query`` using the retriever."""
+
+        if self.retriever is None:
+            return ""
+        try:
+            results = self.retriever.retrieve(query)
+        except Exception:
+            return ""
+        return "\n".join(results)
 
     def generate(
         self,
@@ -41,7 +61,13 @@ class BaseGenerator:
         """
         if self.llm is None:
             return fallback_text
-        formatted_prompt = self.template.format(prompt=prompt)
+        context = self.retrieve_context(prompt)
+        try:
+            formatted_prompt = self.template.format(prompt=prompt, context=context)
+        except KeyError:
+            formatted_prompt = self.template.format(prompt=prompt)
+            if context:
+                formatted_prompt = context + "\n" + formatted_prompt
         if style is not None:
             style_prompt = ""
             if style.description:

--- a/src/analysis/verification_system.py
+++ b/src/analysis/verification_system.py
@@ -52,6 +52,30 @@ class VerificationSystem:
         self.external_checkers.append(checker)
 
     # ------------------------------------------------------------------
+    def reconcile_draft(
+        self, draft: str, context: Iterable[str]
+    ) -> List[VerificationResult]:
+        """Compare ``draft`` with ``context`` and update memory."""
+
+        context_text = " ".join(context).lower()
+        results: List[VerificationResult] = []
+        for sentence in re.split(r"[\.\!?]+", draft):
+            claim = sentence.strip()
+            if not claim:
+                continue
+            verdict = claim.lower() in context_text
+            self.memory.set(claim, verdict, reliability=1.0 if verdict else 0.0)
+            results.append(
+                VerificationResult(
+                    claim=claim,
+                    verdict=verdict,
+                    confidence=self.memory.source_reliability.get(claim, 0.0),
+                    sources=["context"],
+                )
+            )
+        return results
+
+    # ------------------------------------------------------------------
     def verify_claim(self, claim: str) -> VerificationResult:
         """Verify ``claim`` using memory and external checkers."""
 

--- a/src/search/__init__.py
+++ b/src/search/__init__.py
@@ -1,5 +1,6 @@
-"""Search module providing external API client."""
+"""Search module providing search helpers."""
 
 from .api_client import SearchAPIClient
+from .retriever import Retriever
 
-__all__ = ["SearchAPIClient"]
+__all__ = ["SearchAPIClient", "Retriever"]

--- a/src/search/retriever.py
+++ b/src/search/retriever.py
@@ -1,0 +1,62 @@
+"""Retrieve context from local files and web search."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .api_client import SearchAPIClient
+
+
+class Retriever:
+    """Search local data files and an external API for additional context."""
+
+    def __init__(
+        self,
+        data_path: str | Path | None = None,
+        api_client: SearchAPIClient | None = None,
+    ) -> None:
+        self.data_path = Path(data_path) if data_path else None
+        self.api_client = api_client or SearchAPIClient()
+
+    # ------------------------------------------------------------------
+    def _search_files(self, query: str) -> List[str]:
+        """Return matching snippets from local files."""
+        if not self.data_path or not self.data_path.exists():
+            return []
+        matches: List[str] = []
+        q = query.lower()
+        for file in self.data_path.rglob("*"):
+            if not file.is_file():
+                continue
+            try:
+                content = file.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            if q in content.lower():
+                matches.append(content)
+        return matches
+
+    # ------------------------------------------------------------------
+    def _search_api(self, query: str, limit: int) -> List[str]:
+        """Return snippets from the external search API."""
+        try:
+            results = self.api_client.search(query, limit)
+        except Exception:
+            return []
+        snippets: List[str] = []
+        for item in results:
+            snippet = item.get("snippet") if isinstance(item, dict) else None
+            if snippet:
+                snippets.append(snippet)
+        return snippets
+
+    # ------------------------------------------------------------------
+    def retrieve(self, query: str, limit: int = 5) -> List[str]:
+        """Aggregate context from local files and the external API."""
+        context: List[str] = []
+        context.extend(self._search_files(query))
+        context.extend(self._search_api(query, limit))
+        return context
+
+
+__all__ = ["Retriever"]


### PR DESCRIPTION
## Summary
- add retriever for local files and web search
- allow BaseGenerator to mix retrieved context into prompts
- compare drafts with context and update memory when they diverge

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*


------
https://chatgpt.com/codex/tasks/task_e_6896049fc9988323833b16c933da75ce