### PR TITLE
feat(core): add state manager

### DIFF
--- a/src/action/__init__.py
+++ b/src/action/__init__.py
@@ -2,4 +2,37 @@ from .dialogue_master import DialogueMaster
 from .scene_painter import ScenePainter
 from .description_writer import DescriptionWriter
 
-__all__ = ["DialogueMaster", "ScenePainter", "DescriptionWriter"]
+from src.core.state_manager import StateManager
+
+__all__ = [
+    "DialogueMaster",
+    "ScenePainter",
+    "DescriptionWriter",
+    "action_state",
+    "begin",
+    "commit",
+    "rollback",
+]
+
+# Global state manager for the action subsystem.  Action classes can store
+# and restore their state via this manager when complex sequences require
+# rollback capability.
+action_state = StateManager()
+
+
+def begin() -> None:
+    """Create a snapshot of the action state."""
+
+    action_state.begin()
+
+
+def commit() -> None:
+    """Commit changes since the last :func:`begin`."""
+
+    action_state.commit()
+
+
+def rollback() -> None:
+    """Restore the action state from the last snapshot."""
+
+    action_state.rollback()

--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -13,6 +13,8 @@ from .candidate_generator import CandidateGenerator
 from .candidate_selector import CandidateSelector
 from .reasoning_planner import ReasoningPlanner, ReasoningStep
 
+from src.core.state_manager import StateManager
+
 POST_PROCESSOR_REGISTRY = {
     "GrammarProofreader": GrammarProofreader,
 }
@@ -34,4 +36,30 @@ __all__ = [
     "verify_claim",
     "ReasoningPlanner",
     "ReasoningStep",
+    "analysis_state",
+    "begin",
+    "commit",
+    "rollback",
 ]
+
+# Global state manager for analysis subsystem to allow transactional
+# operations when multiple analysis components interact.
+analysis_state = StateManager()
+
+
+def begin() -> None:
+    """Create a snapshot of the analysis state."""
+
+    analysis_state.begin()
+
+
+def commit() -> None:
+    """Commit changes performed since the last :func:`begin`."""
+
+    analysis_state.commit()
+
+
+def rollback() -> None:
+    """Restore the analysis state from the last snapshot."""
+
+    analysis_state.rollback()

--- a/src/core/state_manager.py
+++ b/src/core/state_manager.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Generic state snapshot manager.
+
+This module provides :class:`StateManager` which offers a minimal
+transaction-like interface for Python objects. Components can register
+arbitrary pieces of state with the manager and then use ``begin``,
+``commit`` and ``rollback`` to manage snapshots of that state.  The
+snapshots are created using :func:`copy.deepcopy` so that mutations after
+``begin`` do not affect the stored copy.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+import copy
+
+
+@dataclass
+class _Snapshot:
+    """Container for a single state snapshot."""
+
+    data: Dict[str, Any]
+
+
+class StateManager:
+    """Keep track of subsystem state and allow rollbacks.
+
+    The manager stores named pieces of state in ``_state``.  Calling
+    :meth:`begin` takes a deep copy of the current state and pushes it on a
+    stack.  :meth:`commit` discards the most recent snapshot while
+    :meth:`rollback` restores the last snapshot.
+    """
+
+    def __init__(self) -> None:
+        self._state: Dict[str, Any] = {}
+        self._history: List[_Snapshot] = []
+
+    # ------------------------------------------------------------------
+    def register(self, name: str, value: Any) -> None:
+        """Register ``value`` under ``name`` in the current state."""
+
+        self._state[name] = value
+
+    def get(self, name: str) -> Any:
+        """Return previously registered state ``name`` if present."""
+
+        return self._state.get(name)
+
+    # ------------------------------------------------------------------
+    # transaction handling
+    def begin(self) -> None:
+        """Store a snapshot of the current state."""
+
+        snapshot = copy.deepcopy(self._state)
+        self._history.append(_Snapshot(snapshot))
+
+    def commit(self) -> None:
+        """Discard the last stored snapshot."""
+
+        if not self._history:
+            raise RuntimeError("no transaction to commit")
+        self._history.pop()
+
+    def rollback(self) -> None:
+        """Restore the most recent snapshot."""
+
+        if not self._history:
+            raise RuntimeError("no transaction to rollback")
+        snapshot = self._history.pop()
+        self._state = snapshot.data
+
+    # ------------------------------------------------------------------
+    @property
+    def state(self) -> Dict[str, Any]:
+        """Expose the current state mapping."""
+
+        return self._state
+
+
+__all__ = ["StateManager"]

--- a/src/memory/__init__.py
+++ b/src/memory/__init__.py
@@ -3,6 +3,8 @@
 from importlib import import_module
 from typing import Any
 
+from src.core.state_manager import StateManager
+
 __all__ = [
     "CharacterMemory",
     "EmotionalMemory",
@@ -17,6 +19,10 @@ __all__ = [
     "LazyMemoryLoader",
     "KnowledgeGraph",
     "knowledge_graph",
+    "memory_state",
+    "begin",
+    "commit",
+    "rollback",
 ]
 
 _MODULES = {
@@ -34,6 +40,28 @@ _MODULES = {
     "KnowledgeGraph": "knowledge_graph",
     "knowledge_graph": "knowledge_graph",
 }
+
+# Global state manager for the memory subsystem.  Components that mutate
+# memory can register their state here to support transactional rollbacks.
+memory_state = StateManager()
+
+
+def begin() -> None:
+    """Create a memory state snapshot."""
+
+    memory_state.begin()
+
+
+def commit() -> None:
+    """Commit changes made since the last :func:`begin`."""
+
+    memory_state.commit()
+
+
+def rollback() -> None:
+    """Restore memory state from the last snapshot."""
+
+    memory_state.rollback()
 
 
 def __getattr__(name: str) -> Any:  # pragma: no cover - simple proxy


### PR DESCRIPTION
## Summary
- add StateManager with snapshot-based begin/commit/rollback
- wire Memory, Analysis and Action subsystems to the new state manager

## Testing
- `pytest` (fails: ImportError: cannot import name 'KnowledgeGraph' from 'neira_rust')

------
https://chatgpt.com/codex/tasks/task_e_6896678cbb3083239e27260589246774