### PR TITLE
docs: add overview and markdown lint workflow

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,22 @@
+name: Markdown Lint
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdown-lint.yml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdown-lint.yml'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install -g markdownlint-cli
+      - run: markdownlint "docs/**/*.md"

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,32 @@
+# Developer Guide
+
+This guide describes the expected interfaces and the plugin architecture.
+
+## Interface standards
+
+Modes and other components follow a minimal contract: they expose `start()`
+and `stop()` methods and receive a context object that provides logging and
+access to shared services. External code should interact with modes only
+through this interface.
+
+## Plugin structure
+
+Plugins extend the `Plugin` base class and override hook methods.
+
+```python
+from src.plugins import Plugin
+
+class ExamplePlugin(Plugin):
+    def on_draft(self, draft, context):
+        ...
+
+    def on_gap_analysis(self, draft, gaps):
+        ...
+
+    def on_finalize(self, response):
+        ...
+```
+
+Plugins are discovered by the `PluginManager` and can subscribe to any subset
+of hooks. Each plugin should be self-contained and avoid side effects outside
+the provided context.

--- a/docs/modes/README.md
+++ b/docs/modes/README.md
@@ -1,0 +1,15 @@
+# Modes
+
+Neira exposes distinct modes that share a common interface. Every mode can be
+started and stopped and may hand control to another mode when its task is
+complete.
+
+## Relationships
+
+- **Tutorial mode** walks new users through initial setup before handing
+  control to other modes.
+- **Resource manager** handles local resources. Data prepared here is
+  available to any subsequent mode.
+
+All modes can access shared services such as the event bus and configuration
+system, enabling smooth transitions between them.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,7 @@
+# Documentation Overview
+
+This folder contains guides for Neira's modes, developer information, and user instructions. Each section builds upon core concepts like the mode system and plugin architecture to keep the project modular and extensible.
+
+- [Modes](modes/README.md) – how operational modes interact.
+- [Developer Guide](developer/README.md) – interface standards and plugin structure.
+- [User Guide](user-guide/README.md) – instructions for using Neira.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,10 @@
+# User Guide
+
+The application is organized around modes. Start with the tutorial to explore
+the interface. Once familiar you can switch to other modes, such as the
+resource manager, to import and search your own data.
+
+Plugins may add new features. Enable them in the configuration file and they
+will automatically run during generation. Refer to the
+[developer guide](../developer/README.md) for details about writing
+plugins.


### PR DESCRIPTION
## Summary
- document project structure with overview, mode relationships, and developer/user guides
- explain interface standards and plugin architecture
- add GitHub Action to lint Markdown docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `npx markdownlint-cli docs/**/*.md`


------
https://chatgpt.com/codex/tasks/task_e_689694f532088323b86c863de951a32c