### PR TITLE
Add resource demand predictor and integrate into planning

### DIFF
--- a/src/iteration/resource_manager.py
+++ b/src/iteration/resource_manager.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 import os
 import heapq
+import math
 from collections import defaultdict, deque
+
+from optimization import UsagePredictor
 
 try:  # pragma: no cover - optional dependency
     import psutil
@@ -59,6 +62,9 @@ class ResourceManager:
 
         # Historical usage statistics for moving average per component
         self.resource_usage: Dict[Any, deque[int]] = defaultdict(lambda: deque(maxlen=5))
+
+        # Demand forecasting helper
+        self._predictor = UsagePredictor()
 
         # System usage metrics updated via psutil
         self.current_cpu_usage: float = 0.0
@@ -147,6 +153,7 @@ class ResourceManager:
         """Store historical usage for ``component``."""
 
         self.resource_usage[component].append(amount)
+        self._predictor.record(component, amount)
 
     def get_moving_average(self, component: Any, window: int = 5) -> float:
         """Return moving average of recent allocations for ``component``."""
@@ -155,6 +162,11 @@ class ResourceManager:
         if not data:
             return 0.0
         return sum(data) / len(data)
+
+    def predict_next_demand(self, component: Any) -> float:
+        """Forecast the next allocation amount for ``component``."""
+
+        return self._predictor.predict(component)
 
     # ------------------------------------------------------------------
     def _schedule(self) -> None:
@@ -166,10 +178,12 @@ class ResourceManager:
         pending: List[Tuple[int, Any, int]] = []
         while self._queue:
             priority, component, amount = heapq.heappop(self._queue)
-            if amount <= self.available_cpu:
-                self.available_cpu -= amount
-                self.allocations[component] = amount
-                self._record_usage(component, amount)
+            predicted = max(float(amount), self.predict_next_demand(component))
+            required = int(math.ceil(predicted))
+            if required <= self.available_cpu:
+                self.available_cpu -= required
+                self.allocations[component] = required
+                self._record_usage(component, required)
             else:
                 pending.append((priority, component, amount))
 

--- a/src/optimization/__init__.py
+++ b/src/optimization/__init__.py
@@ -1,0 +1,5 @@
+"""Optimization utilities including demand prediction."""
+
+from .usage_predictor import UsagePredictor
+
+__all__ = ["UsagePredictor"]

--- a/src/optimization/usage_predictor.py
+++ b/src/optimization/usage_predictor.py
@@ -1,0 +1,53 @@
+"""Predict future resource demand based on historical allocations.
+
+The :class:`UsagePredictor` stores recent resource usage for arbitrary
+components and applies simple exponential smoothing to forecast the next
+expected demand.  The implementation intentionally avoids external
+dependencies to keep unit tests lightweight.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Any, Deque, Dict
+
+
+class UsagePredictor:
+    """Track usage history and forecast the next demand value.
+
+    Parameters
+    ----------
+    alpha:
+        Smoothing factor for exponential smoothing. Values closer to ``1``
+        weight recent observations more heavily.
+    history_size:
+        Maximum number of historical samples retained for each component.
+    """
+
+    def __init__(self, alpha: float = 0.5, history_size: int = 20) -> None:
+        self.alpha = float(alpha)
+        self._history: Dict[Any, Deque[float]] = defaultdict(
+            lambda: deque(maxlen=history_size)
+        )
+        self._smoothed: Dict[Any, float] = {}
+
+    # ------------------------------------------------------------------
+    def record(self, component: Any, amount: float) -> None:
+        """Record ``amount`` of resources used by ``component``."""
+
+        hist = self._history[component]
+        hist.append(float(amount))
+        if component not in self._smoothed:
+            self._smoothed[component] = float(amount)
+        else:
+            prev = self._smoothed[component]
+            self._smoothed[component] = self.alpha * float(amount) + (1 - self.alpha) * prev
+
+    # ------------------------------------------------------------------
+    def predict(self, component: Any) -> float:
+        """Return the forecasted demand for ``component``."""
+
+        return self._smoothed.get(component, 0.0)
+
+
+__all__ = ["UsagePredictor"]

--- a/tests/iteration/test_resource_manager.py
+++ b/tests/iteration/test_resource_manager.py
@@ -1,9 +1,16 @@
 import sys
-import psutil
+import math
+import pytest
 
+try:  # pragma: no cover - optional dependency
+    import psutil
+except Exception:  # pragma: no cover - handled gracefully
+    psutil = None  # type: ignore[assignment]
 
 import importlib.util
 from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
 
 module_path = Path(__file__).resolve().parents[2] / "src/iteration/resource_manager.py"
 spec = importlib.util.spec_from_file_location("resource_manager", module_path)
@@ -33,6 +40,9 @@ def test_high_resource_config() -> None:
 
 
 def test_system_usage(monkeypatch) -> None:
+    if psutil is None:
+        pytest.skip("psutil not installed")
+
     class DummyMem:
         percent = 40.0
 
@@ -82,3 +92,21 @@ def test_moving_average() -> None:
     manager.allocate(c, 6)
     manager.release(c)
     assert manager.get_moving_average(c) == 4.0
+
+
+def test_demand_prediction() -> None:
+    class Comp:
+        def __init__(self, priority: int) -> None:
+            self.priority = priority
+
+    c = Comp(priority=1)
+    manager = ResourceManager(gpu_memory=0, cpu_cores=10)
+    # Repeating pattern to build history
+    for amount in [2, 4, 2, 4]:
+        manager._record_usage(c, amount)
+
+    predicted = manager.predict_next_demand(c)
+    assert predicted == pytest.approx(3.25, rel=1e-2)
+
+    assert manager.allocate(c, 1) is True
+    assert manager.allocations[c] == math.ceil(predicted)


### PR DESCRIPTION
## Summary
- Implement exponential-smoothing `UsagePredictor` for forecasting resource demand
- Integrate predictions into `ResourceManager` via new `predict_next_demand` and use during scheduling
- Test repeated usage patterns to verify forecasting and allocation behavior

## Testing
- `pytest tests/iteration/test_resource_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896591803388323886cd5a118874f57