### PR TITLE
chore: run backend tests in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
+set -e
 
 npm run lint
 npm test
 cargo clippy
 cargo test
+cargo test --manifest-path backend/Cargo.toml


### PR DESCRIPTION
## Summary
- ensure husky pre-commit exits on first failure
- run backend cargo tests explicitly

## Testing
- `./.husky/pre-commit` *(fails: unresolved import metrics_exporter_prometheus)*

------
https://chatgpt.com/codex/tasks/task_e_68aed9a3ac288323826ad2d80710df29