### PR TITLE
feat: add node template validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "jsonschema",
+ "once_cell",
  "serde",
  "serde_json",
  "tokio",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonschema = "0.17"
+once_cell = "1"

--- a/examples/node_template.rs
+++ b/examples/node_template.rs
@@ -1,4 +1,4 @@
-use backend::node_template::{load_schema, NodeTemplate};
+use backend::node_template::{validate_template, NodeTemplate};
 use serde_json::json;
 
 fn main() {
@@ -12,9 +12,7 @@ fn main() {
     });
 
     let template: NodeTemplate = serde_json::from_value(example.clone()).expect("deserialize");
-    let schema = load_schema();
-    let result = schema.validate(&example);
-    match result {
+    match validate_template(&example) {
         Ok(_) => println!("{:?}", template),
         Err(errors) => {
             for error in errors {

--- a/tests/node_template_validation_test.rs
+++ b/tests/node_template_validation_test.rs
@@ -1,0 +1,28 @@
+use backend::node_template::{validate_template, NodeTemplate};
+use serde_json::json;
+
+#[test]
+fn valid_template_passes_validation() {
+    let value = json!({
+        "id": "example-node",
+        "analysis_type": "text",
+        "metadata": {"schema": "1.0"}
+    });
+    validate_template(&value).expect("should be valid");
+    let _template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
+}
+
+#[test]
+fn invalid_template_reports_errors() {
+    let value = json!({
+        "analysis_type": "text",
+        "metadata": {}
+    });
+    match validate_template(&value) {
+        Ok(_) => panic!("expected validation errors"),
+        Err(errors) => {
+            assert!(!errors.is_empty());
+            println!("Ошибки: {errors:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable schema validation for NodeTemplate with detailed error paths
- expose validation in example and add tests for valid and invalid templates
- cache schema with once_cell

## Testing
- `cargo test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addbeebfc88323a5f492b7cc6a25dc