### PR TITLE
Remove NPM token requirement for installations

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+# Use default registry without requiring authentication.
+# This prevents failures when NPM_TOKEN is not provided.


### PR DESCRIPTION
## Summary
- remove enforced npm auth token so `npm ci` can access public packages

## Testing
- `npm ci`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb410dbf483238c9668397da61be0