### PR TITLE
Implement NodeTemplate to_json with schema validation

### DIFF
--- a/tests/node_template_to_json_test.rs
+++ b/tests/node_template_to_json_test.rs
@@ -1,0 +1,24 @@
+use backend::node_template::{validate_template, Metadata, NodeTemplate};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn to_json_produces_valid_structure() {
+    let mut extra = HashMap::new();
+    extra.insert("author".to_string(), json!("Alice"));
+
+    let template = NodeTemplate {
+        id: "node-1".to_string(),
+        analysis_type: "text".to_string(),
+        links: vec!["a".to_string(), "b".to_string()],
+        confidence_threshold: Some(0.8),
+        draft_content: Some("draft".to_string()),
+        metadata: Metadata {
+            schema: "1.0.0".to_string(),
+            extra,
+        },
+    };
+
+    let value = template.to_json();
+    validate_template(&value).expect("to_json result should validate");
+}


### PR DESCRIPTION
## Summary
- add `NodeTemplate::to_json` to serialize and validate templates
- cover `NodeTemplate::to_json` with a unit test ensuring schema compliance

## Testing
- `cargo test to_json_produces_valid_structure --test node_template_to_json_test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68ae0157121c8323b647a6fc6d8847f7