### PR TITLE
Add Roslyn-based C# parser with docs and annotation support

### DIFF
--- a/visual_mode/parser/__init__.py
+++ b/visual_mode/parser/__init__.py
@@ -1,17 +1,43 @@
 """Utilities and base classes for visual mode language parsing."""
 
 from .base import LanguageParser  # re-export for convenience
-from .python_parser import PythonParser
-from .java_parser import JavaParser
-from .c_parser import CParser
-from .cpp_parser import CppParser
 from . import utils
 
-__all__ = [
-    "LanguageParser",
-    "PythonParser",
-    "JavaParser",
-    "CParser",
-    "CppParser",
-    "utils",
-]
+# Optional parser implementations.  They are imported lazily so that missing
+# third-party dependencies do not prevent the package from being imported.
+try:  # pragma: no cover - optional dependency
+    from .python_parser import PythonParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    PythonParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from .java_parser import JavaParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    JavaParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from .c_parser import CParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    CParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from .cpp_parser import CppParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    CppParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from .csharp_parser import CSharpParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    CSharpParser = None  # type: ignore
+
+__all__ = ["LanguageParser", "utils"]
+if PythonParser is not None:
+    __all__.append("PythonParser")
+if JavaParser is not None:
+    __all__.append("JavaParser")
+if CParser is not None:
+    __all__.append("CParser")
+if CppParser is not None:
+    __all__.append("CppParser")
+if CSharpParser is not None:
+    __all__.append("CSharpParser")

--- a/visual_mode/parser/csharp_parser.py
+++ b/visual_mode/parser/csharp_parser.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+"""C# source parser for visual programming mode.
+
+This parser leverages Roslyn to parse C# source files and extracts method
+and field declarations together with documentation from XML doc comments or
+inline ``//`` annotations.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+import xml.etree.ElementTree as ET
+
+try:  # pragma: no cover - optional dependency
+    import clr  # type: ignore
+    clr.AddReference("Microsoft.CodeAnalysis")
+    clr.AddReference("Microsoft.CodeAnalysis.CSharp")
+    from Microsoft.CodeAnalysis.CSharp import CSharpSyntaxTree, SyntaxKind
+    from Microsoft.CodeAnalysis.CSharp.Syntax import (
+        FieldDeclarationSyntax,
+        MethodDeclarationSyntax,
+    )
+except Exception:  # pragma: no cover - fallback when Roslyn is unavailable
+    clr = None  # type: ignore
+    CSharpSyntaxTree = None  # type: ignore
+    SyntaxKind = None  # type: ignore
+    MethodDeclarationSyntax = FieldDeclarationSyntax = object  # type: ignore
+
+from .base import LanguageParser
+
+
+@dataclass
+class ParsedCSharp:
+    """Container holding parsed information about a C# compilation unit."""
+
+    tree: Any
+    root: Any
+    source: str
+
+
+def _node_range(node: Any) -> Dict[str, Dict[str, int]]:
+    """Return a dictionary describing the start and end position of ``node``."""
+
+    span = node.GetLocation().GetLineSpan()
+    start = span.StartLinePosition
+    end = span.EndLinePosition
+    return {
+        "start": {"line": start.Line + 1, "column": start.Character + 1},
+        "end": {"line": end.Line + 1, "column": end.Character + 1},
+    }
+
+
+def _xml_doc(node: Any) -> str:
+    """Extract and flatten XML documentation for ``node``."""
+
+    getter = getattr(node, "GetDocumentationCommentXml", None)
+    if getter:
+        xml = getter()
+        if xml:
+            try:
+                root = ET.fromstring(xml)
+                return " ".join(root.itertext()).strip()
+            except Exception:  # pragma: no cover - malformed XML
+                return xml.strip()
+    return ""
+
+
+def _inline_comment(node: Any) -> str:
+    """Return trailing ``//`` comment associated with ``node`` if present."""
+
+    if SyntaxKind is None:
+        return ""
+    token = node.GetLastToken()
+    for trivia in token.TrailingTrivia:
+        if trivia.Kind() == SyntaxKind.SingleLineCommentTrivia:
+            return str(trivia.ToString()).lstrip("//").strip()
+    return ""
+
+
+class CSharpParser(LanguageParser):
+    """Concrete :class:`LanguageParser` implementation for C#."""
+
+    def parse_file(self, path: str | Path) -> ParsedCSharp:
+        if CSharpSyntaxTree is None:  # pragma: no cover - dependency missing
+            raise ImportError("Roslyn is required for CSharpParser")
+        source = Path(path).read_text(encoding="utf-8")
+        tree = CSharpSyntaxTree.ParseText(source)
+        root = tree.GetRoot()
+        return ParsedCSharp(tree=tree, root=root, source=source)
+
+    def extract_nodes(self, module: ParsedCSharp) -> Iterable[Dict[str, Any]]:
+        nodes: List[Dict[str, Any]] = []
+        for node in module.root.DescendantNodes():
+            if isinstance(node, MethodDeclarationSyntax):
+                doc = _xml_doc(node) or _inline_comment(node)
+                nodes.append(
+                    {
+                        "id": node.Identifier.Text,
+                        "type": "block",
+                        "display": doc,
+                        "range": _node_range(node),
+                    }
+                )
+            elif isinstance(node, FieldDeclarationSyntax):
+                doc = _xml_doc(node) or _inline_comment(node)
+                for variable in node.Declaration.Variables:
+                    nodes.append(
+                        {
+                            "id": variable.Identifier.Text,
+                            "type": "variable",
+                            "display": doc,
+                            "range": _node_range(node),
+                        }
+                    )
+        return nodes
+
+    def extract_connections(self, module: ParsedCSharp) -> Iterable[Any]:
+        return []

--- a/visual_mode/parser/tests/test_csharp_parser.py
+++ b/visual_mode/parser/tests/test_csharp_parser.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from pathlib import Path
+import pytest
+
+# Skip if pythonnet or Roslyn assemblies are not available
+clr = pytest.importorskip("clr")
+try:  # pragma: no cover - ensure assemblies
+    clr.AddReference("Microsoft.CodeAnalysis")
+    clr.AddReference("Microsoft.CodeAnalysis.CSharp")
+except Exception:  # pragma: no cover - skip when assemblies missing
+    pytest.skip("Roslyn assemblies not available", allow_module_level=True)
+
+from visual_mode.parser.csharp_parser import CSharpParser
+
+
+def test_method_and_field_mapping(tmp_path: Path) -> None:
+    code = dedent(
+        """
+        /// <summary>Calculator</summary>
+        public class Calc {
+            /// <summary>Add numbers</summary>
+            public int Add(int a, int b) { return a + b; }
+
+            public int value = 0; // initial value
+        }
+        """
+    )
+    file = tmp_path / "Calc.cs"
+    file.write_text(code)
+
+    parser = CSharpParser()
+    module = parser.parse_file(file)
+    nodes = {node["id"]: node for node in parser.extract_nodes(module)}
+
+    assert nodes["Add"]["display"] == "Add numbers"
+    assert nodes["value"]["display"] == "initial value"
+    assert list(parser.extract_connections(module)) == []


### PR DESCRIPTION
## Summary
- add `CSharpParser` using Roslyn to extract methods and fields with XML doc comments or inline `//` annotations
- make parser package resilient to missing optional dependencies via lazy imports
- add tests covering C# doc comment and inline annotation parsing

## Testing
- `PYTHONPATH=. pytest visual_mode/parser/tests/test_csharp_parser.py -q`
- `PYTHONPATH=. pytest visual_mode/parser/tests/test_python_parser.py -q`
- `PYTHONPATH=. pytest visual_mode/parser/tests/test_base_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b9b694a8832394b21fb9763e9123