### PR TITLE
feat: load NodeTemplate schema and example

### DIFF
--- a/backend/src/node_template.rs
+++ b/backend/src/node_template.rs
@@ -41,12 +41,12 @@ const SCHEMA_VERSION: &str = "1.0.0";
 pub fn load_schema() -> Result<&'static Config<'static>, String> {
     let schema = SCHEMA
         .get_or_try_init(|| {
-            let base = env::var("NODE_TEMPLATE_SCHEMA_DIR")
+            let path = env::var("NODE_TEMPLATE_SCHEMA_PATH")
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| {
-                    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../schemas/node-template")
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                        .join("../schemas/node-template.schema.json")
                 });
-            let path = base.join(format!("v{SCHEMA_VERSION}.json"));
             load_schema_from(&path)
         })
         .map_err(|e| {

--- a/examples/node_template.rs
+++ b/examples/node_template.rs
@@ -1,0 +1,22 @@
+use backend::node_template::{load_schema, validate_template, NodeTemplate};
+use serde_json::json;
+
+fn main() {
+    // Load schema to ensure it exists
+    let _schema = load_schema().expect("schema should load");
+
+    // Example template in JSON form
+    let value = json!({
+        "id": "example.template",
+        "analysis_type": "ExampleNode",
+        "metadata": {
+            "schema": "1.0.0",
+            "author": "Example"
+        }
+    });
+
+    // Validate JSON against the schema and deserialize
+    validate_template(&value).expect("template should validate");
+    let template: NodeTemplate = serde_json::from_value(value).expect("deserialize NodeTemplate");
+    println!("Loaded template id: {}", template.id);
+}

--- a/schemas/node-template.schema.json
+++ b/schemas/node-template.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NodeTemplate",
+  "type": "object",
+  "required": ["id", "analysis_type", "metadata"],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "analysis_type": {
+      "type": "string"
+    },
+    "links": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "confidence_threshold": {
+      "type": "number"
+    },
+    "draft_content": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- load NodeTemplate schema from configurable path
- add unversioned JSON schema file
- provide example demonstrating schema validation

## Testing
- `cargo test`
- `cargo run --example node_template`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ee37a74832389f4a9380dfe28b7