### PR TITLE
Add tutorial mode with progress tracking and menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,10 +67,26 @@ def main() -> None:
             print("Добавьте .txt файлы в папку data/books/ и я их изучу!")
             
         print("\n💫 Нейра готова к работе! Используйте теги для общения.")
-        # По умолчанию запускаем интерактивный режим с поддержкой чата.
-        # Диалоговый контроллер оставляем для обратной совместимости.
-        chat = ChatSession(neyra)
-        chat.chat_loop()
+
+        # Простое меню для запуска чата или режима обучения
+        while True:
+            print("\nГлавное меню:")
+            print("1. Чат")
+            print("2. Обучение")
+            print("0. Выход")
+            choice = input("Выберите пункт: ").strip()
+
+            if choice == "1":
+                chat = ChatSession(neyra)
+                chat.chat_loop()
+            elif choice == "2":
+                from modes.tutorial import Tutorial
+
+                Tutorial().run()
+            elif choice == "0":
+                break
+            else:
+                print("Неизвестный пункт меню")
         
     except Exception as e:  # pylint: disable=broad-except
         logger.error(f"Ошибка при пробуждении Нейры: {e}")

--- a/modes/__init__.py
+++ b/modes/__init__.py
@@ -1,0 +1,1 @@
+"""Game modes available in the project."""

--- a/modes/tutorial/__init__.py
+++ b/modes/tutorial/__init__.py
@@ -1,0 +1,5 @@
+"""Tutorial mode with simple lesson scenes."""
+
+from .tutorial import Tutorial
+
+__all__ = ["Tutorial"]

--- a/modes/tutorial/tutorial.py
+++ b/modes/tutorial/tutorial.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+from typing import List
+
+PROGRESS_FILE = Path("userdata/tutorial_progress.json")
+
+
+class Tutorial:
+    """Simple tutorial with a set of lesson scenes."""
+
+    def __init__(self) -> None:
+        self.lessons: List[str] = [
+            "Урок 1. Добро пожаловать в обучение!",
+            "Урок 2. Основы общения с Нейрой.",
+            "Урок 3. Завершение обучения.",
+        ]
+        self.index = self._load_progress()
+
+    # ------------------------------------------------------------------
+    def _load_progress(self) -> int:
+        """Load current lesson index from progress file."""
+        if PROGRESS_FILE.exists():
+            try:
+                with PROGRESS_FILE.open("r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                    return int(data.get("current_lesson", 0))
+            except (json.JSONDecodeError, OSError, ValueError):
+                pass
+        # default progress
+        PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        self._save_progress(0)
+        return 0
+
+    def _save_progress(self, value: int) -> None:
+        PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with PROGRESS_FILE.open("w", encoding="utf-8") as fh:
+            json.dump({"current_lesson": value}, fh, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    def current(self) -> str:
+        """Return text of the current lesson."""
+        return self.lessons[self.index]
+
+    def next(self) -> str:
+        """Advance to the next lesson and return its text."""
+        if self.index < len(self.lessons) - 1:
+            self.index += 1
+            self._save_progress(self.index)
+        return self.current()
+
+    def previous(self) -> str:
+        """Return to the previous lesson."""
+        if self.index > 0:
+            self.index -= 1
+            self._save_progress(self.index)
+        return self.current()
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Run simple CLI navigation through lessons."""
+        print(self.current())
+        while True:
+            cmd = input("(n) следующий, (p) предыдущий, (q) выход: ").strip().lower()
+            if cmd == "n":
+                print(self.next())
+            elif cmd == "p":
+                print(self.previous())
+            elif cmd == "q":
+                break
+            else:
+                print("Неизвестная команда")

--- a/userdata/tutorial_progress.json
+++ b/userdata/tutorial_progress.json
@@ -1,0 +1,3 @@
+{
+  "current_lesson": 0
+}


### PR DESCRIPTION
## Summary
- introduce tutorial mode with basic lesson scenes and persistent progress tracking
- add simple main menu allowing chat or tutorial access
- persist tutorial progress in `userdata/tutorial_progress.json`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'optimization')*

------
https://chatgpt.com/codex/tasks/task_e_689691315c3c83239d5e5024fe5f5715