### PR TITLE
Port tag processor to Rust and add benchmarks

### DIFF
--- a/benchmarks/tag_processor_benchmark.py
+++ b/benchmarks/tag_processor_benchmark.py
@@ -1,0 +1,98 @@
+"""Simple benchmarks comparing Python and Rust tag parsers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from timeit import timeit
+from typing import List
+
+from src.interaction.tag_processor import TagProcessor, ProcessedTag
+
+
+@dataclass
+class PyTag:
+    type: str
+    subject: str
+    commands: List[str]
+
+
+def python_parse(text: str) -> List[PyTag]:
+    def render(tag: PyTag) -> str:
+        base = f"@{tag.type.capitalize()}: {tag.subject}"
+        if tag.commands:
+            base += " " + " ".join(f"/{c}" for c in tag.commands)
+        return base + "@"
+
+    def parse_tag(segment: str, start: int):
+        i = start + 1
+        colon = segment.find(":", i)
+        if colon == -1:
+            return PyTag("", "", []), [], 1
+        tag_type = segment[i:colon].strip().lower()
+        i = colon + 1
+        content_chars: List[str] = []
+        inner: List[PyTag] = []
+        while i < len(segment):
+            ch = segment[i]
+            if ch == "@":
+                if i + 1 < len(segment) and segment[i + 1] == "@":
+                    content_chars.append("@")
+                    i += 2
+                    continue
+                next_at = segment.find("@", i + 1)
+                next_colon = segment.find(":", i + 1)
+                if next_colon != -1 and (next_at == -1 or next_colon < next_at):
+                    nested_tag, nested_inner, consumed = parse_tag(segment, i)
+                    inner.extend(nested_inner)
+                    inner.append(nested_tag)
+                    content_chars.append(render(nested_tag))
+                    i += consumed
+                    continue
+                i += 1
+                break
+            else:
+                content_chars.append(ch)
+                i += 1
+        content = "".join(content_chars).replace("@@", "@")
+        parts = [p.strip() for p in content.split("/") if p.strip()]
+        first = parts[0] if parts else ""
+        commands: List[str] = []
+        subject = first
+        dash_split = "—" if "—" in first else "-" if "-" in first else None
+        if dash_split:
+            subject, cmd = [p.strip() for p in first.split(dash_split, 1)]
+            if cmd:
+                commands.append(cmd)
+        for p in parts[1:]:
+            commands.append(p)
+        tag = PyTag(tag_type, subject, commands)
+        return tag, inner, i - start
+
+    tags: List[PyTag] = []
+    i = 0
+    while i < len(text):
+        if text[i] == "@":
+            tag, inner_tags, consumed = parse_tag(text, i)
+            tags.extend(inner_tags)
+            if tag.type:
+                tags.append(tag)
+            i += consumed
+        else:
+            i += 1
+    return tags
+
+
+SAMPLE_TEXT = "@Персонаж: Лили /внешность /стиль@" * 50
+
+
+def main() -> None:
+    rust_processor = TagProcessor()
+    py_time = timeit(lambda: python_parse(SAMPLE_TEXT), number=200)
+    rust_time = timeit(lambda: rust_processor.parse(SAMPLE_TEXT), number=200)
+    print(f"Python parser: {py_time:.4f}s for 200 runs")
+    print(f"Rust parser:   {rust_time:.4f}s for 200 runs")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual benchmark
+    main()
+

--- a/rust/neira_rust/Cargo.lock
+++ b/rust/neira_rust/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +73,10 @@ dependencies = [
 name = "neira_rust"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "pyo3",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -190,10 +205,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"

--- a/rust/neira_rust/Cargo.toml
+++ b/rust/neira_rust/Cargo.toml
@@ -9,3 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.20", features = ["extension-module"] }
+once_cell = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+

--- a/rust/neira_rust/src/lib.rs
+++ b/rust/neira_rust/src/lib.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+mod tag_processor;
+
 #[pyfunction]
 fn ping() -> PyResult<&'static str> {
     Ok("pong")
@@ -8,5 +10,9 @@ fn ping() -> PyResult<&'static str> {
 #[pymodule]
 fn neira_rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(ping, m)?)?;
+    m.add_class::<tag_processor::Tag>()?;
+    m.add_function(wrap_pyfunction!(tag_processor::parse, m)?)?;
+    m.add_function(wrap_pyfunction!(tag_processor::suggest_entities, m)?)?;
     Ok(())
 }
+

--- a/rust/neira_rust/src/tag_processor.rs
+++ b/rust/neira_rust/src/tag_processor.rs
@@ -1,0 +1,192 @@
+use pyo3::prelude::*;
+use once_cell::sync::Lazy;
+use std::collections::{HashSet};
+use std::fs;
+use std::sync::Mutex;
+use serde_json::Value;
+
+static ENTITIES: Lazy<Mutex<Vec<String>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+#[pyclass]
+#[derive(Clone, Debug)]
+pub struct Tag {
+    #[pyo3(get, set)]
+    pub r#type: String,
+    #[pyo3(get, set)]
+    pub subject: String,
+    #[pyo3(get, set)]
+    pub commands: Vec<String>,
+}
+
+impl Tag {
+    fn empty() -> Self {
+        Tag { r#type: String::new(), subject: String::new(), commands: Vec::new() }
+    }
+}
+
+fn register_entity(name: &str) {
+    if name.is_empty() {
+        return;
+    }
+    let mut entities = ENTITIES.lock().unwrap();
+    if !entities.iter().any(|e| e == name) {
+        entities.push(name.to_string());
+    }
+}
+
+fn capitalize_first(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+    }
+}
+
+fn render(tag: &Tag) -> String {
+    let mut base = format!("@{}: {}", capitalize_first(&tag.r#type), tag.subject);
+    if !tag.commands.is_empty() {
+        let cmds = tag
+            .commands
+            .iter()
+            .map(|c| format!("/{}", c))
+            .collect::<Vec<_>>()
+            .join(" ");
+        base.push(' ');
+        base.push_str(&cmds);
+    }
+    base.push('@');
+    base
+}
+
+fn find_char(chars: &[char], mut i: usize, target: char) -> Option<usize> {
+    while i < chars.len() {
+        if chars[i] == target {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_tag(chars: &[char], start: usize) -> (Tag, Vec<Tag>, usize) {
+    let mut i = start + 1;
+    let colon = find_char(chars, i, ':');
+    if colon.is_none() {
+        return (Tag::empty(), vec![], 1);
+    }
+    let colon_idx = colon.unwrap();
+    let tag_type = chars[i..colon_idx]
+        .iter()
+        .collect::<String>()
+        .trim()
+        .to_lowercase();
+    i = colon_idx + 1;
+    let mut content_chars: Vec<char> = Vec::new();
+    let mut inner: Vec<Tag> = Vec::new();
+    while i < chars.len() {
+        let ch = chars[i];
+        if ch == '@' {
+            if i + 1 < chars.len() && chars[i + 1] == '@' {
+                content_chars.push('@');
+                i += 2;
+                continue;
+            }
+            let next_at = find_char(chars, i + 1, '@');
+            let next_colon = find_char(chars, i + 1, ':');
+            if let Some(nc) = next_colon {
+                if next_at.is_none() || nc < next_at.unwrap() {
+                    let (nested_tag, nested_inner, consumed) = parse_tag(chars, i);
+                    inner.extend(nested_inner);
+                    inner.push(nested_tag.clone());
+                    for rc in render(&nested_tag).chars() {
+                        content_chars.push(rc);
+                    }
+                    i += consumed;
+                    continue;
+                }
+            }
+            i += 1;
+            break;
+        } else {
+            content_chars.push(ch);
+            i += 1;
+        }
+    }
+    let content = content_chars.iter().collect::<String>().replace("@@", "@");
+    let parts: Vec<String> = content
+        .split('/')
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect();
+    let first = parts.first().cloned().unwrap_or_default();
+    let mut commands: Vec<String> = Vec::new();
+    let mut subject = first.clone();
+    if let Some((s, cmd)) = first
+        .split_once('—')
+        .or_else(|| first.split_once('-'))
+    {
+        subject = s.trim().to_string();
+        let cmd = cmd.trim();
+        if !cmd.is_empty() {
+            commands.push(cmd.to_string());
+        }
+    }
+    for p in parts.iter().skip(1) {
+        commands.push(p.clone());
+    }
+    let tag = Tag { r#type: tag_type, subject: subject.clone(), commands };
+    register_entity(&subject);
+    (tag, inner, i - start)
+}
+
+#[pyfunction]
+pub fn parse(text: &str) -> PyResult<Vec<Tag>> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut tags: Vec<Tag> = Vec::new();
+    let mut i: usize = 0;
+    while i < chars.len() {
+        if chars[i] == '@' {
+            let (tag, mut inner, consumed) = parse_tag(&chars, i);
+            tags.append(&mut inner);
+            if !tag.r#type.is_empty() {
+                tags.push(tag);
+            }
+            i += consumed;
+        } else {
+            i += 1;
+        }
+    }
+    Ok(tags)
+}
+
+#[pyfunction]
+pub fn suggest_entities(prefix: &str) -> PyResult<Vec<String>> {
+    let lower = prefix.to_lowercase();
+    let mut suggestions: Vec<String> = {
+        let entities = ENTITIES.lock().unwrap();
+        entities
+            .iter()
+            .filter(|e| e.to_lowercase().starts_with(&lower))
+            .cloned()
+            .collect()
+    };
+
+    if let Ok(text) = fs::read_to_string("data/knowledge_base/characters.json") {
+        if let Ok(val) = serde_json::from_str::<Value>(&text) {
+            if let Some(obj) = val.as_object() {
+                for info in obj.values() {
+                    if let Some(name) = info.get("name").and_then(|v| v.as_str()) {
+                        if name.to_lowercase().starts_with(&lower) {
+                            suggestions.push(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut seen = HashSet::new();
+    suggestions.retain(|e| seen.insert(e.clone()));
+    Ok(suggestions)
+}
+

--- a/src/interaction/tag_processor.py
+++ b/src/interaction/tag_processor.py
@@ -2,32 +2,21 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from pathlib import Path
 import re
 from typing import List, Optional
 
-from src.analysis import PostProcessor, run_post_processors
-from src.analysis.reasoning_planner import ReasoningStep
-from src.memory.index import MemoryIndex
-from src.memory.knowledge_base import KB_ROOT
-from src.search.retriever import Retriever
-
-
-# ---------------------------------------------------------------------------
-# Tag parsing
-
-
-@dataclass
-class ProcessedTag:
-    type: str
-    subject: str
-    commands: List[str]
+from neira_rust import (
+    parse as _parse_tags,
+    suggest_entities as _suggest_entities,
+    Tag as ProcessedTag,
+)
 
 
 class TagProcessor:
-    """Very small helper for working with ``@тег: значение@`` конструкциями."""
+    """Helper for working with ``@тег: значение@`` constructs."""
 
     SLASH_COMMANDS = ["help", "exit", "сгенерировать"]
 
@@ -35,116 +24,11 @@ class TagProcessor:
     def available_tags() -> List[str]:  # pragma: no cover - simple constant
         return ["Нейра", "Персонаж", "Сцена", "Эмоция", "Стиль", "Место"]
 
-    # Basic entity storage for hint generation
-    def __init__(self) -> None:
-        self._entities: List[str] = []
-
-    # Parsing ------------------------------------------------------------
     def parse(self, text: str) -> List[ProcessedTag]:
-        """Parse ``text`` for ``@тег: значение@`` constructs.
-
-        The parser supports nested tags and escaping of the ``@`` symbol via a
-        double ``@@`` sequence.  Commands can be supplied using either an em-dash
-        (``—``) or a regular hyphen after the subject and additional commands can
-        follow separated by ``/``.
-        """
-
-        def render(tag: ProcessedTag) -> str:
-            base = f"@{tag.type.capitalize()}: {tag.subject}"
-            if tag.commands:
-                base += " " + " ".join(f"/{c}" for c in tag.commands)
-            return base + "@"
-
-        def parse_tag(segment: str, start: int) -> tuple[ProcessedTag, List[ProcessedTag], int]:
-            i = start + 1
-            colon = segment.find(":", i)
-            if colon == -1:
-                return ProcessedTag("", "", []), [], 1
-            tag_type = segment[i:colon].strip().lower()
-            i = colon + 1
-            content_chars: List[str] = []
-            inner: List[ProcessedTag] = []
-            while i < len(segment):
-                ch = segment[i]
-                if ch == "@":
-                    if i + 1 < len(segment) and segment[i + 1] == "@":
-                        content_chars.append("@")
-                        i += 2
-                        continue
-                    next_at = segment.find("@", i + 1)
-                    next_colon = segment.find(":", i + 1)
-                    if next_colon != -1 and (next_at == -1 or next_colon < next_at):
-                        nested_tag, nested_inner, consumed = parse_tag(segment, i)
-                        inner.extend(nested_inner)
-                        inner.append(nested_tag)
-                        content_chars.append(render(nested_tag))
-                        i += consumed
-                        continue
-                    i += 1
-                    break
-                else:
-                    content_chars.append(ch)
-                    i += 1
-            content = "".join(content_chars).replace("@@", "@")
-            parts = [p.strip() for p in content.split("/") if p.strip()]
-            first = parts[0] if parts else ""
-            commands: List[str] = []
-            subject = first
-            dash_split = "—" if "—" in first else "-" if "-" in first else None
-            if dash_split:
-                subject, cmd = [p.strip() for p in first.split(dash_split, 1)]
-                if cmd:
-                    commands.append(cmd)
-            for p in parts[1:]:
-                commands.append(p)
-            tag = ProcessedTag(tag_type, subject, commands)
-            self.register_entity(subject)
-            return tag, inner, i - start
-
-        tags: List[ProcessedTag] = []
-        i = 0
-        while i < len(text):
-            if text[i] == "@":
-                tag, inner_tags, consumed = parse_tag(text, i)
-                tags.extend(inner_tags)
-                if tag.type:
-                    tags.append(tag)
-                i += consumed
-            else:
-                i += 1
-        return tags
-
-    # Hint helpers -------------------------------------------------------
-    def register_entity(self, name: str) -> None:
-        if name and name not in self._entities:
-            self._entities.append(name)
+        return _parse_tags(text)
 
     def suggest_entities(self, prefix: str) -> List[str]:
-        """Return known entities starting with ``prefix``.
-
-        Entities are collected from previously parsed tags as well as the
-        knowledge base stored in :mod:`src.memory.knowledge_base`.
-        """
-
-        suggestions = [
-            e for e in self._entities if e.lower().startswith(prefix.lower())
-        ]
-        kb_file = KB_ROOT / "characters.json"
-        try:
-            data = json.loads(kb_file.read_text(encoding="utf-8"))
-            for info in data.values():
-                name = info.get("name", "")
-                if name.lower().startswith(prefix.lower()):
-                    suggestions.append(name)
-        except Exception:
-            pass
-        seen: set[str] = set()
-        result: List[str] = []
-        for name in suggestions:
-            if name not in seen:
-                seen.add(name)
-                result.append(name)
-        return result
+        return _suggest_entities(prefix)
 
     def generate_hints(self, prefix: str) -> List[str]:
         return self.suggest_entities(prefix)
@@ -152,6 +36,8 @@ class TagProcessor:
     # ------------------------------------------------------------------
     def extract_style_examples(self, text: str) -> List[str]:
         """Extract style examples marked by special blocks and persist them."""
+
+        from src.memory.knowledge_base import KB_ROOT
 
         pattern = re.compile(
             r"\[Пример стиля автора,.*?\](.*?)\[Пример окончен\]",
@@ -181,13 +67,12 @@ class TagProcessor:
         retriever: Retriever | None = None,
         post_processors: List[PostProcessor] | None = None,
     ) -> str:
-        """Execute ``plan`` handling ``ACT`` steps.
+        """Execute ``plan`` handling ``ACT`` steps."""
 
-        ``ACT`` steps with ``source='memory'`` query :class:`MemoryIndex` while
-        ``source='rag'`` steps leverage :class:`src.search.retriever.Retriever`.
-        After all actions are performed the aggregated text is run through the
-        provided ``post_processors`` using :func:`run_post_processors`.
-        """
+        from src.analysis import PostProcessor, run_post_processors
+        from src.analysis.reasoning_planner import ReasoningStep
+        from src.memory.index import MemoryIndex
+        from src.search.retriever import Retriever
 
         outputs: List[str] = []
         mem = memory or MemoryIndex()
@@ -234,9 +119,6 @@ class TagProcessor:
 # ---------------------------------------------------------------------------
 # Command handling
 
-from dataclasses import dataclass
-
-
 @dataclass
 class CommandResult:
     text: str = ""
@@ -268,3 +150,4 @@ def handle_command(neyra, text: str, processor: TagProcessor) -> CommandResult:
 
 
 __all__ = ["TagProcessor", "ProcessedTag", "handle_command", "CommandResult"]
+

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -1,17 +1,7 @@
-"""Memory subsystem classes and utilities."""
+"""Memory subsystem classes and utilities with lazy loading."""
 
-from .character_memory import CharacterMemory
-from .emotional_memory import EmotionalMemory
-from .story_timeline import StoryTimeline
-from .world_atlas import WorldAtlas
-from .world_memory import WorldMemory
-from .style_memory import StyleMemory
-from .index import MemoryIndex
-from .embedding_memory import EmbeddingMemory
-from .weighted import WeightedMemory
-from .multi_grid import MultiGridMemory
-from .lazy_loader import LazyMemoryLoader
-from .knowledge_graph import KnowledgeGraph, knowledge_graph
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "CharacterMemory",
@@ -28,3 +18,28 @@ __all__ = [
     "KnowledgeGraph",
     "knowledge_graph",
 ]
+
+_MODULES = {
+    "CharacterMemory": "character_memory",
+    "EmotionalMemory": "emotional_memory",
+    "StoryTimeline": "story_timeline",
+    "WorldAtlas": "world_atlas",
+    "WorldMemory": "world_memory",
+    "StyleMemory": "style_memory",
+    "MemoryIndex": "index",
+    "EmbeddingMemory": "embedding_memory",
+    "WeightedMemory": "weighted",
+    "MultiGridMemory": "multi_grid",
+    "LazyMemoryLoader": "lazy_loader",
+    "KnowledgeGraph": "knowledge_graph",
+    "knowledge_graph": "knowledge_graph",
+}
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple proxy
+    module_name = _MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__} has no attribute {name}")
+    module = import_module(f".{module_name}", __name__)
+    return getattr(module, name)
+


### PR DESCRIPTION
## Summary
- Add `tag_processor` Rust module exporting `parse` and `suggest_entities`
- Wrap Rust parser in Python `TagProcessor` and lazily load heavy dependencies
- Provide a benchmark comparing Python and Rust tag parsing speeds

## Testing
- `cargo test`
- `python -m pytest tests/test_interaction/test_tag_processor.py`
- `PYTHONPATH=. python benchmarks/tag_processor_benchmark.py`


------
https://chatgpt.com/codex/tasks/task_e_68962a0ff6108323b513c42ddbd3c2bd