### PR TITLE
Add lifecycle manager with module health checks

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -22,6 +22,7 @@ except Exception:  # pragma: no cover - fallback when optional modules missing
     resource_manager = None
 from .event_bus import Event, EventBus
 from .priority_scheduler import Priority, PriorityScheduler
+from .lifecycle import BaseModule, LifecycleManager
 
 __all__ = [
     "CacheManager",
@@ -36,4 +37,6 @@ __all__ = [
     "EventBus",
     "Priority",
     "PriorityScheduler",
+    "BaseModule",
+    "LifecycleManager",
 ]

--- a/src/core/lifecycle.py
+++ b/src/core/lifecycle.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Set
+
+
+class BaseModule:
+    """Base interface for components managed by ``LifecycleManager``."""
+
+    def start(self) -> None:  # pragma: no cover - interface method
+        """Initialise module resources."""
+
+    def stop(self) -> None:  # pragma: no cover - interface method
+        """Release any held resources."""
+
+    def health_check(self) -> bool:
+        """Return ``True`` when the module is healthy."""
+        return True
+
+
+@dataclass
+class ModuleRegistration:
+    module: BaseModule
+    dependencies: List[str] = field(default_factory=list)
+
+
+class LifecycleManager:
+    """Coordinate start/stop order and health checks for modules."""
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, ModuleRegistration] = {}
+        self._start_order: List[str] = []
+
+    # ------------------------------------------------------------------
+    def register(
+        self, name: str, module: BaseModule, dependencies: Iterable[str] | None = None
+    ) -> None:
+        """Register a module and its dependencies."""
+
+        self._modules[name] = ModuleRegistration(
+            module=module, dependencies=list(dependencies or [])
+        )
+
+    # ------------------------------------------------------------------
+    def _resolve_order(self) -> List[str]:
+        """Topologically sort modules to respect dependencies."""
+
+        order: List[str] = []
+        temp: Set[str] = set()
+        perm: Set[str] = set()
+
+        def visit(node: str) -> None:
+            if node in perm:
+                return
+            if node in temp:
+                raise ValueError(f"Circular dependency for module '{node}'")
+            temp.add(node)
+            for dep in self._modules[node].dependencies:
+                if dep not in self._modules:
+                    raise KeyError(f"Unknown dependency '{dep}' for module '{node}'")
+                visit(dep)
+            temp.remove(node)
+            perm.add(node)
+            order.append(node)
+
+        for name in list(self._modules):
+            visit(name)
+
+        return order
+
+    # ------------------------------------------------------------------
+    def start_all(self) -> None:
+        """Start all registered modules in dependency order."""
+
+        self._start_order = self._resolve_order()
+        for name in self._start_order:
+            self._modules[name].module.start()
+
+    # ------------------------------------------------------------------
+    def stop_all(self) -> None:
+        """Stop all modules in reverse start order."""
+
+        for name in reversed(self._start_order):
+            self._modules[name].module.stop()
+        self._start_order = []
+
+    # ------------------------------------------------------------------
+    def check_health(self) -> None:
+        """Run health checks for all started modules and restart unhealthy ones."""
+
+        for name in list(self._start_order):
+            module = self._modules[name].module
+            healthy = False
+            try:
+                healthy = module.health_check()
+            except Exception:
+                healthy = False
+            if not healthy:
+                self.restart(name)
+
+    # ------------------------------------------------------------------
+    def restart(self, name: str) -> None:
+        """Restart the specified module regardless of its health."""
+
+        module = self._modules[name].module
+        try:
+            module.stop()
+        finally:
+            module.start()
+
+
+__all__ = ["BaseModule", "LifecycleManager"]

--- a/tests/core/test_lifecycle.py
+++ b/tests/core/test_lifecycle.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from src.core.lifecycle import BaseModule, LifecycleManager
+
+
+class DummyModule(BaseModule):
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+        self.health = True
+
+    def start(self) -> None:
+        self.events.append(f"{self.name}-start")
+
+    def stop(self) -> None:
+        self.events.append(f"{self.name}-stop")
+
+    def health_check(self) -> bool:
+        return self.health
+
+
+def test_initialization_and_shutdown_order() -> None:
+    events: list[str] = []
+    manager = LifecycleManager()
+
+    a = DummyModule("a", events)
+    b = DummyModule("b", events)
+    c = DummyModule("c", events)
+
+    manager.register("a", a)
+    manager.register("b", b, dependencies=["a"])
+    manager.register("c", c, dependencies=["b"])
+
+    manager.start_all()
+    manager.stop_all()
+
+    assert events == [
+        "a-start",
+        "b-start",
+        "c-start",
+        "c-stop",
+        "b-stop",
+        "a-stop",
+    ]
+
+
+def test_health_check_and_restart() -> None:
+    events: list[str] = []
+    manager = LifecycleManager()
+    module = DummyModule("a", events)
+
+    manager.register("a", module)
+    manager.start_all()
+
+    module.health = False
+    manager.check_health()
+
+    assert events == ["a-start", "a-stop", "a-start"]


### PR DESCRIPTION
## Summary
- add `LifecycleManager` to coordinate module startup and shutdown order
- expose lifecycle utilities via `src.core`
- test initialization order and automatic restart on failing health checks

## Testing
- `PYTHONPATH=. pytest tests/core/test_lifecycle.py`

------
https://chatgpt.com/codex/tasks/task_e_68966eb6a2848323941a74e71b573c79