### PR TITLE
Add notification center with UI dropdown and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ logs/*
 !logs/.gitkeep
 !logs/developer_requests.md
 *.log
+!userdata/notifications.log
 
 # Test and coverage outputs
 .pytest_cache/

--- a/ui/notification_center.py
+++ b/ui/notification_center.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class Notification:
+    timestamp: datetime
+    level: str
+    message: str
+    source: str
+
+
+_notifications: List[Notification] = []
+
+IMPORTANT_LEVELS = {"warning", "error", "critical"}
+LOG_FILE = Path("userdata/notifications.log")
+
+
+if LOG_FILE.exists():
+    try:
+        with LOG_FILE.open("r", encoding="utf-8") as f:
+            for line in f:
+                ts, level, source, message = line.rstrip("\n").split("\t", 3)
+                _notifications.append(
+                    Notification(datetime.fromisoformat(ts), level, message, source)
+                )
+    except Exception:
+        # If the log is malformed we simply start with an empty list
+        _notifications.clear()
+
+
+def _persist(note: Notification) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(
+            f"{note.timestamp.isoformat()}\t{note.level}\t{note.source}\t{note.message}\n"
+        )
+
+
+def notify(level: str, message: str, source: str) -> None:
+    """Record a notification and persist important ones."""
+    note = Notification(datetime.utcnow(), level, message, source)
+    _notifications.append(note)
+    if level.lower() in IMPORTANT_LEVELS:
+        _persist(note)
+
+
+def list_notifications() -> List[Notification]:
+    """Return recorded notifications."""
+    return list(_notifications)

--- a/web/app.py
+++ b/web/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 
 from src.core.neyra_brain import Neyra
 from src.interaction import TagProcessor, handle_command
+from ui.notification_center import list_notifications, notify
 
 st.title("Нейра в браузере")
 
@@ -12,7 +13,10 @@ if "neyra" not in st.session_state:
 
 user_input = st.text_input("Введите команду")
 if st.button("Отправить") and user_input:
-    result = handle_command(st.session_state.neyra, user_input, st.session_state.processor)
+    result = handle_command(
+        st.session_state.neyra, user_input, st.session_state.processor
+    )
+    notify("info", f"Команда: {user_input}", "web.app")
     if result.is_exit:
         st.write("Сессия завершена.")
     elif result.text:
@@ -21,7 +25,9 @@ if st.button("Отправить") and user_input:
             "magenta": "magenta",
             "green": "green",
         }.get(result.style or "", "black")
-        st.markdown(f"<span style='color:{color}'>{result.text}</span>", unsafe_allow_html=True)
+        st.markdown(
+            f"<span style='color:{color}'>{result.text}</span>", unsafe_allow_html=True
+        )
         st.session_state.history.append((user_input, result.text))
 
 if st.session_state.history:
@@ -29,3 +35,11 @@ if st.session_state.history:
     for command, response in st.session_state.history:
         st.write(f"**> {command}**")
         st.write(response)
+
+with st.sidebar.expander("Уведомления"):
+    notes = list_notifications()
+    if notes:
+        for n in reversed(notes):
+            st.write(f"[{n.level.upper()}] {n.message} — {n.source}")
+    else:
+        st.write("Нет уведомлений")


### PR DESCRIPTION
## Summary
- add `ui.notification_center` with API to record notifications and persist important ones
- show notifications in a Streamlit sidebar dropdown
- track `userdata/notifications.log` in version control

## Testing
- `python -m py_compile ui/notification_center.py web/app.py`
- `pytest` *(fails: Interrupted: 76 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68972d8547348323be3ec93724ea23e7