### PR TITLE
chore: add duplicate crate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: |
           npm ci
           npm ci --prefix frontend
+      - name: Check duplicate crates
+        run: scripts/check-duplicates.sh
       - name: Lint
         run: npm run lint
       - name: Test backend

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,6 @@ set -e
 npm run lint
 npm test
 cargo clippy
+scripts/check-duplicates.sh
 cargo test
 cargo test --manifest-path backend/Cargo.toml

--- a/scripts/check-duplicates.sh
+++ b/scripts/check-duplicates.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect duplicate crate versions in Cargo dependencies.
+output=$(cargo tree -d)
+if [ -n "$output" ]; then
+  echo "$output"
+  echo "Duplicate crate versions detected. Ensure a single version per crate." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- check for duplicate crate versions with scripts/check-duplicates.sh
- run duplicate check in pre-commit and CI

## Testing
- `npm run lint`
- `npm test`
- `cargo clippy` *(fails: Duplicate crate versions detected)*
- `scripts/check-duplicates.sh` *(fails: Duplicate crate versions detected)*
- `cargo test`
- `cargo test --manifest-path backend/Cargo.toml`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68aedff5f0788323a7d5ac1fcc00c0e1