### PR TITLE
chore: override yaml dependency to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4128,6 +4128,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/listr2": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.2.tgz",
@@ -5727,19 +5740,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "typescript": "^5.4.0"
   },
   "overrides": {
-    "p-limit": "^2.3.0"
+    "p-limit": "^2.3.0",
+    "yaml": "2.8.0"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Summary
- pin `yaml` dependency to 2.8.0 via overrides to avoid version drift
- regenerate lockfile with updated override

## Testing
- `npm install`
- `npm test`
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adace19b108323a2d71d2610f93103