### PR TITLE
Add hotkey manager and hints for shortcuts

### DIFF
--- a/game/ui/templates/main_menu.json
+++ b/game/ui/templates/main_menu.json
@@ -2,8 +2,8 @@
   "type": "menu",
   "title": "Main Menu",
   "buttons": [
-    {"label": "Start", "action": "start_game"},
-    {"label": "Options", "action": "open_options"},
-    {"label": "Quit", "action": "quit_game"}
+    {"label": "Start", "action": "start_game", "tooltip": "Ctrl+N"},
+    {"label": "Options", "action": "open_options", "tooltip": "Ctrl+O"},
+    {"label": "Quit", "action": "quit_game", "tooltip": "Ctrl+Q"}
   ]
 }

--- a/tests/test_hotkey_manager.py
+++ b/tests/test_hotkey_manager.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+# ensure repository root on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+import ui.hotkey_manager as hotkey_manager
+
+
+def test_register_override_and_export(tmp_path, monkeypatch):
+    hotkeys_file = tmp_path / "hotkeys.json"
+    monkeypatch.setattr(hotkey_manager, "HOTKEYS_FILE", hotkeys_file, raising=False)
+    monkeypatch.setattr(hotkey_manager, "_schemes", {}, raising=False)
+    monkeypatch.setattr(hotkey_manager, "_user_overrides", {}, raising=False)
+
+    hotkey_manager.register_scheme("default", {"open": "c-o"})
+    assert hotkey_manager.get_hotkey("open") == "c-o"
+
+    hotkey_manager.override_hotkey("open", "c-p")
+    assert hotkeys_file.exists()
+    assert hotkey_manager.get_hotkey("open") == "c-p"
+
+    exported = hotkey_manager.export_scheme()
+    assert exported["open"] == "c-p"

--- a/ui/command_palette.py
+++ b/ui/command_palette.py
@@ -19,6 +19,7 @@ import inspect
 from typing import Callable, Dict, Iterable, List, Tuple
 
 from help.context_helper import helper
+from ui import hotkey_manager
 
 try:  # pragma: no cover - optional dependency
     from prompt_toolkit import PromptSession
@@ -58,21 +59,36 @@ CommandFunc = Callable[..., object]
 # Global command registry -------------------------------------------------------
 _registry: Dict[str, CommandFunc] = {}
 
-# Hint explaining the purpose of this UI element
+# Hint explaining the purpose of this UI element including its shortcut
 helper.register_hint(
     "command_palette",
-    "Палитра команд: ищите и запускайте действия. Нажмите F1 для подсказок.",
+    "Палитра команд (Ctrl+Shift+P): ищите и запускайте действия. Нажмите F1 для подсказок.",
 )
+hotkey_manager.register_hotkey("command_palette", "c-S-p")
 
 
-def register_command(name: str, func: CommandFunc) -> None:
+def register_command(name: str, func: CommandFunc, hotkey: str | None = None) -> None:
     """Register a callable under ``name``.
+
+    Parameters
+    ----------
+    name:
+        Identifier for the command.
+    func:
+        Callable to execute.
+    hotkey:
+        Optional keyboard shortcut hint which will be forwarded to
+        :mod:`ui.hotkey_manager` for inclusion in exported schemes and
+        displayed in F1 help.
 
     Plugins can call this during import to expose new commands in the
     palette.
     """
 
     _registry[name] = func
+    if hotkey:
+        hotkey_manager.register_hotkey(name, hotkey)
+        helper.register_hint(f"command:{name}", f"{name} — {hotkey}")
 
 
 # Command palette implementation ----------------------------------------------

--- a/ui/hotkey_manager.py
+++ b/ui/hotkey_manager.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Central hotkey management with simple persistence.
+
+This module maintains mappings from action identifiers to keyboard
+shortcuts.  Schemes can be registered and individual hotkeys overridden by
+users.  Overrides are persisted to ``userdata/hotkeys.json`` which allows
+customisation across sessions.  The active scheme can be exported for use
+by front-end components such as menus or command palettes.
+"""
+
+from pathlib import Path
+import json
+from typing import Dict
+
+# --------------------------------------------------------------------------- Paths
+ROOT_DIR = Path(__file__).resolve().parents[1]
+HOTKEYS_FILE = ROOT_DIR / "userdata" / "hotkeys.json"
+
+# --------------------------------------------------------------------------- Internal state
+_schemes: Dict[str, Dict[str, str]] = {}
+_active_scheme: str = "default"
+_user_overrides: Dict[str, str] = {}
+
+
+def _load_overrides() -> Dict[str, str]:
+    """Load user overrides from :data:`HOTKEYS_FILE`."""
+
+    if HOTKEYS_FILE.exists():
+        try:
+            with HOTKEYS_FILE.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_overrides() -> None:
+    """Persist current overrides to :data:`HOTKEYS_FILE`."""
+
+    HOTKEYS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with HOTKEYS_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(_user_overrides, fh, ensure_ascii=False, indent=2)
+
+
+_user_overrides = _load_overrides()
+
+
+def register_scheme(name: str, mapping: Dict[str, str]) -> None:
+    """Register a new hotkey scheme under ``name``.
+
+    ``mapping`` is copied internally.  If ``name`` matches the currently
+    active scheme, stored user overrides are applied on top of it.
+    """
+
+    scheme = dict(mapping)
+    if name == _active_scheme:
+        scheme.update(_user_overrides)
+    _schemes[name] = scheme
+
+
+def set_scheme(name: str) -> None:
+    """Activate an existing scheme by ``name``."""
+
+    if name not in _schemes:
+        raise KeyError(f"Unknown scheme '{name}'")
+    global _active_scheme
+    _active_scheme = name
+    # Apply overrides to the newly selected scheme
+    _schemes[name].update(_user_overrides)
+
+
+def register_hotkey(action: str, hotkey: str, scheme: str | None = None) -> None:
+    """Register ``hotkey`` for ``action`` on ``scheme`` (default: active)."""
+
+    if scheme is None:
+        scheme = _active_scheme
+    _schemes.setdefault(scheme, {})[action] = hotkey
+
+
+def override_hotkey(action: str, hotkey: str) -> None:
+    """Override ``action`` with ``hotkey`` in the active scheme and persist."""
+
+    _user_overrides[action] = hotkey
+    _schemes.setdefault(_active_scheme, {})[action] = hotkey
+    _save_overrides()
+
+
+def get_hotkey(action: str) -> str | None:
+    """Return hotkey assigned to ``action`` in the active scheme."""
+
+    return _schemes.get(_active_scheme, {}).get(action)
+
+
+def export_scheme(name: str | None = None) -> Dict[str, str]:
+    """Return a copy of ``name`` scheme or the active one when omitted."""
+
+    if name is None:
+        name = _active_scheme
+    return dict(_schemes.get(name, {}))
+
+
+# Ensure a default scheme exists on import
+register_scheme(_active_scheme, {})
+
+
+__all__ = [
+    "HOTKEYS_FILE",
+    "register_scheme",
+    "set_scheme",
+    "register_hotkey",
+    "override_hotkey",
+    "get_hotkey",
+    "export_scheme",
+]


### PR DESCRIPTION
## Summary
- add hotkey manager with scheme registration, overrides and export
- integrate command palette and menu with hotkey hints
- persist user hotkey overrides to `userdata/hotkeys.json`

## Testing
- `pytest` *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6897365efdb08323b7fe6f9920d678f9