### PR TITLE
test: add template roundtrip

### DIFF
--- a/backend/tests/template_roundtrip.rs
+++ b/backend/tests/template_roundtrip.rs
@@ -1,0 +1,33 @@
+use backend::node_template::{validate_template, Metadata, NodeTemplate};
+use serde_json::json;
+use std::collections::HashMap;
+
+#[test]
+fn generate_validate_deserialize_template() {
+    let mut extra = HashMap::new();
+    extra.insert("author".to_string(), json!("Alice"));
+
+    let template = NodeTemplate {
+        id: "generated-node".to_string(),
+        analysis_type: "text".to_string(),
+        links: vec!["a".to_string(), "b".to_string()],
+        confidence_threshold: Some(0.5),
+        draft_content: Some("draft".to_string()),
+        metadata: Metadata {
+            schema: "1.0.0".to_string(),
+            extra,
+        },
+    };
+
+    let value = template.to_json();
+    validate_template(&value).expect("generated template should validate");
+    let parsed: NodeTemplate = serde_json::from_value(value).expect("deserialize NodeTemplate");
+
+    assert_eq!(parsed.id, template.id);
+    assert_eq!(parsed.analysis_type, template.analysis_type);
+    assert_eq!(parsed.links, template.links);
+    assert_eq!(parsed.confidence_threshold, template.confidence_threshold);
+    assert_eq!(parsed.draft_content, template.draft_content);
+    assert_eq!(parsed.metadata.schema, template.metadata.schema);
+    assert_eq!(parsed.metadata.extra.get("author"), Some(&json!("Alice")));
+}


### PR DESCRIPTION
## Summary
- add test that generates a NodeTemplate, validates it against current schema, and deserializes back

## Testing
- `cargo test --manifest-path backend/Cargo.toml`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae7a8a6f108323a4acaddc4b69c074