### PR TITLE
docs: extend node template examples

### DIFF
--- a/node-template.md
+++ b/node-template.md
@@ -14,10 +14,13 @@
 
 ## Оглавление
 - [Обязательные поля](#обязательные-поля)
+- [Дополнительные поля](#дополнительные-поля)
 - [Пример](#пример)
   - [JSON](#json)
   - [YAML](#yaml)
 - [Проверка](#проверка)
+- [Рекомендации по валидации и обратной совместимости](#рекомендации-по-валидации-и-обратной-совместимости)
+- [Примеры и тесты](#примеры-и-тесты)
 
 
 Шаблон для создания узлов анализа. Обязательными являются поля `id`, `analysis_type` и `metadata`.
@@ -33,6 +36,14 @@
 | `draft_content` | string | нет | Черновое содержимое узла. |
 | `metadata` | object | да | Дополнительные метаданные в формате ключ‑значение. Должно содержать поле `schema`. |
 
+## Дополнительные поля
+
+Поле `metadata` допускает произвольные ключи. Распространённые примеры:
+
+- `author` — автор шаблона.
+- `tags` — массив строковых тегов.
+- `version` — произвольная версия содержимого.
+
 ## Пример
 
 ### JSON
@@ -45,8 +56,11 @@
   "confidence_threshold": 0.8,
   "draft_content": "Initial description",
   "metadata": {
-    "schema": "1.1.0",
-    "source": "https://example.org"
+    "schema": "1.0.0",
+    "source": "https://example.org",
+    "author": "Alice",
+    "tags": ["demo", "template"],
+    "version": "0.1.0"
   }
 }
 ```
@@ -61,8 +75,13 @@ links:
 confidence_threshold: 0.8
 draft_content: Initial description
 metadata:
-  schema: "1.1.0"
+  schema: "1.0.0"
   source: "https://example.org"
+  author: Alice
+  tags:
+    - demo
+    - template
+  version: "0.1.0"
 ```
 
 ## Проверка
@@ -85,6 +104,15 @@ use std::path::Path;
 let schema = load_schema("1.0.0").unwrap();
 let same_schema = load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).unwrap();
 ```
+
+## Рекомендации по валидации и обратной совместимости
+
+Используйте актуальные JSON Schema для проверки шаблонов. Добавляя новые поля, делайте их необязательными и сохраняйте поддержку предыдущих версий схем. При изменении структуры повышайте номер версии в `metadata.schema` и предоставляйте миграционный путь.
+
+## Примеры и тесты
+
+- Полный пример с дополнительными полями: [tests/example_node_template.rs](tests/example_node_template.rs)
+- Тесты на валидацию шаблонов: [tests/node_template_test.rs](tests/node_template_test.rs), [tests/node_template_validation_test.rs](tests/node_template_validation_test.rs)
 
 ## Схемы
 

--- a/tests/example_node_template.rs
+++ b/tests/example_node_template.rs
@@ -10,10 +10,39 @@ fn example_node_template_validates() {
         "links": ["node-a", "node-b"],
         "confidence_threshold": 0.75,
         "draft_content": "draft",
-        "metadata": { "schema": "1.0.0", "author": "Alice" }
+        "metadata": {
+            "schema": "1.0.0",
+            "author": "Alice",
+            "tags": ["demo", "test"],
+            "version": "0.1.0"
+        }
     });
 
-    let schema = load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).expect("load schema");
-    assert!(schema.validate(&example).is_ok(), "schema validation should pass");
-    let _template: NodeTemplate = serde_json::from_value(example).expect("deserialize");
+    let schema =
+        load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).expect("load schema");
+    assert!(
+        schema.validate(&example).is_ok(),
+        "schema validation should pass"
+    );
+    let template: NodeTemplate = serde_json::from_value(example).expect("deserialize");
+    assert_eq!(
+        template
+            .metadata
+            .extra
+            .get("author")
+            .and_then(|v| v.as_str()),
+        Some("Alice")
+    );
+    assert_eq!(
+        template.metadata.extra.get("tags"),
+        Some(&json!(["demo", "test"]))
+    );
+    assert_eq!(
+        template
+            .metadata
+            .extra
+            .get("version")
+            .and_then(|v| v.as_str()),
+        Some("0.1.0")
+    );
 }

--- a/tests/node_template_test.rs
+++ b/tests/node_template_test.rs
@@ -9,10 +9,38 @@ fn valid_template_is_accepted() {
         "analysis_type": "text",
         "links": ["a", "b"],
         "confidence_threshold": 0.5,
-        "metadata": {"schema": "1.0.0"}
+        "metadata": {
+            "schema": "1.0.0",
+            "author": "Bob",
+            "tags": ["tag1", "tag2"],
+            "version": "0.1.0"
+        }
     });
-    assert!(validate_template(&value).is_ok(), "schema validation should pass");
-    let _template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
+    assert!(
+        validate_template(&value).is_ok(),
+        "schema validation should pass"
+    );
+    let template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
+    assert_eq!(
+        template
+            .metadata
+            .extra
+            .get("author")
+            .and_then(|v| v.as_str()),
+        Some("Bob")
+    );
+    assert_eq!(
+        template.metadata.extra.get("tags"),
+        Some(&json!(["tag1", "tag2"]))
+    );
+    assert_eq!(
+        template
+            .metadata
+            .extra
+            .get("version")
+            .and_then(|v| v.as_str()),
+        Some("0.1.0")
+    );
 }
 
 #[test]
@@ -22,8 +50,14 @@ fn missing_required_fields_are_rejected() {
         "links": [],
         "metadata": {}
     });
-    assert!(schema.validate(&value).is_err(), "schema validation should fail");
-    assert!(serde_json::from_value::<NodeTemplate>(value).is_err(), "deserialization should fail");
+    assert!(
+        schema.validate(&value).is_err(),
+        "schema validation should fail"
+    );
+    assert!(
+        serde_json::from_value::<NodeTemplate>(value).is_err(),
+        "deserialization should fail"
+    );
 }
 
 #[test]
@@ -35,8 +69,14 @@ fn invalid_links_type_fails() {
         "links": "not-an-array",
         "metadata": {"schema": "1.0.0"}
     });
-    assert!(schema.validate(&value).is_err(), "schema validation should fail");
-    assert!(serde_json::from_value::<NodeTemplate>(value).is_err(), "deserialization should fail");
+    assert!(
+        schema.validate(&value).is_err(),
+        "schema validation should fail"
+    );
+    assert!(
+        serde_json::from_value::<NodeTemplate>(value).is_err(),
+        "deserialization should fail"
+    );
 }
 
 #[test]
@@ -48,8 +88,14 @@ fn invalid_confidence_threshold_type_fails() {
         "confidence_threshold": "high",
         "metadata": {"schema": "1.0.0"}
     });
-    assert!(schema.validate(&value).is_err(), "schema validation should fail");
-    assert!(serde_json::from_value::<NodeTemplate>(value).is_err(), "deserialization should fail");
+    assert!(
+        schema.validate(&value).is_err(),
+        "schema validation should fail"
+    );
+    assert!(
+        serde_json::from_value::<NodeTemplate>(value).is_err(),
+        "deserialization should fail"
+    );
 }
 
 #[test]
@@ -60,29 +106,42 @@ fn empty_id_is_handled() {
         "analysis_type": "text",
         "metadata": {"schema": "1.0.0"}
     });
-    assert!(schema.validate(&value).is_ok(), "schema validation should pass for empty id");
+    assert!(
+        schema.validate(&value).is_ok(),
+        "schema validation should pass for empty id"
+    );
     let template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
     assert!(template.id.is_empty());
 }
 
 #[test]
 fn explicit_path_loading_works() {
-    let schema = load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).expect("load schema");
+    let schema =
+        load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).expect("load schema");
     let value = json!({
         "id": "explicit",
         "analysis_type": "text",
         "metadata": {"schema": "1.0.0"}
     });
-    assert!(schema.validate(&value).is_ok(), "schema validation should pass");
+    assert!(
+        schema.validate(&value).is_ok(),
+        "schema validation should pass"
+    );
 }
 
 #[test]
 fn unknown_schema_version_errors() {
-    assert!(load_schema("9.9.9").is_err(), "loading unknown version should fail");
+    assert!(
+        load_schema("9.9.9").is_err(),
+        "loading unknown version should fail"
+    );
     let value = json!({
         "id": "node",
         "analysis_type": "text",
         "metadata": {"schema": "9.9.9"}
     });
-    assert!(validate_template(&value).is_err(), "validation should fail for unknown schema version");
+    assert!(
+        validate_template(&value).is_err(),
+        "validation should fail for unknown schema version"
+    );
 }

--- a/tests/node_template_validation_test.rs
+++ b/tests/node_template_validation_test.rs
@@ -6,10 +6,18 @@ fn valid_template_passes_validation() {
     let value = json!({
         "id": "example-node",
         "analysis_type": "text",
-        "metadata": {"schema": "1.0.0"}
+        "metadata": {
+            "schema": "1.0.0",
+            "author": "Carol",
+            "tags": ["demo"],
+            "version": "0.1.0"
+        }
     });
     validate_template(&value).expect("should be valid");
-    let _template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
+    let template: NodeTemplate = serde_json::from_value(value).expect("deserialize");
+    assert!(template.metadata.extra.contains_key("author"));
+    assert!(template.metadata.extra.contains_key("tags"));
+    assert!(template.metadata.extra.contains_key("version"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- document `author`, `tags`, and `version` metadata fields in NodeTemplate
- add validation and backward compatibility recommendations
- link to example and validation tests

## Testing
- `cargo test --test example_node_template --test node_template_test --test node_template_validation_test`


------
https://chatgpt.com/codex/tasks/task_e_68adfa064bd483239f7eb64050774fb6