### PR TITLE
feat: add centralized config and logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,29 +1,17 @@
-"""
-Главный файл Нейры - здесь она просыпается и знакомится с пользователем.
-"""
-import logging
+"""Главный файл Нейры - здесь она просыпается и знакомится с пользователем."""
+
 from pathlib import Path
 
+from src.core.config import get_logger
 from src.core.neyra_brain import Neyra
 from src.interaction.chat_session import ChatSession
 from src.models import Character
 from src.utils.source_tracker import SourceTracker
 
-def setup_logging() -> None:
-    """Настраиваю систему для записи того, что думает Нейра"""
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - Нейра - %(levelname)s - %(message)s',
-        handlers=[
-            logging.FileHandler('logs/neyra.log', encoding='utf-8'),
-            logging.StreamHandler()
-        ]
-    )
 
 def main() -> None:
     """Нейра просыпается и начинает работать!"""
-    setup_logging()
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
     tracker = SourceTracker()
     
     print("🌟 Пробуждение Нейры... 🌟")

--- a/src/analysis/grammar_proofreader.py
+++ b/src/analysis/grammar_proofreader.py
@@ -1,9 +1,10 @@
 """Simple grammar proofreader using language_tool_python when available."""
 from __future__ import annotations
 
-import logging
 import re
 from typing import Dict, List, Tuple
+
+from src.core.config import get_logger
 
 from .post_processor import PostProcessor
 
@@ -25,7 +26,7 @@ class GrammarProofreader(PostProcessor):
             except Exception:
                 self.tool = None
         else:
-            logging.warning(
+            get_logger(__name__).warning(
                 "language_tool_python is not installed; grammar proofreading quality will be reduced"
             )
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+"""Application configuration and logging setup.
+
+The module defines dataclasses describing configuration schema for the
+project. Configuration values can be supplied via environment variables or
+configuration files stored in the :mod:`config` directory.
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+
+@dataclass
+class PathSettings:
+    """Filesystem related settings."""
+
+    base_dir: Path = Path(os.getenv("NEIRA_BASE_DIR", Path(__file__).resolve().parents[2]))
+    config_dir: Path = Path(os.getenv("NEIRA_CONFIG_DIR", base_dir / "config"))
+    logs_dir: Path = Path(os.getenv("NEIRA_LOG_DIR", base_dir / "logs"))
+
+
+@dataclass
+class LoggingSettings:
+    """Logging configuration."""
+
+    level: str = os.getenv("NEIRA_LOG_LEVEL", "INFO")
+    format: str = os.getenv(
+        "NEIRA_LOG_FORMAT",
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    file: str = os.getenv("NEIRA_LOG_FILE", "neyra.log")
+
+
+@dataclass
+class Settings:
+    """Complete application settings."""
+
+    paths: PathSettings = field(default_factory=PathSettings)
+    logging: LoggingSettings = field(default_factory=LoggingSettings)
+
+
+settings = Settings()
+
+
+def setup_logging() -> None:
+    """Configure the root logger according to :data:`settings`."""
+
+    logs_dir = settings.paths.logs_dir
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / settings.logging.file
+    level = getattr(logging, settings.logging.level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format=settings.logging.format,
+        handlers=[
+            logging.FileHandler(log_file, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+        force=True,
+    )
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger following the global configuration."""
+
+    return logging.getLogger(name)
+
+
+def load_config_file(name: str) -> Any:
+    """Load a configuration file from the configured directory.
+
+    Parameters
+    ----------
+    name:
+        File name within :attr:`PathSettings.config_dir`.
+
+    Returns
+    -------
+    Any
+        Parsed configuration data.
+    """
+
+    path = settings.paths.config_dir / name
+    if not path.exists():  # pragma: no cover - simple guard
+        raise FileNotFoundError(f"Config file {name} not found in {settings.paths.config_dir}")
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        return yaml.safe_load(text)
+    if path.suffix.lower() == ".json":
+        return json.loads(text)
+    raise ValueError(f"Unsupported config format: {path.suffix}")
+
+
+# Configure logging as soon as the module is imported
+setup_logging()
+
+
+__all__ = [
+    "settings",
+    "setup_logging",
+    "get_logger",
+    "load_config_file",
+    "Settings",
+    "PathSettings",
+    "LoggingSettings",
+]

--- a/src/core/enhanced.py
+++ b/src/core/enhanced.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import Dict
 
+from src.core.config import get_logger
 from src.memory.lazy_loader import LazyMemoryLoader
 from src.neurons import NeuronNetwork
 from src.analysis.advanced import AdvancedAnalyzer, AnalysisResult
@@ -21,7 +21,7 @@ class EnhancedNeyra:
     """
 
     def __init__(self, memory_dir: str | Path = "data") -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.memory_loader = LazyMemoryLoader(memory_dir)
         self.network = NeuronNetwork()
         self.analyzer = AdvancedAnalyzer()

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 import asyncio
 import inspect
-import logging
 import threading
 import time
 from typing import Any, Awaitable, Callable, Dict, List, TypeVar, Generic
 
-logger = logging.getLogger(__name__)
+from src.core.config import get_logger
+
+logger = get_logger(__name__)
 
 
 PayloadT = TypeVar("PayloadT")

--- a/src/core/neyra_brain.py
+++ b/src/core/neyra_brain.py
@@ -2,10 +2,10 @@
 Мозг Нейры - здесь я думаю и учусь.
 """
 import json
-import logging
-from typing import List, Dict, Any, Tuple
 from pathlib import Path
+from typing import List, Dict, Any, Tuple
 
+from src.core.config import get_logger, settings
 from src.tags.enhanced_parser import EnhancedTagParser as TagParser, Tag
 from src.tags.command_executor import CommandExecutor
 from src.core.neyra_config import NEYRA_GREETING, NeyraPersonality, NeyraConfig
@@ -51,7 +51,7 @@ class Neyra:
 
     def __init__(self, config: NeyraConfig | None = None) -> None:
         """Просыпаюсь и готовлю свои модули."""
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.parser = TagParser()
         self.llm_max_tokens = 512
         self.llm = self._load_llm()
@@ -167,7 +167,7 @@ class Neyra:
 
     def _load_llm(self) -> BaseLLM | None:
         """Загружаю локальную LLM при наличии конфига."""
-        config_path = Path("config/llm_config.json")
+        config_path = settings.paths.config_dir / "llm_config.json"
         if not config_path.exists():
             return None
         try:

--- a/src/iteration/metrics.py
+++ b/src/iteration/metrics.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from difflib import SequenceMatcher
-import logging
 from typing import Dict
 
-logger = logging.getLogger(__name__)
+from src.core.config import get_logger
+
+logger = get_logger(__name__)
 
 
 def similarity(original: str, revised: str) -> float:

--- a/src/llm/mistral_interface.py
+++ b/src/llm/mistral_interface.py
@@ -1,9 +1,9 @@
 """Mistral LLM interface using llama-cpp-python."""
 from __future__ import annotations
 
-import logging
 from typing import Iterable, Optional
 
+from src.core.config import get_logger
 from .base_llm import BaseLLM, LLMFactory, get_available_vram
 
 # The real implementation relies on ``llama_cpp`` which may not be available
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover
     Llama = None  # type: ignore
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MistralLLM(BaseLLM):

--- a/src/llm/qwen_coder_interface.py
+++ b/src/llm/qwen_coder_interface.py
@@ -1,9 +1,9 @@
 """Qwen Coder LLM interface using llama-cpp-python."""
 from __future__ import annotations
 
-import logging
 from typing import Iterable, Optional
 
+from src.core.config import get_logger
 from .base_llm import BaseLLM, LLMFactory, get_available_vram
 
 # The real implementation relies on ``llama_cpp`` which may not be available
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover
     Llama = None  # type: ignore
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class QwenCoderLLM(BaseLLM):

--- a/src/memory/emotional_memory.py
+++ b/src/memory/emotional_memory.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
-import logging
 from typing import Any, Dict, List
+
+from src.core.config import get_logger
+
+logger = get_logger(__name__)
 
 
 class EmotionalMemory:
@@ -26,7 +29,7 @@ class EmotionalMemory:
             try:
                 self._data = json.loads(self.storage_path.read_text(encoding="utf-8"))
             except json.JSONDecodeError as exc:
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     "Failed to decode emotions file %s: %s", self.storage_path, exc
                 )
                 self._data = {}

--- a/src/memory/world_memory.py
+++ b/src/memory/world_memory.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 import json
-import logging
 from pathlib import Path
 from typing import Any, Dict, List
 
+from src.core.config import get_logger
 from .knowledge_graph import knowledge_graph
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class WorldRule:
@@ -135,18 +138,18 @@ class WorldMemory:
         try:
             raw = json.loads(self.storage_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            logging.getLogger(__name__).warning(
-                "Failed to decode world memory file %s: %s", self.storage_path, exc
-            )
+              logger.warning(
+                  "Failed to decode world memory file %s: %s", self.storage_path, exc
+              )
             try:
                 backup_path = self.storage_path.with_suffix(self.storage_path.suffix + ".bak")
                 self.storage_path.replace(backup_path)
             except Exception as backup_exc:  # pragma: no cover - best effort
-                logging.getLogger(__name__).warning(
-                    "Failed to back up corrupted world memory file %s: %s",
-                    self.storage_path,
-                    backup_exc,
-                )
+                  logger.warning(
+                      "Failed to back up corrupted world memory file %s: %s",
+                      self.storage_path,
+                      backup_exc,
+                  )
             raw = {}
         self._data = {}
         for world, info in raw.items():

--- a/src/monitoring/metrics_monitor.py
+++ b/src/monitoring/metrics_monitor.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, MutableMapping
+
+from src.core.config import get_logger
 
 
 @dataclass
@@ -16,7 +17,7 @@ class MetricsMonitor:
     """Log metrics to a JSONL file and console."""
 
     log_file: Path = Path("logs/metrics.jsonl")
-    logger: logging.Logger = field(default_factory=lambda: logging.getLogger("metrics"))
+    logger: logging.Logger = field(default_factory=lambda: get_logger("metrics"))
     thresholds: MutableMapping[str, Dict[str, float]] = field(default_factory=dict)
     time_series: MutableMapping[str, List[Dict[str, float]]] = field(default_factory=dict)
     resource_metrics: set[str] = field(default_factory=lambda: {"cpu", "memory"})
@@ -24,13 +25,6 @@ class MetricsMonitor:
     def __post_init__(self) -> None:
         # Ensure log directory exists
         self.log_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # Configure logger for console output
-        if not self.logger.handlers:
-            handler = logging.StreamHandler(stream=sys.stdout)
-            handler.setFormatter(logging.Formatter("%(message)s"))
-            self.logger.addHandler(handler)
-        self.logger.setLevel(logging.INFO)
 
     # ------------------------------------------------------------------
     def _write_jsonl(self, data: Dict[str, Any]) -> None:

--- a/src/monitoring/predictive_diagnostics.py
+++ b/src/monitoring/predictive_diagnostics.py
@@ -7,6 +7,7 @@ from typing import Dict
 import logging
 import statistics
 
+from src.core.config import get_logger
 from .metrics_monitor import MetricsMonitor
 
 
@@ -17,9 +18,7 @@ class PredictiveDiagnostics:
     monitor: MetricsMonitor
     window: int = 3
     threshold: float = 0.2  # 20% increase triggers alert
-    logger: logging.Logger = field(
-        default_factory=lambda: logging.getLogger("diagnostics")
-    )
+    logger: logging.Logger = field(default_factory=lambda: get_logger("diagnostics"))
 
     def analyse(self) -> Dict[str, str]:
         """Return alerts for metrics with rising trends."""

--- a/src/neurons/network.py
+++ b/src/neurons/network.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from src.core.config import get_logger
 
 
 class NeuronNetwork:
@@ -11,7 +11,7 @@ class NeuronNetwork:
     """
 
     def __init__(self) -> None:
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
 
     def process(self, command: str) -> str:
         """Process a command and return a textual response."""

--- a/src/plugins/plugin_manager.py
+++ b/src/plugins/plugin_manager.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 import importlib.util
 import inspect
-import logging
 from typing import List
+
+from src.core.config import get_logger
 
 from .plugin_base import Plugin
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PluginManager:

--- a/src/ui/progress.py
+++ b/src/ui/progress.py
@@ -1,10 +1,11 @@
 """Simple API for notifying UI about progress."""
 from __future__ import annotations
 
-import logging
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+from src.core.config import get_logger
+
+logger = get_logger(__name__)
 
 
 def update_progress(stage: str, iteration: Optional[int] = None) -> None:

--- a/src/utils/source_tracker.py
+++ b/src/utils/source_tracker.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import logging
 from typing import List
+
+from src.core.config import get_logger
 
 
 @dataclass
@@ -21,7 +22,7 @@ class SourceTracker:
     def __init__(self, reliability_threshold: float = 0.5) -> None:
         self.reliability_threshold = reliability_threshold
         self.entries: List[SourceEntry] = []
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
 
     def add(self, info: str, source: str, confidence: float) -> None:
         """Register a new source for *info* with *confidence* rating.


### PR DESCRIPTION
## Summary
- add dataclass-based settings schema with env and file integration
- centralize logging configuration and provide `get_logger`
- update modules to use unified logging and config paths

## Testing
- `pytest` *(fails: cannot import name 'KnowledgeGraph' from 'neira_rust')*

------
https://chatgpt.com/codex/tasks/task_e_689671da65ec8323869ad5e880aa2ace