### PR TITLE
ci: validate cargo metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Validate Cargo files
+        run: cargo metadata --locked
       - name: Install dependencies
         run: |
           npm ci

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,7 @@ set -e
 
 npm run lint
 npm test
+cargo metadata --locked
 cargo clippy
 scripts/check-duplicates.sh
 cargo test


### PR DESCRIPTION
## Summary
- check Cargo metadata in CI to validate Cargo.toml and Cargo.lock
- run the same Cargo metadata check in pre-commit hook

## Testing
- `npm test`
- `npm test --prefix frontend`
- `scripts/check-duplicates.sh`
- `cargo clippy`
- `cargo test`
- `cargo test --manifest-path backend/Cargo.toml`
- `cargo metadata --locked --format-version 1 >/tmp/metadata.json && jq '.workspace_members | length' /tmp/metadata.json`


------
https://chatgpt.com/codex/tasks/task_e_68aee6a2b23c8323a7af90ddf98dc44a