### PR TITLE
Add performance profiling with adaptive iteration tuning

### DIFF
--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -42,6 +42,7 @@ from src.iteration import (
 from src.models import Character
 from src.core.cache_manager import CacheManager
 from src.ui import update_progress
+from src.monitoring import PerformanceProfiler
 
 
 class Neyra:
@@ -99,8 +100,27 @@ class Neyra:
         self.current_style = ""
         self.history = RequestHistory(load_existing=False)
         self.cache = CacheManager()
+        self.profiler = PerformanceProfiler()
+        self.optimization_history: List[str] = []
+        self.time_threshold = 0.5
+        self.memory_threshold = 10_000_000.0
 
         self.logger.info("Нейра проснулась! ✨")
+
+    # ------------------------------------------------------------------
+    def _check_and_optimize(self, iteration: int) -> None:
+        """Adjust behaviour based on profiler metrics."""
+        suggestions = self.profiler.suggest_optimizations()
+        for name, data in self.profiler.metrics.items():
+            if data["time"] > self.time_threshold or data["memory"] > self.memory_threshold:
+                if name == "search_sources":
+                    self.deep_searcher.parallel = False
+                self.iteration_controller.max_iterations = min(
+                    self.iteration_controller.max_iterations, iteration
+                )
+        if suggestions:
+            self.optimization_history.extend(suggestions)
+        self.profiler.metrics.clear()
 
     # ------------------------------------------------------------------
     def _apply_memory_set(self, user_id: str) -> None:
@@ -271,8 +291,11 @@ class Neyra:
         user_id = getattr(self, "current_user_id", "default")
         self.style_memory.add(user_id, f"language:{language}")
         self.style_memory.save()
-        self.last_draft = self.draft_generator.generate_draft(
-            text, self.verification_system.memory
+        self.last_draft = self.profiler.profile_operation(
+            "generate_draft",
+            self.draft_generator.generate_draft,
+            text,
+            self.verification_system.memory,
         )
         tags = self.parser.parse_user_input(text)
 
@@ -329,12 +352,14 @@ class Neyra:
             self.iteration_controller.max_critical_spaces = (
                 strategy.max_critical_spaces
             )
+        self.profiler.metrics.clear()
         token_manager = TokenBudgetManager(self.llm_max_tokens)
         self.token_budget_manager = token_manager
         prev_tokens = self.llm_max_tokens
         self.llm_max_tokens = token_manager.draft_tokens
         response = self.process_command(query)
         self.llm_max_tokens = prev_tokens
+        self._check_and_optimize(1)
         draft = self.last_draft or response
         self.deep_searcher.token_budget_manager = token_manager
         iteration = 1
@@ -345,20 +370,27 @@ class Neyra:
             self.logger.info("Iteration %s started", iteration)
             gaps = self.gap_analyzer.analyze(draft)
             if gaps:
-                search_results: List[Dict[str, Any]] = []
                 self.deep_searcher.current_queries = len(gaps)
                 search_limit = token_manager.search_limit(len(gaps))
-                for gap in gaps:
-                    try:
-                        search_results.extend(
-                            self.deep_searcher.search(
-                                gap.claim,
-                                user_id=getattr(self, "current_user_id", "default"),
-                                limit=search_limit,
+
+                def perform_search() -> List[Dict[str, Any]]:
+                    results: List[Dict[str, Any]] = []
+                    for gap in gaps:
+                        try:
+                            results.extend(
+                                self.deep_searcher.search(
+                                    gap.claim,
+                                    user_id=getattr(self, "current_user_id", "default"),
+                                    limit=search_limit,
+                                )
                             )
-                        )
-                    except Exception:
-                        continue
+                        except Exception:
+                            continue
+                    return results
+
+                search_results: List[Dict[str, Any]] = self.profiler.profile_operation(
+                    "search_sources", perform_search
+                )
                 prev_tokens = self.llm_max_tokens
                 self.llm_max_tokens = token_manager.refine_tokens
                 result = self.response_enhancer.enhance(
@@ -374,6 +406,7 @@ class Neyra:
             log_metrics(iteration, previous, response)
             self.logger.info("Iteration %s completed", iteration)
             draft = response
+            self._check_and_optimize(iteration)
             if (
                 iteration >= self.iteration_controller.min_iterations
                 and self.iteration_controller.assess_quality(response)
@@ -385,12 +418,15 @@ class Neyra:
                 break
             iteration += 1
         if not skip_check:
-            response, corrections = run_post_processors(
+            response, corrections = self.profiler.profile_operation(
+                "post_processing",
+                run_post_processors,
                 response,
                 self.post_processors,
                 candidate_generator=self.candidate_generator,
                 candidate_selector=self.candidate_selector,
             )
+            self._check_and_optimize(iteration)
             if corrections:
                 all_corrections.extend(corrections)
         update_progress("finished", iteration)

--- a/tests/monitoring/test_auto_optimization.py
+++ b/tests/monitoring/test_auto_optimization.py
@@ -1,0 +1,118 @@
+import sys
+import types
+import time
+from pathlib import Path
+
+# Stubs for optional dependencies
+sys.modules.setdefault(
+    "neira_rust",
+    types.SimpleNamespace(
+        ping=lambda: "pong",
+        KnowledgeGraph=object,
+        MemoryIndex=object,
+        VerificationResult=object,
+        verify_claim=lambda *_a, **_k: True,
+        parse=lambda *_a, **_k: [],
+        suggest_entities=lambda *_a, **_k: [],
+        Tag=object,
+    ),
+)
+
+stub = types.ModuleType("prompt_toolkit")
+stub.PromptSession = object
+completion = types.ModuleType("prompt_toolkit.completion")
+completion.WordCompleter = object
+history = types.ModuleType("prompt_toolkit.history")
+history.InMemoryHistory = object
+sys.modules.setdefault("prompt_toolkit", stub)
+sys.modules.setdefault("prompt_toolkit.completion", completion)
+sys.modules.setdefault("prompt_toolkit.history", history)
+
+rich = types.ModuleType("rich")
+console = types.ModuleType("rich.console")
+console.Console = object
+markdown = types.ModuleType("rich.markdown")
+markdown.Markdown = object
+panel = types.ModuleType("rich.panel")
+panel.Panel = object
+sys.modules.setdefault("rich", rich)
+sys.modules.setdefault("rich.console", console)
+sys.modules.setdefault("rich.markdown", markdown)
+sys.modules.setdefault("rich.panel", panel)
+
+sentence_transformers = types.ModuleType("sentence_transformers")
+
+class _DummyST:
+    def __init__(self, *a, **k):
+        pass
+
+    def encode(self, *a, **k):
+        return []
+
+sentence_transformers.SentenceTransformer = _DummyST
+sys.modules.setdefault("sentence_transformers", sentence_transformers)
+
+requests = types.ModuleType("requests")
+requests.get = lambda *a, **k: None
+class _DummySession:
+    def get(self, *a, **k):
+        return types.SimpleNamespace(json=lambda: {})
+
+requests.Session = _DummySession
+sys.modules.setdefault("requests", requests)
+
+yaml = types.ModuleType("yaml")
+yaml.safe_load = lambda *a, **k: {}
+sys.modules.setdefault("yaml", yaml)
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core.neyra_brain import Neyra, NeyraConfig
+from src.iteration import KnowledgeGap
+
+
+def test_slow_search_disables_parallel_and_reduces_iterations(monkeypatch):
+    neyra = Neyra()
+    neyra.iteration_controller.max_iterations = 3
+    neyra.time_threshold = 0.01
+    neyra.deep_searcher.parallel = True
+    neyra.verification_system.memory = {}
+
+    monkeypatch.setattr(
+        neyra.gap_analyzer,
+        "analyze",
+        lambda draft: [KnowledgeGap(claim=draft, questions=[], confidence=0.0)],
+    )
+    def slow_search(*args, **kwargs):
+        time.sleep(0.02)
+        return []
+    monkeypatch.setattr(neyra.deep_searcher, "search", slow_search)
+    monkeypatch.setattr(neyra.response_enhancer, "enhance", lambda t, r, i: t)
+
+    neyra.iterative_response("@Проверка:нет@ ___")
+
+    assert neyra.deep_searcher.parallel is False
+    assert neyra.iteration_controller.max_iterations == 1
+    assert any("search_sources" in msg for msg in neyra.optimization_history)
+
+
+def test_slow_post_processing_reduces_iterations(monkeypatch):
+    neyra = Neyra(NeyraConfig(min_iterations=1))
+    neyra.iteration_controller.max_iterations = 3
+    neyra.time_threshold = 0.01
+    neyra.verification_system.memory = {}
+
+    monkeypatch.setattr(neyra.gap_analyzer, "analyze", lambda draft: [])
+    monkeypatch.setattr(neyra.deep_searcher, "search", lambda *a, **k: [])
+    monkeypatch.setattr(neyra.response_enhancer, "enhance", lambda t, r, i: t)
+
+    def slow_post(text, processors, candidate_generator=None, candidate_selector=None):
+        time.sleep(0.02)
+        return text, []
+
+    monkeypatch.setattr("src.core.neyra_brain.run_post_processors", slow_post)
+
+    neyra.iterative_response("просто текст")
+
+    assert neyra.iteration_controller.max_iterations == 1
+    assert any("post_processing" in msg for msg in neyra.optimization_history)


### PR DESCRIPTION
## Summary
- wrap draft generation, search, and post-processing in PerformanceProfiler
- auto-reduce iterations or disable parallel search when resource usage is high
- record optimization history and expose thresholds
- test dynamic load reduction via slow search and post-processing

## Testing
- `pytest tests/monitoring/test_auto_optimization.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neira_rust')*


------
https://chatgpt.com/codex/tasks/task_e_689648b634ec8323bd70579e0f95f2b1