### PR TITLE
feat: persistent idea catalog and CLI utilities

### DIFF
--- a/src/cli/catalog.py
+++ b/src/cli/catalog.py
@@ -1,4 +1,8 @@
-"""Command line helper for interacting with :class:`IdeaCatalog`."""
+"""Command line helper for interacting with :class:`IdeaCatalog`.
+
+The catalog persists changes automatically, so commands like ``add`` and
+``delete`` save their results immediately.
+"""
 
 from __future__ import annotations
 
@@ -33,14 +37,12 @@ def main(argv: Sequence[str] | None = None) -> None:
             print(f"{key}: {val}")
     elif args.cmd == "add":
         catalog.add(args.key, args.text)
-        catalog.save()
     elif args.cmd == "show":
         value = catalog.get(args.key)
         if value is not None:
             print(value)
     elif args.cmd == "delete":
         catalog.delete(args.key)
-        catalog.save()
     else:  # pragma: no cover - argparse already prints help
         parser.print_help()
 

--- a/src/memory/idea_catalog.py
+++ b/src/memory/idea_catalog.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Simple persistent catalog for storing reusable ideas or snippets.
 
 The catalog acts as a key/value store backed by ``data/idea_catalog.json``.
-Entries are stored as ``{"id": "text"}`` mappings and can be
-created, retrieved, updated and deleted.  All operations modify the in-memory
-representation; :meth:`save` persists the catalog to disk.
+Entries are stored as ``{"id": "text"}`` mappings and can be created,
+retrieved, updated and deleted.  Mutating operations persist the catalog
+to disk immediately so the JSON file always reflects the current state.
 """
 
 from pathlib import Path
@@ -33,8 +33,9 @@ class IdeaCatalog:
 
     # CRUD operations ---------------------------------------------------
     def add(self, key: str, value: Any) -> None:
-        """Store ``value`` under ``key``."""
+        """Store ``value`` under ``key`` and save to disk."""
         self._data[key] = value
+        self.save()
 
     def get(self, key: str | None = None) -> Any:
         """Retrieve an entry by ``key`` or return the whole catalog."""
@@ -43,12 +44,14 @@ class IdeaCatalog:
         return self._data.get(key)
 
     def update(self, key: str, value: Any) -> None:
-        """Update ``key`` with ``value``.  Missing keys create new entries."""
+        """Update ``key`` with ``value`` and persist the change."""
         self._data[key] = value
+        self.save()
 
     def delete(self, key: str) -> None:
-        """Remove ``key`` from the catalog if present."""
+        """Remove ``key`` from the catalog if present and save."""
         self._data.pop(key, None)
+        self.save()
 
     # ------------------------------------------------------------------
     def save(self) -> None:

--- a/tests/test_memory/test_idea_catalog.py
+++ b/tests/test_memory/test_idea_catalog.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.memory.idea_catalog import IdeaCatalog
+
+
+def test_crud_operations(tmp_path: Path) -> None:
+    storage = tmp_path / "catalog.json"
+    catalog = IdeaCatalog(storage)
+
+    # Starts empty
+    assert catalog.get() == {}
+
+    # Add entry and ensure it's saved
+    catalog.add("foo", "bar")
+    assert catalog.get("foo") == "bar"
+    assert json.loads(storage.read_text()) == {"foo": "bar"}
+
+    # Update and persist
+    catalog.update("foo", "baz")
+    assert catalog.get("foo") == "baz"
+    assert json.loads(storage.read_text()) == {"foo": "baz"}
+
+    # Delete and persist
+    catalog.delete("foo")
+    assert catalog.get() == {}
+    assert json.loads(storage.read_text()) == {}


### PR DESCRIPTION
## Summary
- make IdeaCatalog persist changes on every CRUD operation
- add catalog CLI helper for listing, adding and deleting entries
- allow InspirationCardsPlugin to resolve `{{key}}` placeholders from the catalog
- cover IdeaCatalog with unit tests

## Testing
- `pytest tests/test_memory/test_idea_catalog.py -q`
- `pytest tests/plugins/test_plugin_system.py -q` *(fails: ModuleNotFoundError: No module named 'optimization')*

------
https://chatgpt.com/codex/tasks/task_e_68975b54eb9483238f73e379e5677817