### PR TITLE
docs: add visual mode workflow and examples

### DIFF
--- a/docs/visual_mode/README.md
+++ b/docs/visual_mode/README.md
@@ -1,0 +1,46 @@
+# Visual Mode Workflow
+
+Neira's visual mode extracts structured graphs from annotated source code. The
+workflow is:
+
+1. **Annotate** code with `@neyra:` comments describing blocks, variables and
+   their connections.
+2. **Parse** the source using the visual-mode parser to build metadata.
+3. **Edit** the resulting graph in the visual editor.
+4. **Localize** display names with `i18n.<locale>` fields when translations are
+   needed.
+
+## Annotation Syntax
+Annotations are normal comments beginning with `@neyra:` followed by a type and
+space separated `key=value` pairs.
+
+Common annotations:
+
+- `@neyra:visual_block` – marks a block that appears in the editor.
+- `@neyra:var` – declares a variable or parameter.
+- `@neyra:connection` – links two identifiers.
+
+Strings containing spaces may be quoted with `"`. Additional attributes are
+permitted and ignored by parsers that do not understand them.
+
+## Supported Languages
+The parser currently ships modules for:
+C, C++, C#, Dart, Go, Haskell, Java, JavaScript, Kotlin, MATLAB, Objective‑C,
+PHP, Python, R, Ruby, Rust, Scala, Swift and TypeScript. Any language that
+supports comments can carry annotations.
+
+## Guidelines for Translators
+
+- Add localized names using `i18n.<locale>="Translation"`.
+- Leave `id` values untouched and keep code semantics unchanged.
+- Record authorship with attributes such as `translator="Name"` and
+  `reviewer="Name"`.
+
+## AI Metadata Usage
+
+When annotations or translations are produced by automation, include
+`source=ai` and optional details such as `model="gpt-4"` or
+`confidence=0.9`. Human curated data may use `source=human` and name the
+`translator`.
+
+Language specific examples are available in the [examples](examples/) folder.

--- a/docs/visual_mode/examples/javascript.md
+++ b/docs/visual_mode/examples/javascript.md
@@ -1,0 +1,13 @@
+# JavaScript
+
+```javascript
+// @neyra:visual_block id="sum" display="Add" i18n.es="Suma" category="math" translator="Ana"
+function add(a, b) {
+  // @neyra:var id="a" display="First number"
+  // @neyra:var id="b" display="Second number"
+  const result = a + b;
+  // @neyra:connection from="a" to="sum" category="data" source=ai model="gpt-4"
+  // @neyra:connection from="b" to="sum" category="data" source=ai model="gpt-4"
+  return result;
+}
+```

--- a/docs/visual_mode/examples/python.md
+++ b/docs/visual_mode/examples/python.md
@@ -1,0 +1,12 @@
+# Python
+
+```python
+# @neyra:visual_block id="sum" display="Add" i18n.es="Suma" category="math" translator="Ana"
+def add(a, b):
+    # @neyra:var id="a" display="First number"
+    # @neyra:var id="b" display="Second number"
+    result = a + b
+    # @neyra:connection from="a" to="sum" category="data" source=ai model="gpt-4" confidence=0.9
+    # @neyra:connection from="b" to="sum" category="data" source=ai model="gpt-4" confidence=0.9
+    return result
+```

--- a/docs/visual_mode/examples/rust.md
+++ b/docs/visual_mode/examples/rust.md
@@ -1,0 +1,13 @@
+# Rust
+
+```rust
+// @neyra:visual_block id="sum" display="Add" i18n.es="Suma" category="math" translator="Ana"
+fn add(a: i32, b: i32) -> i32 {
+    // @neyra:var id="a" display="First number"
+    // @neyra:var id="b" display="Second number"
+    let result = a + b;
+    // @neyra:connection from="a" to="sum" category="data"
+    // @neyra:connection from="b" to="sum" category="data"
+    result
+}
+```


### PR DESCRIPTION
## Summary
- Document visual mode workflow and annotation syntax
- List supported languages, translator guidelines, and AI metadata usage
- Provide Python, JavaScript, and Rust annotation examples

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml'; ModuleNotFoundError: No module named 'clang'; ModuleNotFoundError: No module named 'javalang'; ModuleNotFoundError: No module named 'esprima')*
- `pytest tests/iteration/test_min_iterations.py -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6896e880d0f88323af60364d5cce20da