### PR TITLE
Add inspiration cards plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ data/*
 !data/books/
 !data/cache/
 !data/models/
+!data/inspiration_cards.json
 data/books/*
 !data/books/.gitkeep
 data/cache/*

--- a/data/inspiration_cards.json
+++ b/data/inspiration_cards.json
@@ -1,0 +1,5 @@
+[
+  "Believe in yourself and all that you are.",
+  "Every moment is a fresh beginning.",
+  "What we think, we become."
+]

--- a/plugins/inspiration_cards.py
+++ b/plugins/inspiration_cards.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+from src.plugins import Plugin
+
+
+class InspirationCardsPlugin(Plugin):
+    """Show a random inspiration card during gap analysis."""
+
+    def __init__(self) -> None:
+        data_path = (
+            Path(__file__).resolve().parents[1] / "data" / "inspiration_cards.json"
+        )
+        try:
+            with data_path.open("r", encoding="utf-8") as f:
+                self.cards: list[str] = json.load(f)
+        except Exception:
+            self.cards = []
+
+    def on_gap_analysis(self, draft: str, gaps) -> None:  # pragma: no cover - trivial
+        if not self.cards:
+            return
+        card = random.choice(self.cards)
+        print(f"Inspiration: {card}")


### PR DESCRIPTION
## Summary
- add `InspirationCardsPlugin` to display random inspiration cards on gap analysis
- store card messages in `data/inspiration_cards.json`
- adjust `.gitignore` to track inspiration card data file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/plugins/test_plugin_manager_error.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689686a503f483239a6b6cf373140cf0