### PR TITLE
Add configurable NodeTemplate schema loader

### DIFF
--- a/examples/node_template.rs
+++ b/examples/node_template.rs
@@ -1,5 +1,6 @@
-use backend::node_template::{validate_template, NodeTemplate};
+use backend::node_template::{load_schema_from, NodeTemplate};
 use serde_json::json;
+use std::path::Path;
 
 fn main() {
     let example = json!({
@@ -11,9 +12,13 @@ fn main() {
         "metadata": { "schema": "1.0", "author": "Alice" }
     });
 
-    let template: NodeTemplate = serde_json::from_value(example.clone()).expect("deserialize");
-    match validate_template(&example) {
-        Ok(_) => println!("{:?}", template),
+    let schema = load_schema_from(Path::new("schemas/node-template.schema.json"));
+    let validation = schema.validate(&example);
+    match validation {
+        Ok(_) => {
+            let template: NodeTemplate = serde_json::from_value(example.clone()).expect("deserialize");
+            println!("{:?}", template);
+        }
         Err(errors) => {
             for error in errors {
                 eprintln!("Ошибка проверки: {error}");

--- a/node-template.md
+++ b/node-template.md
@@ -74,6 +74,18 @@ npx ajv validate -s schemas/node-template.schema.json -d node-template.json
 npx ajv validate -s schemas/node-template.schema.json -d node-template.yaml
 ```
 
+### Программная загрузка
+
+В Rust‑коде схема загружается функцией `load_schema`, которая читает путь из переменной окружения `NODE_TEMPLATE_SCHEMA_PATH`. Если переменная не задана, используется `schemas/node-template.schema.json` из текущего репозитория. Для явной загрузки по произвольному пути доступна функция `load_schema_from`.
+
+```rust
+use backend::node_template::{load_schema, load_schema_from};
+use std::path::Path;
+
+let schema = load_schema();
+let same_schema = load_schema_from(Path::new("schemas/node-template.schema.json"));
+```
+
 ## Схемы
 
 JSON‑схемы расположены в каталоге [schemas](schemas). Схема для NodeTemplate: [schemas/node-template.schema.json](schemas/node-template.schema.json). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.

--- a/tests/node_template_test.rs
+++ b/tests/node_template_test.rs
@@ -1,5 +1,6 @@
-use backend::node_template::{NodeTemplate, load_schema};
+use backend::node_template::{NodeTemplate, load_schema, load_schema_from};
 use serde_json::json;
+use std::path::Path;
 
 #[test]
 fn valid_template_is_accepted() {
@@ -63,4 +64,15 @@ fn empty_id_is_handled() {
     assert!(schema.validate(&value).is_ok(), "schema validation should pass for empty id");
     let template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
     assert!(template.id.is_empty());
+}
+
+#[test]
+fn explicit_path_loading_works() {
+    let schema = load_schema_from(Path::new("schemas/node-template.schema.json"));
+    let value = json!({
+        "id": "explicit", 
+        "analysis_type": "text",
+        "metadata": {"schema": "1.0"}
+    });
+    assert!(schema.validate(&value).is_ok(), "schema validation should pass");
 }


### PR DESCRIPTION
## Summary
- read `NODE_TEMPLATE_SCHEMA_PATH` in `load_schema`
- allow explicit schema loading via `load_schema_from`
- document schema loading and update example

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ade1d707248323bb99759ed28227dd