### PR TITLE
Add basic image editor with masks and AI layer generation

### DIFF
--- a/image_editor/__init__.py
+++ b/image_editor/__init__.py
@@ -1,0 +1,13 @@
+"""Utility package for simple image layer manipulation."""
+
+from .layers import Layer, generate_ai_layer, invert_effect, grayscale_effect
+from .svg import import_svg, export_svg
+
+__all__ = [
+    "Layer",
+    "generate_ai_layer",
+    "invert_effect",
+    "grayscale_effect",
+    "import_svg",
+    "export_svg",
+]

--- a/image_editor/ai_layers.py
+++ b/image_editor/ai_layers.py
@@ -1,0 +1,35 @@
+"""Layer generation via external AI API."""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import numpy as np
+import requests
+
+from .layers import Layer
+
+
+def generate_layer(prompt: str, size: Tuple[int, int] = (64, 64)) -> Layer:
+    """Generate a new layer using an external service.
+
+    The service URL can be provided via the ``AI_LAYER_API_URL`` environment
+    variable. When not set, random noise is returned which keeps tests
+    deterministic enough for shape checking.
+    """
+
+    api_url = os.getenv("AI_LAYER_API_URL")
+    width, height = size
+    if api_url:
+        resp = requests.post(
+            api_url,
+            json={"prompt": prompt, "width": width, "height": height},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = np.array(resp.json()["data"], dtype=np.uint8)
+        data = data.reshape((height, width, 3))
+    else:
+        data = (np.random.rand(height, width, 3) * 255).astype(np.uint8)
+    return Layer(name=prompt, content=data)

--- a/image_editor/layers.py
+++ b/image_editor/layers.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Core layer representation with mask and effect support."""
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+import numpy as np
+
+Effect = Callable[[np.ndarray], np.ndarray]
+
+
+@dataclass
+class Layer:
+    """Represents an image layer.
+
+    Attributes:
+        name: Human readable layer name.
+        content: Numpy array of shape (H, W, C).
+        mask: Optional alpha mask with shape (H, W) or (H, W, 1).
+        effects: List of callables applied sequentially to the content.
+        vector_data: Optional SVG snippets representing vector shapes.
+    """
+
+    name: str
+    content: np.ndarray
+    mask: Optional[np.ndarray] = None
+    effects: List[Effect] = field(default_factory=list)
+    vector_data: Optional[List[str]] = None
+
+    def apply_mask(self, data: np.ndarray) -> np.ndarray:
+        """Apply layer mask to data."""
+        if self.mask is None:
+            return data
+        mask = self.mask
+        if mask.ndim == 2:
+            mask = mask[..., np.newaxis]
+        if mask.max() > 1:
+            mask = mask / 255.0
+        return (data * mask).astype(data.dtype)
+
+    def apply_effects(self, data: np.ndarray) -> np.ndarray:
+        """Apply registered effects to data."""
+        for effect in self.effects:
+            data = effect(data)
+        return data
+
+    def render(self) -> np.ndarray:
+        """Return content with mask and effects applied."""
+        data = self.apply_mask(self.content.copy())
+        data = self.apply_effects(data)
+        return data
+
+
+def invert_effect(data: np.ndarray) -> np.ndarray:
+    """Simple color inversion effect."""
+    return 255 - data
+
+
+def grayscale_effect(data: np.ndarray) -> np.ndarray:
+    """Convert to grayscale keeping three channels."""
+    gray = data.mean(axis=2, keepdims=True)
+    return np.repeat(gray, 3, axis=2).astype(data.dtype)
+
+
+def generate_ai_layer(prompt: str, size: tuple[int, int] = (64, 64)) -> Layer:
+    """Generate a layer using the AI API.
+
+    This is a thin wrapper that delegates to :mod:`image_editor.ai_layers`.
+    """
+
+    from .ai_layers import generate_layer
+
+    return generate_layer(prompt, size)

--- a/image_editor/svg.py
+++ b/image_editor/svg.py
@@ -1,0 +1,36 @@
+"""Simple SVG import and export helpers."""
+
+from typing import List, Tuple
+from xml.etree import ElementTree as ET
+import re
+
+ET.register_namespace("", "http://www.w3.org/2000/svg")
+
+
+def export_svg(
+    vector_data: List[str], file_path: str, size: Tuple[int, int] = (100, 100)
+) -> None:
+    """Export SVG snippets to a file."""
+    svg = ET.Element(
+        "svg",
+        xmlns="http://www.w3.org/2000/svg",
+        width=str(size[0]),
+        height=str(size[1]),
+    )
+    for snippet in vector_data:
+        svg.append(ET.fromstring(snippet))
+    tree = ET.ElementTree(svg)
+    tree.write(file_path)
+
+
+def _strip_namespace(snippet: str) -> str:
+    snippet = re.sub(r" xmlns(:ns\d+)?=\"[^\"]+\"", "", snippet)
+    snippet = re.sub(r"ns\d+:", "", snippet)
+    return snippet
+
+
+def import_svg(file_path: str) -> List[str]:
+    """Import SVG snippets from a file."""
+    tree = ET.parse(file_path)
+    root = tree.getroot()
+    return [_strip_namespace(ET.tostring(el, encoding="unicode")) for el in list(root)]

--- a/tests/image_editor/test_layers.py
+++ b/tests/image_editor/test_layers.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+import numpy as np
+
+from image_editor.layers import (
+    Layer,
+    generate_ai_layer,
+    invert_effect,
+)
+from image_editor.svg import export_svg, import_svg
+
+
+def test_mask_and_effects():
+    data = np.ones((2, 2, 3), dtype=np.uint8) * 100
+    mask = np.array([[1, 0], [0, 1]], dtype=np.float32)
+    layer = Layer(name="test", content=data, mask=mask, effects=[invert_effect])
+    rendered = layer.render()
+    expected = np.array(
+        [
+            [[155, 155, 155], [255, 255, 255]],
+            [[255, 255, 255], [155, 155, 155]],
+        ],
+        dtype=np.uint8,
+    )
+    assert np.array_equal(rendered, expected)
+
+
+def test_svg_import_export(tmp_path):
+    vec = ['<rect x="0" y="0" width="10" height="10" />']
+    file_path = tmp_path / "shape.svg"
+    export_svg(vec, str(file_path))
+    loaded = import_svg(str(file_path))
+    assert vec == loaded
+
+
+def test_ai_layer_generation():
+    layer = generate_ai_layer("test", size=(8, 8))
+    assert layer.content.shape == (8, 8, 3)


### PR DESCRIPTION
## Summary
- add `Layer` class supporting masks, effects, and AI layer generation
- support SVG vector import/export helpers
- test masking, SVG IO, and AI layer creation

## Testing
- `pytest tests/image_editor/test_layers.py`

------
https://chatgpt.com/codex/tasks/task_e_6896a0a6c8c48323a4c6f79a47a388c6