### PR TITLE
feat: add resource manager mode and plugin package API

### DIFF
--- a/modes/resource_manager/__init__.py
+++ b/modes/resource_manager/__init__.py
@@ -1,0 +1,4 @@
+"""Resource manager mode for viewing, searching and importing resources."""
+from .resource_manager import ResourceManagerMode
+
+__all__ = ["ResourceManagerMode"]

--- a/modes/resource_manager/resource_manager.py
+++ b/modes/resource_manager/resource_manager.py
@@ -1,0 +1,154 @@
+"""Simple CLI for managing local resources.
+
+Resources are regular files stored in a directory.  Metadata including
+arbitrary attributes and tags are persisted in ``index.db`` (SQLite).  The
+manager provides helper methods used by tests and a minimal interactive
+``run`` method that exposes listing, searching and importing functionality.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+@dataclass
+class Resource:
+    """Representation of a single resource entry."""
+
+    name: str
+    path: Path
+    tags: List[str]
+    metadata: Dict[str, Any]
+
+
+class ResourceIndex:
+    """Persistence layer storing resource metadata in SQLite."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS resources (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT,
+                    path TEXT,
+                    tags TEXT,
+                    metadata TEXT
+                )
+                """
+            )
+
+    # ------------------------------------------------------------------
+    def add(self, resource: Resource) -> None:
+        tags = ",".join(resource.tags)
+        meta = json.dumps(resource.metadata, ensure_ascii=False)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "INSERT INTO resources (name, path, tags, metadata) VALUES (?, ?, ?, ?)",
+                (resource.name, str(resource.path), tags, meta),
+            )
+
+    # ------------------------------------------------------------------
+    def list(self) -> List[Resource]:
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                "SELECT name, path, tags, metadata FROM resources ORDER BY name"
+            ).fetchall()
+        result: List[Resource] = []
+        for name, path, tags, meta in rows:
+            tag_list = [t for t in (tags or "").split(",") if t]
+            metadata = json.loads(meta) if meta else {}
+            result.append(Resource(name=name, path=Path(path), tags=tag_list, metadata=metadata))
+        return result
+
+    # ------------------------------------------------------------------
+    def search(self, term: str) -> List[Resource]:
+        like = f"%{term}%"
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT name, path, tags, metadata FROM resources
+                WHERE name LIKE ? OR tags LIKE ?
+                ORDER BY name
+                """,
+                (like, like),
+            ).fetchall()
+        result: List[Resource] = []
+        for name, path, tags, meta in rows:
+            tag_list = [t for t in (tags or "").split(",") if t]
+            metadata = json.loads(meta) if meta else {}
+            result.append(Resource(name=name, path=Path(path), tags=tag_list, metadata=metadata))
+        return result
+
+
+class ResourceManagerMode:
+    """Manage resources stored locally with metadata and tags."""
+
+    def __init__(self, root: Path | str = Path("resources")) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.index = ResourceIndex(self.root / "index.db")
+
+    # ------------------------------------------------------------------
+    def import_resource(
+        self,
+        source: Path,
+        tags: List[str] | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ) -> Resource:
+        """Copy ``source`` into the resource directory and index it."""
+
+        destination = self.root / source.name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(source, destination)
+        resource = Resource(
+            name=source.name,
+            path=destination,
+            tags=tags or [],
+            metadata=metadata or {},
+        )
+        self.index.add(resource)
+        return resource
+
+    # ------------------------------------------------------------------
+    def list_resources(self) -> List[Resource]:
+        return self.index.list()
+
+    def search(self, term: str) -> List[Resource]:
+        return self.index.search(term)
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - interactive helper
+        print("Resource Manager")
+        while True:
+            cmd = input("(l)ist, (s)earch, (i)mport, (q)uit: ").strip().lower()
+            if cmd == "l":
+                for res in self.list_resources():
+                    print(f"{res.name} [{', '.join(res.tags)}]")
+            elif cmd == "s":
+                term = input("Search term: ").strip()
+                for res in self.search(term):
+                    print(f"{res.name} [{', '.join(res.tags)}]")
+            elif cmd == "i":
+                path = Path(input("Path to file: ").strip())
+                tags = [t.strip() for t in input("Tags (comma separated): ").split(",") if t.strip()]
+                self.import_resource(path, tags)
+                print("Imported")
+            elif cmd == "q":
+                break
+            else:
+                print("Unknown command")
+
+
+__all__ = ["ResourceManagerMode", "Resource", "ResourceIndex"]

--- a/src/plugins/package_api.py
+++ b/src/plugins/package_api.py
@@ -1,0 +1,51 @@
+"""Utilities for uploading and downloading plugin packages.
+
+The project uses a very small plugin system where Python modules are placed in
+``plugins/``. Some tooling requires transferring these plugins as ``.zip``
+packages. The helpers in this module provide a lightweight API for saving and
+retrieving such archives without introducing additional dependencies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+
+
+def upload_package(zip_path: Path, plugin_dir: Path | str = "plugins") -> Path:
+    """Store ``zip_path`` inside ``plugin_dir``.
+
+    Parameters
+    ----------
+    zip_path:
+        Path to an existing ``.zip`` file.
+    plugin_dir:
+        Destination directory. Created when missing.
+
+    Returns
+    -------
+    Path
+        Location of the stored package.
+    """
+
+    plugin_dir = Path(plugin_dir)
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    destination = plugin_dir / Path(zip_path).name
+    shutil.copy(zip_path, destination)
+    return destination
+
+
+def download_package(name: str, plugin_dir: Path | str = "plugins") -> bytes:
+    """Return the binary contents of a stored plugin package.
+
+    ``name`` may be provided with or without the ``.zip`` suffix.
+    """
+
+    plugin_dir = Path(plugin_dir)
+    path = plugin_dir / name
+    if path.suffix != ".zip":
+        path = path.with_suffix(".zip")
+    return path.read_bytes()
+
+
+__all__ = ["upload_package", "download_package"]

--- a/tests/modes/test_resource_manager_mode.py
+++ b/tests/modes/test_resource_manager_mode.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import json
+import sqlite3
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from modes.resource_manager import ResourceManagerMode
+
+
+def test_import_and_search(tmp_path: Path) -> None:
+    root = tmp_path / "resources"
+    manager = ResourceManagerMode(root=root)
+
+    # create external file to import
+    src = tmp_path / "sample.txt"
+    src.write_text("hello", encoding="utf-8")
+
+    manager.import_resource(src, tags=["text", "sample"], metadata={"size": 5})
+
+    all_resources = manager.list_resources()
+    assert len(all_resources) == 1
+    assert all_resources[0].tags == ["text", "sample"]
+
+    results = manager.search("sample")
+    assert results and results[0].name == "sample.txt"
+
+    # verify raw DB contents for tags and metadata
+    conn = sqlite3.connect(root / "index.db")
+    row = conn.execute("SELECT tags, metadata FROM resources").fetchone()
+    assert row is not None
+    assert row[0] == "text,sample"
+    assert json.loads(row[1])["size"] == 5

--- a/tests/plugins/test_package_api.py
+++ b/tests/plugins/test_package_api.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import zipfile
+import importlib.util
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+module_path = ROOT / "src/plugins/package_api.py"
+spec = importlib.util.spec_from_file_location("package_api", module_path)
+assert spec and spec.loader
+package_api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(package_api)  # type: ignore
+upload_package = package_api.upload_package
+download_package = package_api.download_package
+
+
+def test_upload_and_download(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugins"
+    archive = tmp_path / "demo.zip"
+
+    # create dummy zip file
+    data_file = tmp_path / "data.txt"
+    data_file.write_text("hi", encoding="utf-8")
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(data_file, "data.txt")
+
+    stored_path = upload_package(archive, plugin_dir)
+    assert stored_path.exists()
+
+    content = download_package("demo", plugin_dir)
+    assert content == archive.read_bytes()


### PR DESCRIPTION
## Summary
- add resource manager mode with import/search/list and metadata storage in resources/index.db
- support uploading and downloading zipped plugin packages
- test resource manager metadata and plugin package utilities

## Testing
- `pytest tests/modes/test_resource_manager_mode.py tests/plugins/test_package_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6896937a2c148323ab68ee9fb3338982