### PR TITLE
Add YAML node template example and docs update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
  jsonschema-valid = "0.5.2"
 once_cell = "1"
+
+[dev-dependencies]
+serde_yaml = "0.9"
 [package.metadata]
 rustflags = ["-Dwarnings"]

--- a/docs/usage-example.md
+++ b/docs/usage-example.md
@@ -1,6 +1,6 @@
 # Usage Example
 
-Validate a node template file in JSON or YAML format:
+Validate a node template file in JSON or YAML format. YAML input is converted to JSON before validation:
 
 ```bash
 cargo run --bin validate_template <path>

--- a/examples/node_template.yaml
+++ b/examples/node_template.yaml
@@ -1,0 +1,5 @@
+id: example.template
+analysis_type: ExampleNode
+metadata:
+  schema: "1.0.0"
+  author: "Example"

--- a/examples/node_template_yaml.rs
+++ b/examples/node_template_yaml.rs
@@ -1,0 +1,18 @@
+use std::fs::File;
+
+use backend::node_template::{validate_template, NodeTemplate};
+use serde_yaml::Value as YamlValue;
+
+fn main() {
+    // Read the YAML template from a file.
+    let file = File::open("examples/node_template.yaml").expect("open YAML file");
+    let yaml: YamlValue = serde_yaml::from_reader(file).expect("read YAML");
+
+    // Convert YAML value to JSON value.
+    let value = serde_json::to_value(yaml).expect("convert to JSON");
+
+    // Validate JSON against the schema and deserialize.
+    validate_template(&value).expect("template should validate");
+    let template: NodeTemplate = serde_json::from_value(value).expect("deserialize NodeTemplate");
+    println!("Loaded template id: {}", template.id);
+}


### PR DESCRIPTION
## Summary
- add example that reads a YAML template, converts it to JSON and validates it
- document that YAML files are supported alongside JSON

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae866a3edc8323acba5f30d3ac203d