### PR TITLE
Add LSP client and profiler panel for code editor

### DIFF
--- a/code_editor/__init__.py
+++ b/code_editor/__init__.py
@@ -1,0 +1,4 @@
+from .lsp_client import LSPClient
+from .profiler_panel import ProfilerPanel
+
+__all__ = ["LSPClient", "ProfilerPanel"]

--- a/code_editor/lsp_client.py
+++ b/code_editor/lsp_client.py
@@ -1,0 +1,129 @@
+"""Minimal Language Server Protocol (LSP) client.
+
+This module provides a small utility wrapper around a language server
+process.  It communicates using the LSP specification over the
+``stdio`` transport.  The client is intentionally lightweight and does
+not depend on external packages so it can be easily embedded in simple
+scripts or tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from queue import Empty, Queue
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class LSPClient:
+    """Basic LSP client speaking the ``stdio`` transport."""
+
+    server_command: List[str] = field(default_factory=lambda: ["pylsp"])
+    root_uri: str = field(default_factory=lambda: Path.cwd().as_uri())
+
+    _process: Optional[subprocess.Popen] = field(init=False, default=None)
+    _recv_queue: "Queue[str]" = field(init=False, default_factory=Queue)
+    _reader_thread: Optional[threading.Thread] = field(init=False, default=None)
+    _id: int = field(init=False, default=0)
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start the language server process and send ``initialize``."""
+
+        if self._process is not None:
+            return
+
+        self._process = subprocess.Popen(
+            self.server_command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+
+        self._reader_thread = threading.Thread(target=self._reader, daemon=True)
+        self._reader_thread.start()
+
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": self._next_id(),
+                "method": "initialize",
+                "params": {
+                    "processId": os.getpid(),
+                    "rootUri": self.root_uri,
+                    "capabilities": {},
+                },
+            }
+        )
+
+    # ------------------------------------------------------------------
+    def _reader(self) -> None:
+        assert self._process and self._process.stdout
+        while True:
+            line = self._process.stdout.readline()
+            if not line:
+                break
+            if line.startswith("Content-Length:"):
+                length = int(line.split(":")[1].strip())
+                # skip header end line
+                self._process.stdout.readline()
+                content = self._process.stdout.read(length)
+                self._recv_queue.put(content)
+
+    # ------------------------------------------------------------------
+    def _send(self, payload: Dict[str, Any]) -> None:
+        if not self._process or not self._process.stdin:
+            raise RuntimeError("LSP server not started")
+        body = json.dumps(payload)
+        message = f"Content-Length: {len(body)}\r\n\r\n{body}"
+        self._process.stdin.write(message)
+        self._process.stdin.flush()
+
+    # ------------------------------------------------------------------
+    def _next_id(self) -> int:
+        self._id += 1
+        return self._id
+
+    # ------------------------------------------------------------------
+    def completion(self, uri: str, line: int, character: int) -> Any:
+        request_id = self._next_id()
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "textDocument/completion",
+                "params": {
+                    "textDocument": {"uri": uri},
+                    "position": {"line": line, "character": character},
+                },
+            }
+        )
+        return self._await_response(request_id)
+
+    # ------------------------------------------------------------------
+    def _await_response(self, request_id: int, timeout: float = 5) -> Any:
+        try:
+            while True:
+                message = self._recv_queue.get(timeout=timeout)
+                data = json.loads(message)
+                if data.get("id") == request_id:
+                    return data.get("result")
+        except Empty:
+            return None
+
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        try:
+            if self._process:
+                self._send({"jsonrpc": "2.0", "id": self._next_id(), "method": "shutdown"})
+                self._send({"jsonrpc": "2.0", "method": "exit"})
+        finally:
+            if self._process:
+                self._process.terminate()
+                self._process = None

--- a/code_editor/profiler_panel.py
+++ b/code_editor/profiler_panel.py
@@ -1,0 +1,41 @@
+"""Profiler panel for code editor.
+
+This module exposes a small helper around :class:`PerformanceProfiler`
+from :mod:`src.monitoring` to gather execution metrics and present them
+in a textual form that could be displayed in a user interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
+
+from src.monitoring import PerformanceProfiler
+
+
+@dataclass
+class ProfilerPanel:
+    """Simple facade over :class:`PerformanceProfiler`."""
+
+    profiler: PerformanceProfiler = field(default_factory=PerformanceProfiler)
+
+    # ------------------------------------------------------------------
+    def profile(self, name: str, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Profile ``func`` and store metrics using ``name``."""
+
+        return self.profiler.profile_operation(name, func, *args, **kwargs)
+
+    # ------------------------------------------------------------------
+    def report(self) -> str:
+        """Return a formatted report of collected metrics."""
+
+        lines: List[str] = ["Profiling report", "------------------"]
+        for name, data in self.profiler.metrics.items():
+            lines.append(f"{name}: {data['time']:.6f}s, {data['memory']} bytes")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    def suggestions(self) -> List[str]:
+        """Return optimization suggestions based on collected data."""
+
+        return self.profiler.suggest_optimizations()

--- a/code_templates/example_plugin.py
+++ b/code_templates/example_plugin.py
@@ -1,0 +1,25 @@
+"""Template plugin for the code editor.
+
+This file demonstrates the minimal structure required for plugins.
+Developers can copy this template to start building their own
+extensions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.plugins import Plugin
+
+
+@dataclass
+class ExamplePlugin(Plugin):
+    """Small example plugin used as a template."""
+
+    name: str = "Example"
+
+    def on_activate(self) -> str:  # pragma: no cover - placeholder
+        return f"{self.name} activated"
+
+    def on_deactivate(self) -> str:  # pragma: no cover - placeholder
+        return f"{self.name} deactivated"

--- a/tests/code_editor/test_lsp_client.py
+++ b/tests/code_editor/test_lsp_client.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from code_editor.lsp_client import LSPClient
+
+
+def test_id_generation():
+    client = LSPClient()
+    first = client._next_id()
+    second = client._next_id()
+    assert second == first + 1

--- a/tests/code_editor/test_profiler_panel.py
+++ b/tests/code_editor/test_profiler_panel.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from code_editor.profiler_panel import ProfilerPanel
+
+
+def test_profile_and_report():
+    panel = ProfilerPanel()
+
+    def dummy():
+        return 21
+
+    result = panel.profile("dummy", dummy)
+    assert result == 21
+
+    report = panel.report()
+    assert "dummy" in report
+
+    suggestions = panel.suggestions()
+    assert isinstance(suggestions, list)


### PR DESCRIPTION
## Summary
- add minimal LSP client for the code editor
- implement profiling panel backed by PerformanceProfiler
- provide plugin template for code templates

## Testing
- `pytest tests/monitoring/test_performance_profiler.py tests/code_editor/test_lsp_client.py tests/code_editor/test_profiler_panel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68969cd6eb94832386eafb0bcd6ef03c