### PR TITLE
Add C++ parser with namespace and template support

### DIFF
--- a/visual_mode/parser/__init__.py
+++ b/visual_mode/parser/__init__.py
@@ -4,6 +4,14 @@ from .base import LanguageParser  # re-export for convenience
 from .python_parser import PythonParser
 from .java_parser import JavaParser
 from .c_parser import CParser
+from .cpp_parser import CppParser
 from . import utils
 
-__all__ = ["LanguageParser", "PythonParser", "JavaParser", "CParser", "utils"]
+__all__ = [
+    "LanguageParser",
+    "PythonParser",
+    "JavaParser",
+    "CParser",
+    "CppParser",
+    "utils",
+]

--- a/visual_mode/parser/cpp_parser.py
+++ b/visual_mode/parser/cpp_parser.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""C++ source parser for visual programming mode.
+
+Extends :class:`CParser` with support for namespaces, templates and line
+comments (``//``) in addition to block comments for annotations.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from clang import cindex
+
+from .c_parser import CParser, ParsedC, _extract_block_comments, _node_range
+
+
+def _extract_comments(source: str) -> Dict[int, str]:
+    """Return mapping of line numbers to preceding comments.
+
+    Both block (``/* ... */``) and single line (``//``) comments are supported.
+    """
+
+    comments = _extract_block_comments(source)
+    lines = source.splitlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("//"):
+            block: List[str] = []
+            while i < len(lines) and lines[i].strip().startswith("//"):
+                block.append(lines[i].strip()[2:].strip())
+                i += 1
+            while i < len(lines) and not lines[i].strip():
+                i += 1
+            if i < len(lines):
+                comments[i + 1] = "\n".join([ln for ln in block if ln]).strip()
+            continue
+        i += 1
+    return comments
+
+
+class CppParser(CParser):
+    """Concrete :class:`LanguageParser` implementation for C++."""
+
+    def parse_file(self, path: str | Path) -> ParsedC:
+        path = Path(path)
+        source = path.read_text(encoding="utf-8")
+        index = cindex.Index.create()
+        options = cindex.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD
+        args = ["-std=c++17", "-x", "c++"]
+        tu = index.parse(str(path), args=args, options=options)
+        comments = _extract_comments(source)
+        return ParsedC(translation_unit=tu, source=source, path=path, comments=comments)
+
+    def extract_nodes(self, module: ParsedC) -> Iterable[Dict[str, Any]]:
+        nodes: List[Dict[str, Any]] = []
+        path = module.path
+
+        def walk(cursor: cindex.Cursor, namespace: str = "") -> None:
+            for child in cursor.get_children():
+                loc = child.location
+                if loc.file is None or Path(loc.file.name) != path:
+                    continue
+                if child.kind == cindex.CursorKind.NAMESPACE:
+                    ns = f"{namespace}::{child.spelling}" if namespace else child.spelling
+                    walk(child, ns)
+                elif child.kind in (
+                    cindex.CursorKind.FUNCTION_DECL,
+                    cindex.CursorKind.FUNCTION_TEMPLATE,
+                ):
+                    doc = module.comments.get(child.extent.start.line, "")
+                    name = child.spelling
+                    if namespace:
+                        name = f"{namespace}::{name}"
+                    nodes.append(
+                        {
+                            "id": name,
+                            "type": "block",
+                            "display": doc,
+                            "range": _node_range(child),
+                        }
+                    )
+                elif child.kind == cindex.CursorKind.MACRO_DEFINITION:
+                    doc = module.comments.get(child.extent.start.line, "")
+                    name = child.spelling
+                    if namespace:
+                        name = f"{namespace}::{name}"
+                    nodes.append(
+                        {
+                            "id": name,
+                            "type": "macro",
+                            "display": doc,
+                            "range": _node_range(child),
+                        }
+                    )
+                else:
+                    walk(child, namespace)
+
+        walk(module.translation_unit.cursor)
+        return nodes
+
+    def extract_connections(self, module: ParsedC) -> Iterable[Any]:
+        return []

--- a/visual_mode/parser/tests/test_cpp_parser.py
+++ b/visual_mode/parser/tests/test_cpp_parser.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from pathlib import Path
+
+from visual_mode.parser.cpp_parser import CppParser
+
+
+def test_cpp_parser_handles_namespaces_and_templates(tmp_path: Path) -> None:
+    code = dedent(
+        '''
+        namespace math {
+        // Adds two numbers
+        int add(int a, int b) { return a + b; }
+
+        /* Multiplies two numbers */
+        template <typename T>
+        T mul(T a, T b) { return a * b; }
+        }
+        '''
+    )
+
+    src = tmp_path / "sample.cpp"
+    src.write_text(code)
+
+    parser = CppParser()
+    module = parser.parse_file(src)
+    nodes = {node["id"]: node for node in parser.extract_nodes(module)}
+
+    assert nodes["math::add"]["display"] == "Adds two numbers"
+    assert nodes["math::mul"]["display"] == "Multiplies two numbers"


### PR DESCRIPTION
## Summary
- implement a C++ parser built on the C parser
- handle namespaces, function templates, and both // and block comment annotations
- expose CppParser and add tests

## Testing
- `python -m pytest visual_mode/parser/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b6a40b288323814aadfe980ed546