### PR TITLE
Add Java parser for visual mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ requests>=2.31.0
 language_tool_python>=2.0.0
 networkx>=3.0
 websockets>=12.0
+javalang>=0.13.0

--- a/requirements_desktop.txt
+++ b/requirements_desktop.txt
@@ -38,3 +38,4 @@ whoosh>=2.7.4
 # Notifications
 plyer>=2.1.0
 networkx>=3.0
+javalang>=0.13.0

--- a/visual_mode/parser/__init__.py
+++ b/visual_mode/parser/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import LanguageParser  # re-export for convenience
 from .python_parser import PythonParser
+from .java_parser import JavaParser
 from . import utils
 
-__all__ = ["LanguageParser", "PythonParser", "utils"]
+__all__ = ["LanguageParser", "PythonParser", "JavaParser", "utils"]

--- a/visual_mode/parser/java_parser.py
+++ b/visual_mode/parser/java_parser.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+"""Java source parser for visual programming mode.
+
+This module provides :class:`JavaParser` which converts Java source code into a
+structure of visual blocks.  It uses the :mod:`javalang` library to parse the
+source into an AST and extracts documentation from block comments and
+Javadoc-style annotations.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+import re
+
+import javalang
+
+from .base import LanguageParser
+
+
+@dataclass
+class ParsedJava:
+    """Container holding parsed information about a Java compilation unit."""
+
+    tree: javalang.tree.CompilationUnit
+    source: str
+    comments: Dict[int, str]
+
+
+def _clean_comment_text(text: str) -> str:
+    """Normalize comment text by stripping decorations."""
+
+    lines = text.splitlines()
+    cleaned = []
+    for line in lines:
+        line = line.strip()
+        if line.startswith("*"):
+            line = line.lstrip("*")
+        cleaned.append(line.strip())
+    return "\n".join([ln for ln in cleaned if ln]).strip()
+
+
+def _extract_block_comments(source: str) -> Dict[int, str]:
+    """Return mapping of line numbers to preceding block comments.
+
+    The returned dictionary maps the *first code line* following a block or
+    Javadoc comment to the comment's text.
+    """
+
+    comments: Dict[int, str] = {}
+    lines = source.splitlines()
+
+    for match in re.finditer(r"/\*+(.*?)\*/", source, re.DOTALL):
+        comment_body = match.group(1)
+        comment = _clean_comment_text(comment_body)
+
+        # Determine the line where the comment ends
+        end_offset = match.end()
+        end_line = source[:end_offset].count("\n") + 1
+
+        # Find the next line containing code
+        next_line = end_line + 1
+        while next_line <= len(lines):
+            text = lines[next_line - 1].strip()
+            if text and not text.startswith("//") and not text.startswith("/*"):
+                comments[next_line] = comment
+                break
+            next_line += 1
+
+    return comments
+
+
+def _node_range(node: Any) -> Dict[str, Dict[str, int]]:
+    """Return a dictionary describing the start and end position of ``node``."""
+
+    if getattr(node, "position", None):
+        line, col = node.position
+    else:
+        line, col = 1, 0
+    start = {"line": line, "column": col + 1}
+    return {"start": start, "end": start}
+
+
+class JavaParser(LanguageParser):
+    """Concrete :class:`LanguageParser` implementation for Java."""
+
+    def parse_file(self, path: str | Path) -> ParsedJava:
+        source = Path(path).read_text(encoding="utf-8")
+        tree = javalang.parse.parse(source)
+        comments = _extract_block_comments(source)
+        return ParsedJava(tree=tree, source=source, comments=comments)
+
+    def extract_nodes(self, module: ParsedJava) -> Iterable[Dict[str, Any]]:
+        nodes: List[Dict[str, Any]] = []
+        tree = module.tree
+
+        # Package declaration
+        if tree.package:
+            pkg = tree.package
+            line = pkg.position.line if pkg.position else 1
+            doc = module.comments.get(line, "")
+            nodes.append(
+                {
+                    "id": pkg.name,
+                    "type": "block",
+                    "display": doc,
+                    "range": _node_range(pkg),
+                }
+            )
+
+        # Classes and their methods/constructors
+        for _, class_node in tree.filter(javalang.tree.ClassDeclaration):
+            line = class_node.position.line if class_node.position else 1
+            doc = module.comments.get(line, "")
+            nodes.append(
+                {
+                    "id": class_node.name,
+                    "type": "block",
+                    "display": doc,
+                    "range": _node_range(class_node),
+                }
+            )
+            # Methods
+            for method in list(class_node.methods) + list(class_node.constructors):
+                line = method.position.line if method.position else 1
+                doc = module.comments.get(line, "")
+                nodes.append(
+                    {
+                        "id": method.name,
+                        "type": "block",
+                        "display": doc,
+                        "range": _node_range(method),
+                    }
+                )
+
+        return nodes
+
+    def extract_connections(self, module: ParsedJava) -> Iterable[Any]:
+        return []

--- a/visual_mode/parser/tests/test_java_parser.py
+++ b/visual_mode/parser/tests/test_java_parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from pathlib import Path
+
+from visual_mode.parser.java_parser import JavaParser
+
+
+def test_package_class_method_mapping(tmp_path: Path) -> None:
+    code = dedent(
+        """
+        /* Package comment */
+        package example;
+
+        /**
+         * Main class doc
+         */
+        public class Main {
+            /* Multiply numbers */
+            public int mul(int a, int b) {
+                return a * b;
+            }
+        }
+        """
+    )
+    file = tmp_path / "Main.java"
+    file.write_text(code)
+
+    parser = JavaParser()
+    module = parser.parse_file(file)
+    nodes = list(parser.extract_nodes(module))
+    mapping = {node["id"]: node for node in nodes}
+
+    assert mapping["example"]["display"] == "Package comment"
+    assert mapping["Main"]["display"] == "Main class doc"
+    assert mapping["mul"]["display"] == "Multiply numbers"
+    assert list(parser.extract_connections(module)) == []


### PR DESCRIPTION
## Summary
- implement `JavaParser` leveraging javalang to map package, class and method scopes and extract block and Javadoc comments
- expose Java parser from the parser package and add javalang dependency
- add tests covering comment mapping and scope extraction

## Testing
- `PYTHONPATH=. pytest visual_mode/parser/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896b2375368832392413bdfc0035c82