### PR TITLE
cache node template schema with once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ version = "0.1.0"
 dependencies = [
  "backend",
  "jsonschema",
+ "once_cell",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ backend = { path = "backend" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonschema = "0.17"
+once_cell = "1"
 [package.metadata]
 rustflags = ["-Dwarnings"]

--- a/node-template.md
+++ b/node-template.md
@@ -95,13 +95,13 @@ npx ajv validate -s schemas/node-template/v1.0.0.json -d node-template.yaml
 
 ### Программная загрузка
 
-В Rust‑коде схема загружается функцией `load_schema(version)`, которая читает файл по указанной версии. Каталог с версиями можно переопределить переменной окружения `NODE_TEMPLATE_SCHEMA_DIR`; по умолчанию используется `schemas/node-template` из текущего репозитория. Для явной загрузки по произвольному пути доступна функция `load_schema_from`.
+В Rust‑коде схема загружается функцией `load_schema()`, которая читает файл текущей версии схемы. Каталог можно переопределить переменной окружения `NODE_TEMPLATE_SCHEMA_DIR`; по умолчанию используется `schemas/node-template` из текущего репозитория. Для явной загрузки по произвольному пути доступна функция `load_schema_from`.
 
 ```rust
 use backend::node_template::{load_schema, load_schema_from};
 use std::path::Path;
 
-let schema = load_schema("1.0.0").unwrap();
+let schema = load_schema().unwrap();
 let same_schema = load_schema_from(Path::new("schemas/node-template/v1.0.0.json")).unwrap();
 ```
 

--- a/tests/node_template_test.rs
+++ b/tests/node_template_test.rs
@@ -45,7 +45,7 @@ fn valid_template_is_accepted() {
 
 #[test]
 fn missing_required_fields_are_rejected() {
-    let schema = load_schema("1.0.0").expect("load schema");
+    let schema = load_schema().expect("load schema");
     let value = json!({
         "links": [],
         "metadata": {}
@@ -62,7 +62,7 @@ fn missing_required_fields_are_rejected() {
 
 #[test]
 fn invalid_links_type_fails() {
-    let schema = load_schema("1.0.0").expect("load schema");
+    let schema = load_schema().expect("load schema");
     let value = json!({
         "id": "node",
         "analysis_type": "text",
@@ -81,7 +81,7 @@ fn invalid_links_type_fails() {
 
 #[test]
 fn invalid_confidence_threshold_type_fails() {
-    let schema = load_schema("1.0.0").expect("load schema");
+    let schema = load_schema().expect("load schema");
     let value = json!({
         "id": "node",
         "analysis_type": "text",
@@ -100,7 +100,7 @@ fn invalid_confidence_threshold_type_fails() {
 
 #[test]
 fn empty_id_is_handled() {
-    let schema = load_schema("1.0.0").expect("load schema");
+    let schema = load_schema().expect("load schema");
     let value = json!({
         "id": "",
         "analysis_type": "text",
@@ -131,10 +131,6 @@ fn explicit_path_loading_works() {
 
 #[test]
 fn unknown_schema_version_errors() {
-    assert!(
-        load_schema("9.9.9").is_err(),
-        "loading unknown version should fail"
-    );
     let value = json!({
         "id": "node",
         "analysis_type": "text",


### PR DESCRIPTION
## Summary
- cache the node template JSON schema with `OnceCell` and expose it via `load_schema`
- validate template version against supported schema version
- adjust tests and docs for static schema usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adff4b4ec48323b0f749b798927211