### PR TITLE
Add partner neurons and orchestrator

### DIFF
--- a/neurons/plugins/creative_partner.py
+++ b/neurons/plugins/creative_partner.py
@@ -1,0 +1,20 @@
+"""Creative partner neuron plugin."""
+
+from __future__ import annotations
+
+from src.neurons import Neuron
+
+
+class CreativePartnerNeuron(Neuron):
+    """Neuron that decorates input text with a creative flair."""
+
+    type = "creative_partner"
+
+    def __init__(self, id: str) -> None:
+        super().__init__(id=id, type=self.type)
+
+    def process(self, text: str) -> str:
+        """Return ``text`` with a creative prefix."""
+
+        self.activate()
+        return f"[Creative] {text}"

--- a/neurons/plugins/logical_partner.py
+++ b/neurons/plugins/logical_partner.py
@@ -1,0 +1,20 @@
+"""Logical partner neuron plugin."""
+
+from __future__ import annotations
+
+from src.neurons import Neuron
+
+
+class LogicalPartnerNeuron(Neuron):
+    """Neuron that applies logical reasoning to text."""
+
+    type = "logical_partner"
+
+    def __init__(self, id: str) -> None:
+        super().__init__(id=id, type=self.type)
+
+    def process(self, text: str) -> str:
+        """Return ``text`` with a logical prefix."""
+
+        self.activate()
+        return f"[Logical] {text}"

--- a/src/neurons/network.py
+++ b/src/neurons/network.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from src.core.config import get_logger
+from .partners import run_partners
 
 
 class NeuronNetwork:
@@ -17,6 +18,9 @@ class NeuronNetwork:
         """Process a command and return a textual response."""
 
         self.logger.debug("NeuronNetwork received command: %s", command)
+        if command.startswith("partner:"):
+            text = command.split(":", 1)[1].strip()
+            return run_partners(text)
         return f"processed: {command}"
 
 

--- a/src/neurons/partners.py
+++ b/src/neurons/partners.py
@@ -1,0 +1,17 @@
+"""Orchestrator for partner neurons."""
+
+from __future__ import annotations
+
+from .factory import NeuronFactory
+
+
+def run_partners(text: str) -> str:
+    """Activate creative and logical partner neurons sequentially."""
+
+    creative = NeuronFactory.create("creative_partner", id="creative")
+    intermediate = creative.process(text)
+    logical = NeuronFactory.create("logical_partner", id="logical")
+    return logical.process(intermediate)
+
+
+__all__ = ["run_partners"]

--- a/tests/test_partner_orchestrator.py
+++ b/tests/test_partner_orchestrator.py
@@ -1,0 +1,23 @@
+from src.neurons import NeuronFactory
+from src.neurons.partners import run_partners
+from src.neurons.network import NeuronNetwork
+
+
+def setup_function() -> None:
+    NeuronFactory._registry.clear()  # type: ignore[attr-defined]
+    NeuronFactory.load_plugins()
+
+
+def test_partner_neurons_registration() -> None:
+    creative = NeuronFactory.create("creative_partner", id="c")
+    logical = NeuronFactory.create("logical_partner", id="l")
+    assert creative.process("hello").startswith("[Creative]")
+    assert logical.process("world").startswith("[Logical]")
+
+
+def test_partner_orchestrator_and_network() -> None:
+    result = run_partners("hello")
+    assert result == "[Logical] [Creative] hello"
+    network = NeuronNetwork()
+    assert network.process("partner: hi") == "[Logical] [Creative] hi"
+    assert network.process("other") == "processed: other"


### PR DESCRIPTION
## Summary
- add creative and logical partner neuron plugins
- orchestrate partner neurons with new module and integrate with network
- test partner neuron pipeline and network activation

## Testing
- `pytest tests/test_partner_orchestrator.py tests/test_character_neuron_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689682b888e48323b8fe19f701bdd1df