### PR TITLE
feat: add centralized autocomplete engine

### DIFF
--- a/book_editor/__init__.py
+++ b/book_editor/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Autocomplete integration helpers for the book editor."""
+
+from typing import List
+
+from src.commands.autocomplete import get_suggestions
+
+
+def context_menu_autocomplete(prefix: str, file_type: str = "markdown") -> List[str]:
+    """Return autocomplete suggestions for the context menu.
+
+    ``file_type`` defaults to ``"markdown"`` to mirror the typical content
+    handled by the book editor.
+    """
+
+    return get_suggestions(prefix, file_type=file_type, mode="book_editor")
+
+
+def panel_autocomplete(prefix: str, file_type: str = "markdown") -> List[str]:
+    """Return autocomplete suggestions for the main editing panel."""
+
+    return get_suggestions(prefix, file_type=file_type, mode="book_editor")
+
+
+__all__ = ["context_menu_autocomplete", "panel_autocomplete"]

--- a/code_editor/__init__.py
+++ b/code_editor/__init__.py
@@ -7,6 +7,10 @@ in heavy requirements such as ``PyYAML`` which some panels depend on.
 
 from __future__ import annotations
 
+from typing import List
+
+from src.commands.autocomplete import get_suggestions
+
 try:  # pragma: no cover - optional dependency
     from .lsp_client import LSPClient
 except Exception:  # pragma: no cover - gracefully degrade when deps missing
@@ -25,10 +29,24 @@ except Exception:  # pragma: no cover - gracefully degrade when deps missing
     GitUI = None  # type: ignore[assignment]
     ConflictWindow = None  # type: ignore[assignment]
 
+
+def context_menu_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
+    """Return autocomplete entries for the editor's context menu."""
+
+    return get_suggestions(prefix, file_type=file_type, mode="code_editor")
+
+
+def panel_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
+    """Return autocomplete suggestions for the main editing pane."""
+
+    return get_suggestions(prefix, file_type=file_type, mode="code_editor")
+
 __all__ = [
     "LSPClient",
     "ProfilerPanel",
     "TranslationPanel",
     "GitUI",
     "ConflictWindow",
+    "context_menu_autocomplete",
+    "panel_autocomplete",
 ]

--- a/src/commands/autocomplete.py
+++ b/src/commands/autocomplete.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Autocomplete database and suggestion helpers.
+
+The module maintains a small in-memory table describing available command
+``tags`` together with their expected argument hints and the programming
+languages where they are applicable.  Callers can query
+:func:`get_suggestions` to retrieve context aware completions which can be
+further filtered by file type and the current editor mode.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class TagHint:
+    """Metadata describing a single autocomplete entry."""
+
+    arguments: List[str]
+    languages: List[str]
+    modes: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Core database of known tags.  The dataset is intentionally tiny – it merely
+# provides enough structure for unit tests exercising the autocomplete logic.
+TAG_HINTS: Dict[str, TagHint] = {
+    "@todo": TagHint(
+        arguments=["message"],
+        languages=["python", "markdown"],
+        modes=["code_editor", "book_editor"],
+    ),
+    "@style": TagHint(
+        arguments=["selector", "property"],
+        languages=["css"],
+        modes=["code_editor", "visual_programming"],
+    ),
+    "@node": TagHint(
+        arguments=["type"],
+        languages=["python"],
+        modes=["visual_programming"],
+    ),
+}
+
+# Derive a flat list of languages for quick lookup or display purposes.
+LANGUAGES: List[str] = sorted({lang for hint in TAG_HINTS.values() for lang in hint.languages})
+
+
+def get_suggestions(
+    prefix: str,
+    *,
+    file_type: str | None = None,
+    mode: str | None = None,
+) -> List[str]:
+    """Return autocomplete suggestions matching ``prefix``.
+
+    Parameters
+    ----------
+    prefix:
+        Partial tag typed by the user.  Matching is case insensitive.
+    file_type:
+        Optional hint specifying the language of the file currently being
+        edited.  When provided, only tags advertising that language are
+        returned.
+    mode:
+        Name of the active editor (e.g. ``"code_editor"``).  When given, only
+        tags supporting the mode are included in the results.
+    """
+
+    prefix = prefix.lower()
+    suggestions: List[str] = []
+    for tag, hint in TAG_HINTS.items():
+        if not tag.startswith(prefix):
+            continue
+        if file_type and file_type not in hint.languages:
+            continue
+        if mode and mode not in hint.modes:
+            continue
+        suggestion = tag
+        if hint.arguments:
+            suggestion += " " + " ".join(hint.arguments)
+        suggestions.append(suggestion)
+    return sorted(suggestions)
+
+
+__all__ = ["TagHint", "TAG_HINTS", "LANGUAGES", "get_suggestions"]

--- a/visual_programming/__init__.py
+++ b/visual_programming/__init__.py
@@ -1,10 +1,26 @@
 """Utilities for the visual programming subsystem."""
 
+from typing import List
+
+from src.commands.autocomplete import get_suggestions
+
 from .translation_sync import TranslationSync
 from .node_palette import NodePalette, NodeTemplate
 from .history import History
 from .error_highlight import highlight_errors
 from .nodes.html_css import HTMLElement, CSSRule, export_html_css
+
+
+def context_menu_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
+    """Return autocomplete suggestions for visual programming context menus."""
+
+    return get_suggestions(prefix, file_type=file_type, mode="visual_programming")
+
+
+def panel_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
+    """Return autocomplete entries for the visual editor panel."""
+
+    return get_suggestions(prefix, file_type=file_type, mode="visual_programming")
 
 __all__ = [
     "TranslationSync",
@@ -15,4 +31,6 @@ __all__ = [
     "HTMLElement",
     "CSSRule",
     "export_html_css",
+    "context_menu_autocomplete",
+    "panel_autocomplete",
 ]


### PR DESCRIPTION
## Summary
- add `commands.autocomplete` module with tag, argument and language database
- expose autocomplete helpers in book editor, code editor and visual programming modules
- filter suggestions by file type and active editor mode

## Testing
- `pytest tests/test_visual_programming.py tests/test_code_editor/test_translation_panel.py -q`
- `pytest tests/code_editor/test_lsp_client.py tests/test_code_editor/test_git_ui.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml', 'clang', 'javalang', 'esprima')*

------
https://chatgpt.com/codex/tasks/task_e_68971239459c832383a6aae66241a796