### PR TITLE
Add CI workflow for Node and Rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.75
+          override: true
+      - name: Install dependencies and run JS tests
+        run: npm ci && npm test
+      - name: Run Rust tests
+        run: cargo test


### PR DESCRIPTION
## Summary
- add GitHub Actions CI running on push and pull requests for all branches
- install Node.js 20 and Rust 1.75
- run npm and cargo tests

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c7ae3708323994e73babb1fa790