### PR TITLE
Add character neuron plugin

### DIFF
--- a/neira_rust/__init__.py
+++ b/neira_rust/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Any
 
 
 def ping() -> str:  # pragma: no cover - simple stub
@@ -39,6 +39,24 @@ class MemoryIndex:
         pass
 
 
+class KnowledgeGraph:
+    """Lightweight stand-in for the Rust ``KnowledgeGraph``.
+
+    It stores simple triples in memory and exposes the minimal API used by the
+    Python codebase.  The real project offers a much richer implementation but
+    for tests we only need to ensure imports succeed and method calls do not
+    fail."""
+
+    def __init__(self) -> None:
+        self.facts: List[Tuple[str, str, str]] = []
+
+    def add_fact(self, subject: str, relation: str, obj: str) -> None:
+        self.facts.append((subject, relation, obj))
+
+    def check_claim(self, claim: str) -> bool:  # pragma: no cover - trivial
+        return True
+
+
 @dataclass
 class VerificationResult:
     claim: str
@@ -49,4 +67,4 @@ def verify_claim(claim: str) -> VerificationResult:  # pragma: no cover - stub
     return VerificationResult(claim=claim, verified=True)
 
 
-__all__ = ["ping", "MemoryIndex"]
+__all__ = ["ping", "MemoryIndex", "KnowledgeGraph"]

--- a/neurons/plugins/character_neuron.py
+++ b/neurons/plugins/character_neuron.py
@@ -1,0 +1,52 @@
+"""Character neuron plugin for generating responses in a specific voice.
+
+This plugin demonstrates how to build a neuron that speaks as a
+particular character.  Upon initialisation it retrieves character
+information from :mod:`src.memory.character_memory` and uses that to
+shape responses in :meth:`process`.
+"""
+
+from __future__ import annotations
+
+from src.neurons import Neuron
+from src.memory import CharacterMemory
+from src.models import Character
+
+
+class CharacterNeuron(Neuron):
+    """Neuron that replies using a character's individual voice."""
+
+    type = "character"
+
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        *,
+        style: str | None = None,
+        theme: str | None = None,
+        memory: CharacterMemory | None = None,
+    ) -> None:
+        super().__init__(id=id, type=self.type)
+        self.name = name
+        self.memory = memory or CharacterMemory()
+        char = self.memory.get(name)
+        if char is None:
+            char = Character(name=name)
+            self.memory.add(char)
+        self.character = char
+        self.style = style or ", ".join(self.character.personality_traits)
+        self.theme = theme or self.character.appearance
+
+    # ------------------------------------------------------------------
+    def process(self, text: str) -> str:
+        """Return ``text`` phrased in the character's unique voice."""
+
+        self.activate()
+        parts = [self.character.name]
+        if self.style:
+            parts.append(self.style)
+        if self.theme:
+            parts.append(self.theme)
+        prefix = " | ".join(parts)
+        return f"{prefix}: {text}"

--- a/tests/test_character_neuron_plugin.py
+++ b/tests/test_character_neuron_plugin.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from src.neurons import NeuronFactory
+from src.memory import CharacterMemory
+from src.models import Character
+
+
+def test_character_neuron_plugin_registration_and_voice(tmp_path) -> None:
+    memory = CharacterMemory(tmp_path / "chars.json")
+    memory.add(
+        Character(
+            name="Alice", personality_traits=["brave"], appearance="steampunk"
+        )
+    )
+
+    NeuronFactory._registry.clear()  # type: ignore[attr-defined]
+    NeuronFactory.load_plugins()
+
+    neuron = NeuronFactory.create(
+        "character", id="c1", name="Alice", memory=memory
+    )
+    response = neuron.process("Hello there")
+    assert "Alice" in response
+    assert "brave" in response


### PR DESCRIPTION
## Summary
- add `CharacterNeuron` plugin that speaks in a specific character's voice
- provide lightweight `KnowledgeGraph` stub for plugin compatibility
- test plugin registration and voice generation

## Testing
- `pytest tests/test_character_neuron_plugin.py -q`
- `pytest -q` *(fails: IndentationError in world_memory.py; ModuleNotFoundError for optimization; ImportError for parse in neira_rust)*


------
https://chatgpt.com/codex/tasks/task_e_6896807ca34483238ca1630aa757dedf