### PR TITLE
chore: pin yargs-parser and add npm registry config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "overrides": {
     "p-limit": "^2.3.0",
-    "yaml": "2.8.0"
+    "yaml": "2.8.0",
+    "yargs-parser": "^21.1.1"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Summary
- ensure yargs-parser dependency resolves to `^21.1.1`
- add `.npmrc` with npmjs registry and token support

## Testing
- `npm install`
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb1ac12188323b71c83c1922ae4d3