### PR TITLE
docs: add OS-specific setup instructions

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -43,3 +43,57 @@ NEIRA_LOG_LEVEL=info
 3. Логи сборки и выполнения сохраняйте в отдельной директории, чтобы упростить диагностику.
 4. В случае ошибок используйте механизм отката для возврата к последней рабочей версии.
 5. О завершении сборки отправляйте уведомления по e‑mail или через вебhook, чтобы команда оперативно получала информацию о результатах.
+
+## Windows
+
+### Установка Node.js 20
+
+```powershell
+winget install OpenJS.NodeJS.LTS --version 20
+node -v
+```
+
+### Установка Rust 1.75
+
+```powershell
+winget install Rustlang.Rustup
+rustup default 1.75
+rustc --version
+```
+
+### Запуск тестов
+
+```powershell
+npm test
+cargo test
+```
+
+На Windows команды выполняются в PowerShell или `cmd`. Утилиты `npm` и `cargo` доступны как `npm.cmd` и `cargo.exe`; при первом запуске `cargo test` возможно появление запроса брандмауэра.
+
+## macOS
+
+### Установка Node.js 20
+
+```bash
+brew install node@20
+node -v
+```
+
+### Установка Rust 1.75
+
+```bash
+brew install rustup
+rustup-init -y
+rustup install 1.75.0
+rustup default 1.75.0
+rustc --version
+```
+
+### Запуск тестов
+
+```bash
+npm test
+cargo test
+```
+
+На macOS тесты запускаются из стандартного терминала. При первом использовании инструментов разработки может потребоваться установка Xcode Command Line Tools с помощью `xcode-select --install`.

--- a/testing.md
+++ b/testing.md
@@ -56,3 +56,61 @@
 - **Gradual expansion** — разрешения расширяются только по мере необходимости.
 - **Human oversight** — критические действия требуют участия человека.
 - **Audit trail** — каждый этап фиксируется для последующего анализа.
+
+## Windows
+
+### Установка Node.js 20
+
+```powershell
+winget install OpenJS.NodeJS.LTS --version 20
+node -v
+```
+
+### Установка Rust 1.75
+
+```powershell
+winget install Rustlang.Rustup
+rustup default 1.75
+rustc --version
+```
+
+### Особенности `npm test` и `cargo test`
+
+```powershell
+npm test
+cargo test
+```
+
+- Переменные среды задаются через `setx` или `$Env:VAR=значение`.
+- Для скриптов, рассчитанных на Unix, может потребоваться пакет `cross-env`.
+- `cargo test` создаёт `.exe` файлы; пути в тестах следует указывать с `\\`.
+
+## macOS
+
+### Установка Node.js 20
+
+```bash
+brew install node@20
+node -v
+```
+
+### Установка Rust 1.75
+
+```bash
+brew install rustup
+rustup-init -y
+rustup install 1.75.0
+rustup default 1.75.0
+rustc --version
+```
+
+### Особенности `npm test` и `cargo test`
+
+```bash
+npm test
+cargo test
+```
+
+- При необходимости используйте `sudo` для установки зависимостей.
+- Инструменты сборки требуют Xcode Command Line Tools (`xcode-select --install`).
+- `cargo test` может запрашивать доступ к сети для скачивания зависимостей.


### PR DESCRIPTION
## Summary
- document Node.js 20 and Rust 1.75 setup steps for Windows and macOS
- note OS-specific nuances when running `npm test` and `cargo test`

## Testing
- `node -v`
- `rustc --version`
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ada4b0c3208323b2fa632cb40fee89