### PR TITLE
docs: add visual mode annotation schema

### DIFF
--- a/visual_mode/metadata_schema.json
+++ b/visual_mode/metadata_schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Neira Visual Mode Metadata",
+  "type": "object",
+  "properties": {
+    "blocks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/block" }
+    },
+    "variables": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/variable" }
+    },
+    "connections": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/connection" }
+    }
+  },
+  "required": ["blocks", "variables", "connections"],
+  "$defs": {
+    "position": {
+      "type": "object",
+      "properties": {
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["line", "column"]
+    },
+    "range": {
+      "type": "object",
+      "properties": {
+        "start": { "$ref": "#/$defs/position" },
+        "end": { "$ref": "#/$defs/position" }
+      },
+      "required": ["start", "end"]
+    },
+    "i18n": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]{2}(?:-[A-Z]{2})?$": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "block": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "display": { "type": "string" },
+        "i18n": { "$ref": "#/$defs/i18n" },
+        "category": { "type": "string" },
+        "range": { "$ref": "#/$defs/range" }
+      },
+      "required": ["id"]
+    },
+    "variable": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "display": { "type": "string" },
+        "i18n": { "$ref": "#/$defs/i18n" },
+        "category": { "type": "string" },
+        "range": { "$ref": "#/$defs/range" }
+      },
+      "required": ["id"]
+    },
+    "connection": {
+      "type": "object",
+      "properties": {
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "display": { "type": "string" },
+        "i18n": { "$ref": "#/$defs/i18n" },
+        "category": { "type": "string" }
+      },
+      "required": ["from", "to"]
+    }
+  }
+}

--- a/visual_mode/schema.md
+++ b/visual_mode/schema.md
@@ -1,0 +1,67 @@
+# Visual Mode Comment Annotations
+
+Neira's visual mode reads metadata embedded in code comments. Each annotation
+starts with the `@neyra:` prefix so the base language parser can ignore them.
+
+## General Rules
+- Annotations must live inside the host language's comment syntax (e.g. `#`,
+  `//`, `/* */`).
+- Place each annotation on its own line or at the end of a line of code.
+- Attributes are written as `key=value` pairs separated by spaces. Strings may
+  be quoted with `"` if they contain whitespace.
+
+Additional annotations can be defined using the same `@neyra:` prefix.
+
+## `@neyra:visual_block`
+Marks a code region that represents a block in the visual editor.
+
+Example:
+```python
+# @neyra:visual_block id="sum" display="Add" category="math"
+```
+
+**Fields**
+- `id` (required) – unique identifier for the block.
+- `display` – base display name shown in the UI.
+- `i18n.<locale>` – localized display names, e.g. `i18n.es="Suma"`.
+- `category` – classification string for grouping blocks.
+- `range` – `start_line:start_col-end_line:end_col` describing covered code.
+
+## `@neyra:var`
+Declares a variable or parameter used in the visual graph.
+
+```
+# @neyra:var id="x" display="X value"
+```
+
+Fields mirror `@neyra:visual_block` and may include `category`, `display`,
+`i18n.<locale>` and `range`.
+
+## `@neyra:connection`
+Defines a connection between blocks or variables.
+
+```
+# @neyra:connection from="sum" to="result" category="data"
+```
+
+**Fields**
+- `from` and `to` (required) – identifiers of the source and target nodes.
+- `display`, `i18n.<locale>`, and `category` – optional metadata.
+
+## Position Encoding
+Positions and ranges use 1-based line and column numbers.
+- `position=line:column` marks a single point.
+- `range=start_line:start_col-end_line:end_col` marks a span.
+
+## Display Names & Localization
+- `display` provides a default name.
+- `i18n.<locale>` overrides the name for a locale (e.g. `i18n.fr`).
+
+## Categories
+The `category` field groups blocks, variables, or connections under an
+arbitrary string.
+
+## Editor Integration
+Since annotations are ordinary comments, editors that do not understand them
+should ignore them entirely. Visual-mode aware tools may parse `@neyra:` lines
+but must not alter program semantics when annotations are added or removed.


### PR DESCRIPTION
## Summary
- document comment-based visual annotations for `@neyra:` directives
- define JSON schema for visual mode metadata

## Testing
- `pytest` *(fails: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6896a49cc11c83239140f31780589cb8