### PR TITLE
feat: add collaborative editing server and client support

### DIFF
--- a/code_editor/__init__.py
+++ b/code_editor/__init__.py
@@ -29,6 +29,11 @@ except Exception:  # pragma: no cover - gracefully degrade when deps missing
     GitUI = None  # type: ignore[assignment]
     ConflictWindow = None  # type: ignore[assignment]
 
+try:  # pragma: no cover - optional dependency
+    from .collab_client import CodeEditorCollabClient
+except Exception:  # pragma: no cover - gracefully degrade when deps missing
+    CodeEditorCollabClient = None  # type: ignore[assignment]
+
 
 def context_menu_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
     """Return autocomplete entries for the editor's context menu."""
@@ -47,6 +52,7 @@ __all__ = [
     "TranslationPanel",
     "GitUI",
     "ConflictWindow",
+    "CodeEditorCollabClient",
     "context_menu_autocomplete",
     "panel_autocomplete",
 ]

--- a/code_editor/collab_client.py
+++ b/code_editor/collab_client.py
@@ -1,0 +1,12 @@
+"""Collaborative client for the code editor."""
+
+from collab.client import CollabClient
+
+
+class CodeEditorCollabClient(CollabClient):
+    """Thin wrapper around :class:`collab.client.CollabClient` for clarity."""
+
+    pass
+
+
+__all__ = ["CodeEditorCollabClient"]

--- a/collab/__init__.py
+++ b/collab/__init__.py
@@ -1,0 +1,13 @@
+"""Collaboration utilities for Neira editors."""
+
+try:  # pragma: no cover - optional dependency
+    from .server import CollabServer
+except Exception:  # pragma: no cover - gracefully degrade
+    CollabServer = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from .client import CollabClient
+except Exception:  # pragma: no cover - gracefully degrade
+    CollabClient = None  # type: ignore[assignment]
+
+__all__ = ["CollabServer", "CollabClient"]

--- a/collab/client.py
+++ b/collab/client.py
@@ -1,0 +1,89 @@
+"""WebSocket client for collaborative editors.
+
+The client keeps track of cursor positions of other users. Editors can
+connect to a shared :class:`CollabServer` and update ``remote_cursors`` to
+render other users' cursors locally.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import websockets
+except Exception:  # pragma: no cover - handled during runtime
+    websockets = None  # type: ignore
+
+
+class CollabClient:
+    """Minimal collaborative editing client.
+
+    Parameters
+    ----------
+    uri:
+        WebSocket server URI.
+    user:
+        Identifier of the current user.
+    """
+
+    def __init__(self, uri: str, user: str) -> None:
+        self.uri = uri
+        self.user = user
+        self.websocket: Optional[websockets.WebSocketClientProtocol] = None
+        self.remote_cursors: Dict[str, int] = {}
+        self._listener: Optional[asyncio.Task] = None
+
+    async def connect(self) -> None:
+        """Connect to the collaborative server and start receiving events."""
+
+        if websockets is None:
+            raise RuntimeError("websockets library is required for CollabClient")
+        self.websocket = await websockets.connect(self.uri)
+        self._listener = asyncio.create_task(self._receiver())
+
+    async def _receiver(self) -> None:
+        assert self.websocket is not None
+        async for message in self.websocket:
+            data = json.loads(message)
+            if (
+                data.get("type") == "cursor"
+                and data.get("user") != self.user
+            ):
+                self.remote_cursors[data["user"]] = int(data.get("position", 0))
+
+    async def send_cursor(self, position: int) -> None:
+        """Broadcast the user's current cursor ``position``."""
+
+        if self.websocket is None:
+            raise RuntimeError("Client is not connected")
+        payload = {"type": "cursor", "user": self.user, "position": position}
+        await self.websocket.send(json.dumps(payload))
+
+    async def send_change(self, file_path: str, content: str) -> None:
+        """Send a file change to the server.
+
+        The server is responsible for committing the change and rebroadcasting
+        it to other clients.
+        """
+
+        if self.websocket is None:
+            raise RuntimeError("Client is not connected")
+        payload = {
+            "type": "change",
+            "user": self.user,
+            "file": file_path,
+            "content": content,
+        }
+        await self.websocket.send(json.dumps(payload))
+
+    async def close(self) -> None:
+        """Close the connection to the server."""
+
+        if self.websocket is not None:
+            await self.websocket.close()
+            self.websocket = None
+        if self._listener is not None:
+            self._listener.cancel()
+            self._listener = None

--- a/collab/server.py
+++ b/collab/server.py
@@ -1,0 +1,122 @@
+"""WebSocket based collaboration server.
+
+The server relays cursor positions and file changes between connected clients.
+File changes are automatically committed to the Git repository and every
+message is appended to a session log inside ``collab/history``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import json
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import websockets
+    from websockets.server import WebSocketServerProtocol
+except Exception:  # pragma: no cover - handled during runtime
+    websockets = None  # type: ignore
+    WebSocketServerProtocol = object  # type: ignore
+
+
+class CollabServer:
+    """Collaboration WebSocket server.
+
+    Parameters
+    ----------
+    host, port:
+        Address on which to listen for connections.
+    repo_root:
+        Root directory of the Git repository whose files are being edited.
+    """
+
+    def __init__(self, host: str = "localhost", port: int = 8765, repo_root: Optional[Path] = None) -> None:
+        self.host = host
+        self.port = port
+        self.repo_root = Path(repo_root or Path.cwd())
+        self.clients: Dict[str, WebSocketServerProtocol] = {}
+        self._server: Optional[asyncio.base_events.Server] = None
+        history_root = Path(__file__).with_name("history")
+        history_root.mkdir(parents=True, exist_ok=True)
+        ts = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        self.log_file = history_root / f"session-{ts}.log"
+
+    async def _handler(self, websocket: WebSocketServerProtocol, path: str) -> None:
+        user: Optional[str] = None
+        try:
+            async for raw in websocket:
+                data = json.loads(raw)
+                user = data.get("user")
+                msg_type = data.get("type")
+                if msg_type == "cursor":
+                    if user:
+                        self.clients[user] = websocket
+                    await self.broadcast(raw, sender=websocket)
+                    self._log(data)
+                elif msg_type == "change":
+                    commit = self._apply_change(data)
+                    await self.broadcast(raw, sender=websocket)
+                    self._log(data, commit)
+        finally:
+            if user and user in self.clients:
+                del self.clients[user]
+
+    async def broadcast(self, message: str, sender: Optional[WebSocketServerProtocol] = None) -> None:
+        """Send ``message`` to all clients except ``sender``."""
+
+        if not self.clients:
+            return
+        await asyncio.gather(
+            *[
+                ws.send(message)
+                for ws in self.clients.values()
+                if ws is not sender
+            ]
+        )
+
+    def _apply_change(self, data: Dict) -> Optional[str]:
+        file_path = data.get("file")
+        content = data.get("content")
+        if not file_path or content is None:
+            return None
+        path = self.repo_root / file_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        subprocess.run(["git", "add", file_path], cwd=self.repo_root, check=False)
+        subprocess.run(
+            ["git", "commit", "-m", f"Collab edit by {data.get('user', 'unknown')}"],
+            cwd=self.repo_root,
+            check=False,
+        )
+        return self._current_commit()
+
+    def _current_commit(self) -> Optional[str]:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout.strip() or None
+
+    def _log(self, data: Dict, commit: Optional[str] = None) -> None:
+        record = {"timestamp": _dt.datetime.utcnow().isoformat(), **data}
+        if commit:
+            record["commit"] = commit
+        with self.log_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    async def start(self) -> None:
+        if websockets is None:
+            raise RuntimeError("websockets library is required for CollabServer")
+        self._server = await websockets.serve(self._handler, self.host, self.port)
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None

--- a/visual_programming/__init__.py
+++ b/visual_programming/__init__.py
@@ -10,6 +10,11 @@ from .history import History
 from .error_highlight import highlight_errors
 from .nodes.html_css import HTMLElement, CSSRule, export_html_css
 
+try:  # pragma: no cover - optional dependency
+    from .collab_client import VisualCollabClient
+except Exception:  # pragma: no cover - gracefully degrade when deps missing
+    VisualCollabClient = None  # type: ignore[assignment]
+
 
 def context_menu_autocomplete(prefix: str, file_type: str = "python") -> List[str]:
     """Return autocomplete suggestions for visual programming context menus."""
@@ -31,6 +36,7 @@ __all__ = [
     "HTMLElement",
     "CSSRule",
     "export_html_css",
+    "VisualCollabClient",
     "context_menu_autocomplete",
     "panel_autocomplete",
 ]

--- a/visual_programming/collab_client.py
+++ b/visual_programming/collab_client.py
@@ -1,0 +1,12 @@
+"""Collaborative client for the visual programming editor."""
+
+from collab.client import CollabClient
+
+
+class VisualCollabClient(CollabClient):
+    """Wrapper around :class:`collab.client.CollabClient` for the visual editor."""
+
+    pass
+
+
+__all__ = ["VisualCollabClient"]


### PR DESCRIPTION
## Summary
- implement WebSocket collaboration server that commits edits and logs sessions
- add shared client for broadcasting cursors and file changes
- expose collaborative clients in code and visual editors

## Testing
- `pytest` *(fails: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68971a10be6c83238a9979732f3ea905