### PR TITLE
docs: add deployment ci-cd guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - [Глоссарий](glossary.md)
 - [FAQ](faq.md)
 - [Загрузка обучающих данных](training.md)
-- [Развертывание Neira](deployment.md)
+- [CI/CD и деплой](docs/deployment.md)
 - [Веб-интерфейс обучения](web-interface.md)
 - [Тестирование Neira](testing.md)
 - [Дорожная карта Neira](roadmap.md)
@@ -372,7 +372,7 @@ time_slice_ms = 10
 
 Подробные инструкции по установке зависимостей,
 запуску демонстрационной конфигурации и настройке
-переменных окружения приведены в [deployment.md](deployment.md).
+переменных окружения приведены в [docs/deployment.md](docs/deployment.md).
 
 ## Дополнительная документация
 - [Узлы действий](action-nodes.md)
@@ -395,3 +395,19 @@ JSON‑схемы расположены в каталоге [schemas](schemas).
 npm test
 cargo test
 ```
+
+## CI/CD
+
+Основные команды конвейера:
+
+```bash
+npm run build
+npm test
+cargo build --release
+cargo test
+npm pack
+cargo package
+scp target/release/neira user@server:/opt/neira
+```
+
+Подробнее см. [docs/deployment.md](docs/deployment.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,54 @@
+# CI/CD и деплой узлов
+
+Документ описывает типичный конвейер непрерывной интеграции и доставки для Neira.
+
+## Этапы конвейера
+
+1. **Сборка**
+   - `npm run build` — компиляция TypeScript-узлов.
+   - `cargo build --release` — сборка Rust-компонентов.
+2. **Тесты**
+   - `npm test` — запуск тестов на TypeScript.
+   - `cargo test` — запуск тестов на Rust.
+3. **Упаковка**
+   - `npm pack` — формирование npm-пакета.
+   - `cargo package` — подготовка crate к публикации.
+4. **Выкладка**
+   - `scp target/release/neira user@server:/opt/neira` — копирование бинарника на сервер.
+   - `npm publish` — публикация JS-пакета при необходимости.
+
+## Пример GitHub Actions
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: cargo test
+      - run: cargo build --release
+      - name: Package
+        run: |
+          npm pack
+          cargo package
+      - name: Deploy
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: scp target/release/neira user@server:/opt/neira
+```


### PR DESCRIPTION
## Summary
- document CI/CD pipeline with build, test, package and deploy steps
- include sample GitHub Actions workflow for automatic deployment
- reference guide in README and list core CI/CD commands

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad90d12acc832398748c24daeb9479