### PR TITLE
Add TypeScript parser for visual mode using compiler API

### DIFF
--- a/visual_mode/parser/__init__.py
+++ b/visual_mode/parser/__init__.py
@@ -35,6 +35,11 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - dependency missing
     JavaScriptParser = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    from .typescript_parser import TypeScriptParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    TypeScriptParser = None  # type: ignore
+
 __all__ = ["LanguageParser", "utils"]
 if PythonParser is not None:
     __all__.append("PythonParser")
@@ -48,3 +53,5 @@ if CSharpParser is not None:
     __all__.append("CSharpParser")
 if JavaScriptParser is not None:
     __all__.append("JavaScriptParser")
+if TypeScriptParser is not None:
+    __all__.append("TypeScriptParser")

--- a/visual_mode/parser/tests/test_typescript_parser.py
+++ b/visual_mode/parser/tests/test_typescript_parser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from pathlib import Path
+
+from visual_mode.parser.typescript_parser import TypeScriptParser
+
+
+def test_typescript_functions_and_classes(tmp_path: Path) -> None:
+    code = dedent(
+        '''
+        function add(a: number, b: number): number {
+            return a + b;
+        }
+
+        @sealed
+        class Greeter {
+            constructor(private greeting: string) {}
+        }
+        '''
+    )
+    file = tmp_path / "sample.ts"
+    file.write_text(code)
+
+    parser = TypeScriptParser()
+    module = parser.parse_file(file)
+    nodes = list(parser.extract_nodes(module))
+
+    mapping = {n["id"]: n for n in nodes}
+
+    assert mapping["add"]["return_type"] == "number"
+    assert mapping["add"]["parameters"] == [
+        {"name": "a", "type": "number"},
+        {"name": "b", "type": "number"},
+    ]
+    assert mapping["Greeter"].get("decorators") == ["sealed"]
+    assert list(parser.extract_connections(module)) == []

--- a/visual_mode/parser/typescript_parser.py
+++ b/visual_mode/parser/typescript_parser.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+"""TypeScript source parser for visual programming mode.
+
+This parser invokes the TypeScript compiler API via ``node`` to analyse a
+TypeScript source file.  It extracts top level function and class declarations
+and resolves parameter and return types together with decorator information.
+The extracted information mirrors that of other language parsers in this
+package and can be consumed by the visual editor.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+import json
+import os
+import shutil
+import subprocess
+
+from .base import LanguageParser
+
+
+@dataclass
+class ParsedTypeScript:
+    """Container holding parsed information about a TypeScript module."""
+
+    symbols: List[Dict[str, Any]]
+
+
+class TypeScriptParser(LanguageParser):
+    """Concrete :class:`LanguageParser` implementation for TypeScript."""
+
+    def _ensure_node(self) -> str:
+        node = shutil.which("node")
+        if node is None:
+            raise EnvironmentError("node executable not found")
+        return node
+
+    def parse_file(self, path: str | Path) -> ParsedTypeScript:
+        path = Path(path)
+        node = self._ensure_node()
+        npm = shutil.which("npm")
+        node_path = ""
+        if npm is not None:
+            try:  # pragma: no cover - best effort
+                node_path = (
+                    subprocess.run(
+                        [npm, "root", "-g"], capture_output=True, text=True, check=True
+                    ).stdout.strip()
+                )
+            except Exception:  # pragma: no cover - npm unavailable
+                node_path = ""
+        env = os.environ.copy()
+        if node_path:
+            env["NODE_PATH"] = node_path
+
+        script = r"""
+const ts = require('typescript');
+const fs = require('fs');
+const fileName = process.argv[1];
+const sourceText = fs.readFileSync(fileName, 'utf8');
+const options = { target: ts.ScriptTarget.Latest, module: ts.ModuleKind.CommonJS, experimentalDecorators: true };
+const program = ts.createProgram([fileName], options);
+const checker = program.getTypeChecker();
+const source = program.getSourceFile(fileName);
+
+function getDoc(node) {
+  const tags = ts.getJSDocCommentsAndTags(node) || [];
+  return tags.map(t => t.getFullText().trim()).join('\n');
+}
+function getDecorators(node) {
+  if (ts.canHaveDecorators && ts.canHaveDecorators(node)) {
+    const decs = ts.getDecorators ? ts.getDecorators(node) || [] : [];
+    return decs.map(d => d.expression.getText());
+  }
+  return node.decorators ? node.decorators.map(d => d.expression.getText()) : [];
+}
+function toLoc(pos) {
+  const lc = source.getLineAndCharacterOfPosition(pos);
+  return { line: lc.line + 1, column: lc.character + 1 };
+}
+function paramType(p) {
+  const type = checker.getTypeAtLocation(p);
+  return checker.typeToString(type);
+}
+const nodes = [];
+ts.forEachChild(source, node => {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    const sig = checker.getSignatureFromDeclaration(node);
+    const returnType = sig ? checker.typeToString(checker.getReturnTypeOfSignature(sig)) : '';
+    const params = node.parameters.map(p => ({ name: p.name.getText(), type: paramType(p) }));
+    const decorators = getDecorators(node);
+    nodes.push({
+      kind: 'function',
+      name: node.name.getText(),
+      doc: getDoc(node),
+      returnType,
+      parameters: params,
+      decorators,
+      range: { start: toLoc(node.getStart()), end: toLoc(node.end) }
+    });
+  } else if (ts.isClassDeclaration(node) && node.name) {
+    const decorators = getDecorators(node);
+    nodes.push({
+      kind: 'class',
+      name: node.name.getText(),
+      doc: getDoc(node),
+      decorators,
+      range: { start: toLoc(node.getStart()), end: toLoc(node.end) }
+    });
+  }
+});
+process.stdout.write(JSON.stringify({nodes}));
+"""
+        result = subprocess.run(
+            [node, "-e", script, str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        data = json.loads(result.stdout)
+        return ParsedTypeScript(symbols=data.get("nodes", []))
+
+    def extract_nodes(self, module: ParsedTypeScript) -> Iterable[Dict[str, Any]]:
+        nodes: List[Dict[str, Any]] = []
+        for sym in module.symbols:
+            node: Dict[str, Any] = {
+                "id": sym.get("name", ""),
+                "type": "block" if sym.get("kind") == "function" else "class",
+                "display": sym.get("doc", ""),
+                "range": sym.get("range", {}),
+            }
+            if sym.get("decorators"):
+                node["decorators"] = sym["decorators"]
+            if sym.get("kind") == "function":
+                node["return_type"] = sym.get("returnType", "")
+                node["parameters"] = sym.get("parameters", [])
+            nodes.append(node)
+        return nodes
+
+    def extract_connections(self, module: ParsedTypeScript) -> Iterable[Any]:
+        return []


### PR DESCRIPTION
## Summary
- add TypeScript parser leveraging the TypeScript compiler API to resolve function and class metadata including types and decorators
- expose TypeScriptParser in visual_mode.parser package
- test TypeScript parsing of functions and decorated classes

## Testing
- `PYTHONPATH=. pytest visual_mode/parser/tests/test_typescript_parser.py -q`
- `PYTHONPATH=. pytest visual_mode/parser/tests -q` *(fails: ModuleNotFoundError: No module named 'clang'; ModuleNotFoundError: No module named 'javalang'; ModuleNotFoundError: No module named 'esprima')*

------
https://chatgpt.com/codex/tasks/task_e_6896be21a35c8323b64199dacb810abf