### PR TITLE
Configure npm auth token for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 registry=https://registry.npmjs.org/
-# Use default registry without requiring authentication.
-# This prevents failures when NPM_TOKEN is not provided.
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+# Set the registry URL above to your corporate registry if required.
+# NPM_TOKEN should be provided in CI to avoid 403 responses during npm installs.


### PR DESCRIPTION
## Summary
- read `NPM_TOKEN` in `.npmrc` so installs can authenticate to private registries
- expose `NPM_TOKEN` from GitHub Secrets in CI workflow

## Testing
- `npm run lint`
- `npm test`
- `cargo test`
- `cargo clippy -- -D warnings`
- `NPM_TOKEN=faketoken npm ci`


------
https://chatgpt.com/codex/tasks/task_e_68adb721576c83239caec7f02d24b2d7