### PR TITLE
feat: add node palette and history

### DIFF
--- a/visual_programming/__init__.py
+++ b/visual_programming/__init__.py
@@ -1,5 +1,14 @@
 """Utilities for the visual programming subsystem."""
 
 from .translation_sync import TranslationSync
+from .node_palette import NodePalette, NodeTemplate
+from .history import History
+from .error_highlight import highlight_errors
 
-__all__ = ["TranslationSync"]
+__all__ = [
+    "TranslationSync",
+    "NodePalette",
+    "NodeTemplate",
+    "History",
+    "highlight_errors",
+]

--- a/visual_programming/error_highlight.py
+++ b/visual_programming/error_highlight.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Helpers for detecting common graph issues such as unconnected ports or
+missing required data.  The returned errors can be used by the editor to visually
+highlight problematic nodes or ports.
+"""
+
+from typing import Any, Dict, List
+
+
+def highlight_errors(graph: Dict[str, Any]) -> List[str]:
+    """Return a list of human readable error descriptions for ``graph``.
+
+    The function operates on a very small set of conventions in order to remain
+    compatible with various graph implementations:
+
+    * Nodes may define a ``ports`` mapping.  Each port is expected to contain a
+      ``connections`` list (or ``connected_to``) describing links to other
+      nodes.  Ports without connections are reported as errors.
+    * When a node specifies ``requires_data`` it must also provide a non-empty
+      ``data`` entry.  Otherwise an error about missing data is generated.
+    """
+
+    errors: List[str] = []
+    for node in graph.get("nodes", []):
+        node_id = node.get("id", "<unnamed>")
+        ports = node.get("ports", {})
+        for port_name, port in ports.items():
+            connections = port.get("connections") or port.get("connected_to") or []
+            if not connections:
+                errors.append(f"{node_id}.{port_name} has no connection")
+        if node.get("requires_data") and not node.get("data"):
+            errors.append(f"{node_id} is missing required data")
+    return errors
+
+
+__all__ = ["highlight_errors"]

--- a/visual_programming/history.py
+++ b/visual_programming/history.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Simple change history with undo support for visual programming graphs."""
+
+from dataclasses import dataclass, field
+from typing import Any, List
+import copy
+
+
+@dataclass
+class History:
+    """Utility to record immutable snapshots and restore previous states.
+
+    The history stores deep copies of the supplied states in a stack.  Calling
+    :meth:`undo` returns the previously recorded state or ``None`` if no older
+    snapshot is available.
+    """
+
+    limit: int | None = None
+    _states: List[Any] = field(default_factory=list)
+
+    def record(self, state: Any) -> None:
+        """Store ``state`` as the latest snapshot."""
+
+        self._states.append(copy.deepcopy(state))
+        if self.limit is not None and len(self._states) > self.limit:
+            # Drop oldest entry when exceeding the limit
+            del self._states[0]
+
+    def undo(self) -> Any | None:
+        """Return the previous snapshot without altering it.
+
+        The most recently recorded state is discarded and the new last item is
+        returned.  ``None`` is returned when there is no earlier snapshot.
+        """
+
+        if len(self._states) <= 1:
+            return None
+        # Remove current state and return copy of the previous
+        self._states.pop()
+        return copy.deepcopy(self._states[-1])
+
+    def clear(self) -> None:
+        """Remove all stored states."""
+
+        self._states.clear()
+
+
+__all__ = ["History"]

--- a/visual_programming/node_palette.py
+++ b/visual_programming/node_palette.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Palette of available node templates for the visual programming editor.
+
+The palette stores a collection of template definitions that can be searched by
+name.  It is intentionally lightweight and does not perform any GUI related
+logic; the editor is expected to consume the data structure and render it
+accordingly.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Any
+
+
+@dataclass
+class NodeTemplate:
+    """Description of a node template.
+
+    Parameters
+    ----------
+    name:
+        Human readable name of the node template.
+    data:
+        Arbitrary mapping with additional metadata required to instantiate the
+        node inside a graph.  The structure is purposely left open to keep the
+        module decoupled from the editor implementation.
+    """
+
+    name: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NodePalette:
+    """Container managing a set of :class:`NodeTemplate` objects."""
+
+    templates: Dict[str, NodeTemplate] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------ manage
+    def add_template(self, template: NodeTemplate) -> None:
+        """Register ``template`` in the palette."""
+
+        self.templates[template.name] = template
+
+    def get_template(self, name: str) -> NodeTemplate | None:
+        """Return template identified by ``name`` or ``None`` if missing."""
+
+        return self.templates.get(name)
+
+    # ------------------------------------------------------------------ search
+    def search(self, query: str) -> List[NodeTemplate]:
+        """Return templates whose names contain ``query``.
+
+        The search is case insensitive and returns a new list with matching
+        templates in arbitrary order.
+        """
+
+        query = query.lower().strip()
+        return [tpl for n, tpl in self.templates.items() if query in n.lower()]
+
+
+__all__ = ["NodePalette", "NodeTemplate"]


### PR DESCRIPTION
## Summary
- add simple node palette for template registration and name search
- implement generic change history with undo support
- provide helper for highlighting unconnected ports or missing data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68970beab57c832381186fe7a8a58d13