### PR TITLE
Add LoRA adapter support to personalities and LLM manager

### DIFF
--- a/personalities/master.py
+++ b/personalities/master.py
@@ -20,6 +20,7 @@ class MasterPersonality(AIPersonality):
     """AI personality for game masters with narrative abilities."""
 
     traits: Dict[str, float] = field(default_factory=lambda: DEFAULT_TRAITS.copy())
+    lora_adapters: List[str] = field(default_factory=list)
 
     specializations: ClassVar[Dict[str, Dict[str, List[str]]]] = {
         "lorekeeper": {
@@ -34,7 +35,24 @@ class MasterPersonality(AIPersonality):
         },
     }
 
-    def __init__(self, name: str, specialization: str = "lorekeeper") -> None:
+    def __init__(
+        self,
+        name: str,
+        specialization: str = "lorekeeper",
+        lora_adapters: List[str] | None = None,
+    ) -> None:
+        """Initialize a master personality.
+
+        Parameters
+        ----------
+        name:
+            Display name of the personality.
+        specialization:
+            Optional specialization preset such as ``lorekeeper``.
+        lora_adapters:
+            Identifiers for LoRA adapters associated with this personality.
+        """
+
         preset = self.specializations.get(specialization, {})
         super().__init__(
             name=name,
@@ -46,6 +64,7 @@ class MasterPersonality(AIPersonality):
             communication_style=preset.get("communication_style", "narrative"),
         )
         self.traits = DEFAULT_TRAITS.copy()
+        self.lora_adapters = lora_adapters or []
 
     def describe_scene(self, elements: List[str]) -> str:
         """Return a narrative description of the given ``elements``."""

--- a/personalities/player.py
+++ b/personalities/player.py
@@ -20,6 +20,7 @@ class PlayerPersonality(AIPersonality):
     """AI personality for players with action choices."""
 
     traits: Dict[str, float] = field(default_factory=lambda: DEFAULT_TRAITS.copy())
+    lora_adapters: List[str] = field(default_factory=list)
 
     archetypes: ClassVar[Dict[str, Dict[str, List[str]]]] = {
         "warrior": {
@@ -34,7 +35,24 @@ class PlayerPersonality(AIPersonality):
         },
     }
 
-    def __init__(self, name: str, archetype: str = "warrior") -> None:
+    def __init__(
+        self,
+        name: str,
+        archetype: str = "warrior",
+        lora_adapters: List[str] | None = None,
+    ) -> None:
+        """Initialize a player personality.
+
+        Parameters
+        ----------
+        name:
+            Display name of the personality.
+        archetype:
+            Optional archetype preset such as ``warrior``.
+        lora_adapters:
+            Identifiers for LoRA adapters associated with this personality.
+        """
+
         preset = self.archetypes.get(archetype, {})
         super().__init__(
             name=name,
@@ -43,9 +61,12 @@ class PlayerPersonality(AIPersonality):
             personality_traits=preset.get("personality_traits", []),
             current_character=archetype.capitalize(),
             decision_style=preset.get("decision_style", "balanced"),
-            communication_style=preset.get("communication_style", "conversational"),
+            communication_style=preset.get(
+                "communication_style", "conversational"
+            ),
         )
         self.traits = DEFAULT_TRAITS.copy()
+        self.lora_adapters = lora_adapters or []
 
     def choose_action(self, situation: str, options: List[str]) -> str:
         """Select an action from ``options`` given the ``situation``."""

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -3,7 +3,10 @@
 
 The script fetches a GGUF model from a provided URL, stores it under
 ``models/<model_type>`` and updates ``config/llm_config.json`` so that
-subsequent runs of Neyra use the new model.
+subsequent runs of Neyra use the new model.  LoRA adapters generated with
+``train_qwen_coder.py`` should be copied manually to
+``models/adapters/<name>`` and referenced in personalities via their
+``lora_adapters`` attribute.
 """
 
 from __future__ import annotations

--- a/scripts/train_qwen_coder.py
+++ b/scripts/train_qwen_coder.py
@@ -1,4 +1,9 @@
-"""Minimal fine-tuning of Qwen2.5-Coder-1.5B using Unsloth and TRL."""
+"""Fine-tune Qwen2.5-Coder-1.5B and produce a LoRA adapter.
+
+The resulting directory contains weights compatible with :mod:`peft`.  After
+training, move ``output_dir`` to ``models/adapters/<name>`` so that the
+adapter can be loaded at runtime.
+"""
 
 from __future__ import annotations
 
@@ -99,6 +104,9 @@ def main() -> None:
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
     model.save_pretrained(args.output_dir)
     tokenizer.save_pretrained(args.output_dir)
+    print(
+        "Saved LoRA adapter. Copy the directory to models/adapters/<name> for use"
+    )
 
 
 if __name__ == "__main__":

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass, field
 import time
 from typing import Any, Callable, Dict, Optional, Tuple
 
+try:  # pragma: no cover - optional peft dependency
+    from peft import PeftModel  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    PeftModel = None  # type: ignore
+
 from .base_llm import BaseLLM
 from src.learning.learning_system import LearningSystem
 from .prompts import chat_prompt
@@ -44,6 +49,7 @@ class Task:
     user_id: str | None = None
     request_type: str = "general"
     context: Dict[str, Any] | None = None
+    lora_adapters: list[str] | None = None
 
 
 class LLMManager:
@@ -77,6 +83,19 @@ class LLMManager:
             capabilities=capabilities or set(),
             prompt_adapter=prompt_adapter,
         )
+
+    # ------------------------------------------------------------------
+    def _apply_lora(self, llm: BaseLLM, adapters: list[str] | None) -> None:
+        """Attach ``adapters`` to ``llm`` using :mod:`peft` if available."""
+
+        if not adapters or PeftModel is None or not hasattr(llm, "model"):
+            return
+        model = getattr(llm, "model", None)
+        if model is None:
+            return
+        for path in adapters:
+            model = PeftModel.from_pretrained(model, path)
+        llm.model = model
 
     # ------------------------------------------------------------------
     def select_model(self, task: Task) -> Tuple[str, BaseLLM, str]:
@@ -164,6 +183,7 @@ class LLMManager:
             for name, spec in self.models.items():
                 if not spec.llm.is_available():
                     continue
+                self._apply_lora(spec.llm, task.lora_adapters)
                 adapted = spec.adapt_prompt(task.prompt)
                 start = time.perf_counter()
                 outputs[name] = spec.llm.generate(adapted, **kwargs)
@@ -177,6 +197,7 @@ class LLMManager:
             return result
 
         name, model, adapted = self.select_model(task)
+        self._apply_lora(model, task.lora_adapters)
         start = time.perf_counter()
         result = model.generate(adapted, **kwargs)
         end = time.perf_counter()


### PR DESCRIPTION
## Summary
- allow `LLMManager` to attach LoRA adapters via `peft`
- let `MasterPersonality` and `PlayerPersonality` specify LoRA adapters
- document training and storage of adapters in helper scripts

## Testing
- `pytest` *(fails: 77 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896216e04e88323a602c8e15d1d82c9