### PR TITLE
Add R parser for visual mode

### DIFF
--- a/visual_mode/parser/__init__.py
+++ b/visual_mode/parser/__init__.py
@@ -76,6 +76,11 @@ except Exception:  # pragma: no cover - dependency missing
     SwiftParser = None  # type: ignore
 
 try:  # pragma: no cover - optional dependency
+    from .r_parser import RParser  # type: ignore
+except Exception:  # pragma: no cover - dependency missing
+    RParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
     from .scala_parser import ScalaParser  # type: ignore
 except Exception:  # pragma: no cover - dependency missing
     ScalaParser = None  # type: ignore
@@ -111,3 +116,5 @@ if SwiftParser is not None:
     __all__.append("SwiftParser")
 if ScalaParser is not None:
     __all__.append("ScalaParser")
+if RParser is not None:
+    __all__.append("RParser")

--- a/visual_mode/parser/r_parser.py
+++ b/visual_mode/parser/r_parser.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""R source parser for visual programming mode.
+
+This parser uses a lightweight tokenizer implemented in Python to extract
+top-level function and variable assignments from R source code. Documentation
+is derived from inline ``#`` comments or preceding comment lines. The resulting
+structure mirrors the format produced by other language parsers and can be
+consumed by the visual editor."""
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .base import LanguageParser
+
+
+@dataclass
+class ParsedR:
+    """Container holding parsed information about an R source file."""
+
+    source: str
+    lines: List[str]
+    comments: Dict[int, str]
+
+
+def _collect_comments(lines: List[str]) -> Dict[int, str]:
+    """Map code line numbers to associated ``#`` comment text."""
+
+    comments: Dict[int, str] = {}
+    pending: List[str] = []
+    for idx, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            pending.append(stripped.lstrip("#").strip())
+            continue
+        if not stripped:
+            pending.clear()
+            continue
+        doc = ""
+        if "#" in line:
+            doc = line.split("#", 1)[1].strip()
+        elif pending:
+            doc = " ".join(pending).strip()
+        if doc:
+            comments[idx] = doc
+        pending.clear()
+    return comments
+
+
+class RParser(LanguageParser):
+    """Concrete :class:`LanguageParser` implementation for R."""
+
+    _FUNC_RE = re.compile(r"^\s*([A-Za-z\.][A-Za-z0-9\._]*)\s*(?:<-|=)\s*function\s*\(")
+    _ASSIGN_RE = re.compile(r"^\s*([A-Za-z\.][A-Za-z0-9\._]*)\s*(?:<-|=)")
+
+    def parse_file(self, path: str | Path) -> ParsedR:
+        source = Path(path).read_text(encoding="utf-8")
+        lines = source.splitlines()
+        comments = _collect_comments(lines)
+        return ParsedR(source=source, lines=lines, comments=comments)
+
+    def extract_nodes(self, module: ParsedR) -> Iterable[Dict[str, Any]]:
+        nodes: List[Dict[str, Any]] = []
+        brace_level = 0
+        for idx, line in enumerate(module.lines, start=1):
+            code = line.split("#", 1)[0]
+            if brace_level == 0:
+                func_match = self._FUNC_RE.match(code)
+                if func_match:
+                    name = func_match.group(1)
+                    doc = module.comments.get(idx, "")
+                    nodes.append(
+                        {
+                            "id": name,
+                            "type": "block",
+                            "display": doc,
+                            "range": {
+                                "start": {"line": idx, "column": 1},
+                                "end": {"line": idx, "column": len(line) + 1},
+                            },
+                        }
+                    )
+                else:
+                    assign_match = self._ASSIGN_RE.match(code)
+                    if assign_match:
+                        name = assign_match.group(1)
+                        doc = module.comments.get(idx, "")
+                        nodes.append(
+                            {
+                                "id": name,
+                                "type": "variable",
+                                "display": doc,
+                                "range": {
+                                    "start": {"line": idx, "column": 1},
+                                    "end": {"line": idx, "column": len(line) + 1},
+                                },
+                            }
+                        )
+            brace_level += code.count("{") - code.count("}")
+        return nodes
+
+    def extract_connections(self, module: ParsedR) -> Iterable[Any]:
+        return []

--- a/visual_mode/parser/tests/test_r_parser.py
+++ b/visual_mode/parser/tests/test_r_parser.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from textwrap import dedent
+from pathlib import Path
+
+from visual_mode.parser.r_parser import RParser
+
+
+def test_r_parser_comments(tmp_path: Path) -> None:
+    code = dedent(
+        """
+        x <- 1  # first variable
+        # variable y
+        y <- 2
+
+        # Adds two numbers
+        add <- function(a, b) {
+            a + b
+        }
+        """
+    )
+    file = tmp_path / "sample.R"
+    file.write_text(code)
+
+    parser = RParser()
+    module = parser.parse_file(file)
+    nodes = list(parser.extract_nodes(module))
+    mapping = {node["id"]: node for node in nodes}
+
+    assert mapping["x"]["display"] == "first variable"
+    assert mapping["y"]["display"] == "variable y"
+    assert mapping["add"]["display"] == "Adds two numbers"
+    assert list(parser.extract_connections(module)) == []


### PR DESCRIPTION
## Summary
- add R language parser with lightweight tokenizer and `#` comment annotations
- expose `RParser` in parser package
- cover R parsing with unit test

## Testing
- `PYTHONPATH=. pytest visual_mode/parser/tests/test_r_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d8fb4ab483239da914f719487f27