### PR TITLE
Add adaptive loader for resource-based component management

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -2,10 +2,20 @@ from .cache_manager import CacheManager
 from .ai_personality import AIPersonality
 from .personality_context import PersonalityContext
 from .session_memory import SessionMemory
+from .adaptive_loader import (
+    enable,
+    disable,
+    determine_active_components,
+    resource_manager,
+)
 
 __all__ = [
     "CacheManager",
     "AIPersonality",
     "PersonalityContext",
     "SessionMemory",
+    "enable",
+    "disable",
+    "determine_active_components",
+    "resource_manager",
 ]

--- a/src/core/adaptive_loader.py
+++ b/src/core/adaptive_loader.py
@@ -1,0 +1,114 @@
+"""Adaptive component loader using :class:`ResourceManager`.
+
+This module lazily imports Python components when needed and releases them
+again when they are no longer required.  The :func:`enable` function attempts
+to allocate resources for the requested component via
+``ResourceManager.allocate`` before importing the module.  When
+``disable`` is called, the module is removed from ``sys.modules`` and any
+allocated resources are returned to the manager.
+
+In addition the :func:`determine_active_components` helper can be used to
+decide which components should remain active based on the current system load
+as reported by :class:`ResourceManager`.
+"""
+
+from __future__ import annotations
+
+import gc
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, Iterable, List
+
+import importlib.util
+
+
+def _load_resource_manager() -> type:
+    """Load ``ResourceManager`` without importing the full package."""
+
+    path = Path(__file__).resolve().parent.parent / "iteration" / "resource_manager.py"
+    spec = importlib.util.spec_from_file_location("_resource_manager", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader  # for type checkers
+    sys.modules["_resource_manager"] = module
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module.ResourceManager
+
+
+ResourceManager = _load_resource_manager()
+
+# Global resource manager used by the loader.
+resource_manager = ResourceManager()
+
+# Registry of currently loaded components and their resource allocations.
+_loaded: Dict[str, ModuleType] = {}
+_allocations: Dict[str, int] = {}
+
+
+def enable(component: str, amount: int = 1) -> ModuleType:
+    """Lazily import ``component`` and allocate resources for it.
+
+    Parameters
+    ----------
+    component:
+        Dotted module path of the component to load.
+    amount:
+        Amount of CPU units to request from :data:`resource_manager`.
+    """
+
+    if component in _loaded:
+        return _loaded[component]
+
+    if not resource_manager.allocate(component, amount):
+        raise RuntimeError(f"insufficient resources for {component}")
+
+    module = importlib.import_module(component)
+    _loaded[component] = module
+    _allocations[component] = amount
+    return module
+
+
+def disable(component: str) -> None:
+    """Unload ``component`` and release its resources."""
+
+    module = _loaded.pop(component, None)
+    if module is None:
+        return
+
+    resource_manager.release(component)
+    sys.modules.pop(component, None)
+    _allocations.pop(component, None)
+
+    # Trigger garbage collection to free memory eagerly.
+    gc.collect()
+
+
+def determine_active_components(
+    load_profile: str, candidates: Iterable[str]
+) -> List[str]:
+    """Return the subset of ``candidates`` that should stay active.
+
+    The decision is based on the current CPU and memory usage reported by
+    :data:`resource_manager` in combination with ``load_profile``.  The
+    ``load_profile`` can be one of ``"low"``, ``"medium"`` or ``"high"`` and
+    controls how aggressively components are pruned when system resources are
+    under pressure.
+    """
+
+    cpu_usage, mem_usage = resource_manager.update_usage()
+    thresholds = {"low": 90.0, "medium": 75.0, "high": 50.0}
+    limit = thresholds.get(load_profile, 75.0)
+
+    if cpu_usage > limit or mem_usage > limit:
+        return []
+    return list(candidates)
+
+
+__all__ = [
+    "enable",
+    "disable",
+    "determine_active_components",
+    "resource_manager",
+]
+

--- a/tests/core/test_adaptive_loader.py
+++ b/tests/core/test_adaptive_loader.py
@@ -1,0 +1,48 @@
+import gc
+import sys
+import weakref
+
+from src.core import adaptive_loader
+
+
+def test_enable_and_disable_releases_resources(tmp_path):
+    module_name = "dummy_module"
+    module_code = (
+        "class Big:\n"
+        "    def __init__(self):\n"
+        "        self.data = [0] * 100000\n"
+        "DATA = Big()\n"
+    )
+    module_file = tmp_path / f"{module_name}.py"
+    module_file.write_text(module_code, encoding="utf-8")
+    sys.path.insert(0, str(tmp_path))
+
+    try:
+        rm = adaptive_loader.resource_manager
+        before_cpu = rm.available_cpu
+
+        mod = adaptive_loader.enable(module_name)
+        assert module_name in sys.modules
+        assert rm.available_cpu == before_cpu - 1
+
+        ref = weakref.ref(mod.DATA)
+
+        adaptive_loader.disable(module_name)
+        del mod
+        gc.collect()
+
+        assert ref() is None
+        assert module_name not in sys.modules
+        assert rm.available_cpu == before_cpu
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_determine_active_components_respects_profile(monkeypatch):
+    def fake_update() -> tuple[float, float]:
+        return 99.0, 99.0
+
+    monkeypatch.setattr(adaptive_loader.resource_manager, "update_usage", fake_update)
+    result = adaptive_loader.determine_active_components("medium", ["a", "b"])
+    assert result == []
+


### PR DESCRIPTION
## Summary
- add adaptive loader that lazily imports modules and releases resources
- integrate loader into core package exports
- test component enabling/disabling and resource checks

## Testing
- `PYTHONPATH=. pytest tests/core/test_adaptive_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896539390fc83239e7f0ddacd9d338c