### PR TITLE
Add extensible command palette

### DIFF
--- a/tests/ui/test_command_palette.py
+++ b/tests/ui/test_command_palette.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import sys
+import types
+
+# Stub external dependencies used by configuration
+yaml = types.ModuleType("yaml")
+yaml.safe_load = lambda s: {}
+sys.modules.setdefault("yaml", yaml)
+
+dotenv = types.ModuleType("dotenv")
+dotenv.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault("dotenv", dotenv)
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from ui.command_palette import CommandPalette, register_command
+from src.plugins import PluginManager
+
+
+def test_search_by_name_and_argument():
+    def sample_action(foo, bar):
+        return foo, bar
+
+    register_command("sample", sample_action)
+    palette = CommandPalette()
+
+    # Search by command name
+    names = [name for name, _ in palette.search("sam")]
+    assert "sample" in names
+
+    # Search by argument name
+    names = [name for name, _ in palette.search("bar")]
+    assert "sample" in names
+
+
+def test_plugin_can_register_command(tmp_path):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    plugin_file = plugin_dir / "cmd_plugin.py"
+    plugin_file.write_text(
+        "from src.plugins import Plugin\n"
+        "from ui.command_palette import register_command\n"
+        "class CmdPlugin(Plugin):\n    pass\n"
+        "def greet(name):\n    return f'hi {name}'\n"
+        "register_command('greet', greet)\n"
+    )
+
+    PluginManager(plugin_dir)
+    palette = CommandPalette()
+    names = [name for name, _ in palette.search("greet")]
+    assert "greet" in names
+
+
+def test_hotkey_registered():
+    palette = CommandPalette()
+    keys = [k for b in palette.key_bindings.bindings for k in b.keys]
+    assert "c-S-p" in keys or "c-P" in keys

--- a/ui/command_palette.py
+++ b/ui/command_palette.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""Simple command palette for quickly executing registered actions.
+
+The palette keeps a registry of commands that can be extended by core
+modules or external plugins.  Commands are searchable both by their name
+and the names of their parameters which allows quick discovery of
+functionality.
+
+The module exposes a :func:`register_command` function that plugins can
+import and call during initialisation.  A :class:`CommandPalette`
+instance provides a minimal interactive interface using ``prompt_toolkit``
+and installs a global key binding (``Ctrl+Shift+P``) that activates the
+palette.
+"""
+
+from dataclasses import dataclass
+import inspect
+from typing import Callable, Dict, Iterable, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.completion import FuzzyWordCompleter
+    from prompt_toolkit.key_binding import KeyBindings
+except Exception:  # pragma: no cover - library may not be installed
+    PromptSession = None  # type: ignore
+    FuzzyWordCompleter = None  # type: ignore
+
+    class _Binding:
+        def __init__(self, keys: Tuple[str, ...], handler: Callable):
+            self.keys = keys
+            self.handler = handler
+
+    class KeyBindings:  # type: ignore
+        def __init__(self) -> None:
+            self.bindings: List[_Binding] = []
+
+        def add(self, *keys: str) -> Callable[[Callable], Callable]:
+            def decorator(func: Callable) -> Callable:
+                self.bindings.append(_Binding(keys, func))
+                return func
+
+            return decorator
+
+    class PromptSession:  # type: ignore
+        def prompt(self, *_args, **_kwargs) -> str:
+            return ""
+
+    class FuzzyWordCompleter:  # type: ignore
+        def __init__(self, *_args, **_kwargs) -> None:  # pragma: no cover - minimal stub
+            pass
+
+
+CommandFunc = Callable[..., object]
+
+# Global command registry -------------------------------------------------------
+_registry: Dict[str, CommandFunc] = {}
+
+
+def register_command(name: str, func: CommandFunc) -> None:
+    """Register a callable under ``name``.
+
+    Plugins can call this during import to expose new commands in the
+    palette.
+    """
+
+    _registry[name] = func
+
+
+# Command palette implementation ----------------------------------------------
+@dataclass
+class CommandPalette:
+    """Command palette with fuzzy search across commands and arguments."""
+
+    commands: Dict[str, CommandFunc] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.commands = _registry
+        self.session = PromptSession()
+        self.key_bindings = KeyBindings()
+
+        @self.key_bindings.add("c-S-p")
+        def _activate(event) -> None:  # pragma: no cover - interactive
+            self.activate()
+
+    # ------------------------------------------------------------------
+    def search(self, query: str) -> List[Tuple[str, CommandFunc]]:
+        """Return commands matching ``query``.
+
+        The search inspects both the command name and the names of the
+        parameters accepted by the underlying callable.
+        """
+
+        q = query.lower()
+        results: List[Tuple[str, CommandFunc]] = []
+        for name, func in self.commands.items():
+            params = inspect.signature(func).parameters
+            if q in name.lower() or any(q in p.lower() for p in params):
+                results.append((name, func))
+        return results
+
+    # ------------------------------------------------------------------
+    def activate(self) -> None:  # pragma: no cover - interactive
+        """Open an interactive palette allowing the user to execute commands."""
+
+        if PromptSession is None or FuzzyWordCompleter is None:
+            return
+        completer = FuzzyWordCompleter(list(self.commands))
+        cmd_name = self.session.prompt("Command: ", completer=completer)
+        if not cmd_name:
+            return
+        cmd = self.commands.get(cmd_name)
+        if not cmd:
+            return
+        sig = inspect.signature(cmd)
+        kwargs = {}
+        for param in sig.parameters.values():
+            value = self.session.prompt(f"{param.name}: ")
+            kwargs[param.name] = value
+        cmd(**kwargs)  # type: ignore[arg-type]
+
+
+__all__ = ["CommandPalette", "register_command"]


### PR DESCRIPTION
## Summary
- add UI command palette with search across command names and arguments
- allow plugins to extend palette through `register_command`
- bind global hotkey Ctrl+Shift+P for palette activation
- cover command palette behavior with tests

## Testing
- `pytest tests/ui/test_command_palette.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68971c29a09883239d806a481945f02d