### PR TITLE
Add translation profile management

### DIFF
--- a/code_editor/translation_panel.py
+++ b/code_editor/translation_panel.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
+from src.translation.profiles import (
+    get_active_profile,
+    set_active_profile,
+)
+
 try:  # pragma: no cover - optional dependency
     import yaml
 except Exception:  # pragma: no cover - fallback when PyYAML is missing
@@ -65,7 +70,15 @@ class TranslationPanel:
     templates: List[str] = field(
         default_factory=lambda: ["@neyra:todo", "@neyra:fix", "@neyra:note"]
     )
-    auto_update: bool = field(default_factory=lambda: _load_config().get("auto_update", False))
+    auto_update: bool = field(
+        default_factory=lambda: _load_config().get("auto_update", False)
+    )
+    dictionary: Dict[str, str] = field(
+        default_factory=lambda: dict(get_active_profile().dictionary)
+    )
+    profile_name: str = field(
+        default_factory=lambda: get_active_profile().name
+    )
 
     # ------------------------------------------------------------------
     def highlight_uncommented(self, text: str) -> List[int]:
@@ -103,10 +116,12 @@ class TranslationPanel:
         if trigger != "ctrl_enter":
             return {}
 
-        # The "translation" is intentionally naive – it simply reverses the
-        # string.  The goal is to have deterministic behaviour for tests
-        # without pulling in heavy NLP dependencies.
-        translation = text[::-1]
+        translation = self.dictionary.get(text)
+        if translation is None:
+            # The fallback "translation" is intentionally naive – it simply
+            # reverses the string.  The goal is to have deterministic behaviour
+            # for tests without pulling in heavy NLP dependencies.
+            translation = text[::-1]
         return {"translation": translation, "templates": list(self.templates)}
 
     # ------------------------------------------------------------------
@@ -140,6 +155,15 @@ class TranslationPanel:
                     new_lines.append(line)
             updated[name] = "\n".join(new_lines)
         return updated
+
+    # ------------------------------------------------------------------ Profile management
+    def select_profile(self, name: str) -> None:
+        """Switch to another translation profile."""
+
+        set_active_profile(name)
+        profile = get_active_profile()
+        self.dictionary = dict(profile.dictionary)
+        self.profile_name = profile.name
 
 
 # ---------------------------------------------------------------------------

--- a/src/translation/__init__.py
+++ b/src/translation/__init__.py
@@ -1,5 +1,20 @@
 """Translation utilities for annotating source code."""
 
 from .manager import TranslationManager, Identifier
+from .profiles import (
+    Profile,
+    load_profiles,
+    get_active_profile,
+    get_active_profile_name,
+    set_active_profile,
+)
 
-__all__ = ["TranslationManager", "Identifier"]
+__all__ = [
+    "TranslationManager",
+    "Identifier",
+    "Profile",
+    "load_profiles",
+    "get_active_profile",
+    "get_active_profile_name",
+    "set_active_profile",
+]

--- a/src/translation/profiles.py
+++ b/src/translation/profiles.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Profile management for translation dictionaries.
+
+Profiles are stored as JSON files inside ``userdata/translation_profiles``.
+Each file contains a ``priority`` integer and a ``dictionary`` mapping of
+identifier → translated display name.  The active profile is determined by the
+``active_profile.json`` file in the same directory or, when absent, by selecting
+the profile with the highest priority.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+import json
+
+# --------------------------------------------------------------------------- Paths
+ROOT_DIR = Path(__file__).resolve().parents[2]
+PROFILE_DIR = ROOT_DIR / "userdata" / "translation_profiles"
+ACTIVE_FILE = PROFILE_DIR / "active_profile.json"
+
+
+# --------------------------------------------------------------------------- Data model
+@dataclass
+class Profile:
+    """Representation of a translation profile."""
+
+    name: str
+    priority: int
+    dictionary: Dict[str, str]
+
+
+# --------------------------------------------------------------------------- Helpers
+
+def load_profiles() -> Dict[str, Profile]:
+    """Load all profiles from :data:`PROFILE_DIR`.
+
+    Invalid or unreadable files are skipped.  The result maps profile names to
+    :class:`Profile` instances.
+    """
+
+    profiles: Dict[str, Profile] = {}
+    if not PROFILE_DIR.exists():
+        return profiles
+    for path in PROFILE_DIR.glob("*.json"):
+        if path.name == ACTIVE_FILE.name:
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        priority = int(data.get("priority", 0))
+        dictionary = {
+            str(k): str(v) for k, v in (data.get("dictionary") or {}).items()
+        }
+        profiles[path.stem] = Profile(path.stem, priority, dictionary)
+    return profiles
+
+
+def _read_active_name() -> Optional[str]:
+    if ACTIVE_FILE.exists():
+        try:
+            data = json.loads(ACTIVE_FILE.read_text(encoding="utf-8"))
+            name = data.get("name")
+            if isinstance(name, str):
+                return name
+        except Exception:
+            return None
+    return None
+
+
+def get_active_profile_name(profiles: Dict[str, Profile] | None = None) -> Optional[str]:
+    """Return the currently active profile name.
+
+    The explicit selection stored in ``active_profile.json`` takes precedence.
+    When unset, the profile with the highest ``priority`` value is used.  The
+    function returns ``None`` when no profiles are available.
+    """
+
+    if profiles is None:
+        profiles = load_profiles()
+    selected = _read_active_name()
+    if selected and selected in profiles:
+        return selected
+    if profiles:
+        return max(profiles.values(), key=lambda p: p.priority).name
+    return None
+
+
+def set_active_profile(name: str) -> None:
+    """Persist ``name`` as the active profile."""
+
+    PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    ACTIVE_FILE.write_text(json.dumps({"name": name}), encoding="utf-8")
+
+
+
+def get_active_profile() -> Profile:
+    """Return the active :class:`Profile` instance.
+
+    When no profiles exist, an empty profile is returned allowing callers to
+    operate with an empty dictionary.
+    """
+
+    profiles = load_profiles()
+    name = get_active_profile_name(profiles)
+    if name and name in profiles:
+        return profiles[name]
+    return Profile(name or "", 0, {})
+
+
+__all__ = [
+    "Profile",
+    "load_profiles",
+    "get_active_profile",
+    "get_active_profile_name",
+    "set_active_profile",
+]

--- a/tests/test_translation_profiles.py
+++ b/tests/test_translation_profiles.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import src.translation.profiles as tp
+
+
+def test_profile_sync_between_editor_and_visual(tmp_path, monkeypatch):
+    # Redirect profile storage to temporary directory
+    monkeypatch.setattr(tp, "PROFILE_DIR", tmp_path)
+    monkeypatch.setattr(tp, "ACTIVE_FILE", tmp_path / "active_profile.json")
+
+    # Create sample profiles
+    (tmp_path / "first.json").write_text(
+        json.dumps({"priority": 1, "dictionary": {"hello": "hi"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "second.json").write_text(
+        json.dumps({"priority": 2, "dictionary": {"hello": "hola"}}),
+        encoding="utf-8",
+    )
+
+    # Initially select the first profile
+    tp.set_active_profile("first")
+
+    from code_editor.translation_panel import TranslationPanel
+    from visual_programming.translation_sync import TranslationSync
+
+    panel = TranslationPanel()
+    assert panel.suggest("hello", trigger="ctrl_enter")["translation"] == "hi"
+
+    sync = TranslationSync()
+    assert sync.manager.dictionary.get("hello") == "hi"
+
+    # Switch profile via the panel and ensure synchronization
+    panel.select_profile("second")
+
+    new_panel = TranslationPanel()
+    assert new_panel.suggest("hello", trigger="ctrl_enter")["translation"] == "hola"
+
+    new_sync = TranslationSync()
+    assert new_sync.manager.dictionary.get("hello") == "hola"

--- a/visual_programming/translation_sync.py
+++ b/visual_programming/translation_sync.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from src.translation.manager import TranslationManager
+from src.translation.profiles import (
+    get_active_profile,
+    set_active_profile,
+)
 
 
 NEYRA_RE = re.compile(r"@neyra:(?:visual_block|var) id=\"(?P<id>[^\"]+)\" display=\"(?P<display>[^\"]+)\"")
@@ -41,6 +45,24 @@ class TranslationSync:
 
     lang: str = "en"
     manager: TranslationManager = field(default_factory=TranslationManager)
+    profile_name: str = ""
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple delegation
+        self.load_profile()
+
+    # ------------------------------------------------------------------ Profile management
+    def load_profile(self) -> None:
+        """Refresh the manager dictionary from the active profile."""
+
+        profile = get_active_profile()
+        self.profile_name = profile.name
+        self.manager.dictionary = dict(profile.dictionary)
+
+    def select_profile(self, name: str) -> None:
+        """Set ``name`` as the active profile."""
+
+        set_active_profile(name)
+        self.load_profile()
 
     # ------------------------------------------------------------------ Graph ↔ Code
     def sync(self, code: str, graph: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
@@ -57,11 +79,11 @@ class TranslationSync:
         """
 
         # Update code comments from graph nodes ------------------------- Graph → Code
-        dictionary = {
-            node["id"]: node.get("display", "")
-            for node in graph.get("nodes", [])
-            if node.get("id") and node.get("display")
-        }
+        profile = get_active_profile()
+        dictionary = dict(profile.dictionary) if profile else {}
+        for node in graph.get("nodes", []):
+            if node.get("id") and node.get("display"):
+                dictionary[node["id"]] = node.get("display", "")
         self.manager.dictionary = dictionary
         code = self.manager.annotate_source(code, self.lang)
 


### PR DESCRIPTION
## Summary
- Introduce translation profiles stored under `userdata/translation_profiles` with active profile selection
- Load and switch profiles in editor translation panel
- Sync profile dictionary across visual programming via TranslationSync

## Testing
- `pytest tests/test_translation_manager.py tests/test_code_editor/test_translation_panel.py tests/test_translation_profiles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897142c003883238c1c614f72dbfd27