### PR TITLE
Add state migration framework

### DIFF
--- a/src/core/migration.py
+++ b/src/core/migration.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""State migration utilities.
+
+The state managed by :class:`~src.core.state_manager.StateManager` can evolve
+between versions.  Versions are expressed as ``(major, minor)`` tuples of
+integers, for example ``(1, 0)`` or ``(2, 5)``.  To upgrade state from one
+version to another, a sequence of migration steps is executed where each step
+knows how to transform the state from one specific version to the next.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Tuple
+
+Version = Tuple[int, int]
+MigrationFunc = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+
+@dataclass
+class MigrationStep:
+    """A single transformation from one version to another.
+
+    ``migrate`` receives the current state mapping and returns an updated
+    mapping for ``to_version``.
+    """
+
+    from_version: Version
+    to_version: Version
+    migrate: MigrationFunc
+
+
+class Migrator:
+    """Apply registered migration steps to a state mapping."""
+
+    def __init__(self) -> None:
+        self._steps: Dict[Version, MigrationStep] = {}
+
+    def add_step(self, step: MigrationStep) -> None:
+        """Register a :class:`MigrationStep`."""
+
+        self._steps[step.from_version] = step
+
+    def migrate(
+        self, state: Dict[str, Any], from_version: Version, to_version: Version
+    ) -> Dict[str, Any]:
+        """Migrate ``state`` from ``from_version`` to ``to_version``.
+
+        Steps are executed sequentially until ``to_version`` is reached.
+        """
+
+        current = from_version
+        new_state = state
+        while current != to_version:
+            step = self._steps.get(current)
+            if step is None:
+                raise ValueError(
+                    f"no migration step registered for {current} -> {to_version}"
+                )
+            new_state = step.migrate(new_state)
+            current = step.to_version
+        return new_state
+
+
+__all__ = ["Version", "MigrationStep", "Migrator"]

--- a/src/core/state_manager.py
+++ b/src/core/state_manager.py
@@ -11,8 +11,10 @@ snapshots are created using :func:`copy.deepcopy` so that mutations after
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 import copy
+
+from .migration import Migrator, Version
 
 
 @dataclass
@@ -29,11 +31,21 @@ class StateManager:
     :meth:`begin` takes a deep copy of the current state and pushes it on a
     stack.  :meth:`commit` discards the most recent snapshot while
     :meth:`rollback` restores the last snapshot.
+
+    A schema ``version`` is associated with the state.  When the version is
+    changed via :meth:`set_version`, registered migration steps are executed to
+    transform the state to the new format.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        version: Version = (1, 0),
+        migrator: Optional[Migrator] = None,
+    ) -> None:
         self._state: Dict[str, Any] = {}
         self._history: List[_Snapshot] = []
+        self._version: Version = version
+        self._migrator = migrator or Migrator()
 
     # ------------------------------------------------------------------
     def register(self, name: str, value: Any) -> None:
@@ -68,6 +80,21 @@ class StateManager:
             raise RuntimeError("no transaction to rollback")
         snapshot = self._history.pop()
         self._state = snapshot.data
+
+    # ------------------------------------------------------------------
+    @property
+    def version(self) -> Version:
+        """Return the current state version."""
+
+        return self._version
+
+    def set_version(self, new_version: Version) -> None:
+        """Update to ``new_version`` applying migrations if necessary."""
+
+        if new_version == self._version:
+            return
+        self._state = self._migrator.migrate(self._state, self._version, new_version)
+        self._version = new_version
 
     # ------------------------------------------------------------------
     @property

--- a/tests/core/test_state_manager_migration.py
+++ b/tests/core/test_state_manager_migration.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.core.migration import Migrator, MigrationStep
+from src.core.state_manager import StateManager
+
+
+def test_migration_applied_on_version_change():
+    def step(state):
+        state["value"] += 1
+        return state
+
+    migrator = Migrator()
+    migrator.add_step(MigrationStep((1, 0), (1, 1), step))
+
+    manager = StateManager(version=(1, 0), migrator=migrator)
+    manager.register("value", 1)
+
+    manager.set_version((1, 1))
+    assert manager.version == (1, 1)
+    assert manager.get("value") == 2


### PR DESCRIPTION
## Summary
- add migration utilities with versioned steps
- support applying migrations in StateManager when version changes
- test that migrations transform state data

## Testing
- `pytest tests/core/test_state_manager_migration.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'KnowledgeGraph' from 'neira_rust' and ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68967879d61c8323b5c494f7bfa4476d