### PR TITLE
Add analysis node result with reasoning chain and metrics

### DIFF
--- a/backend/src/analysis_node.rs
+++ b/backend/src/analysis_node.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeStatus {
+    Draft,
+    Active,
+    Deprecated,
+    Error,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct QualityMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credibility: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recency_days: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub demand: Option<u32>,
+}
+
+impl QualityMetrics {
+    pub fn compute(reasoning_chain: &[String]) -> Self {
+        let credibility = if reasoning_chain.is_empty() { 0.0 } else { 1.0 };
+        let demand = reasoning_chain.len() as u32;
+        QualityMetrics {
+            credibility: Some(credibility),
+            recency_days: Some(0),
+            demand: Some(demand),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnalysisMetadata {
+    pub schema: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AnalysisResult {
+    pub id: String,
+    pub output: String,
+    pub status: NodeStatus,
+    pub quality_metrics: QualityMetrics,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_chain: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uncertainty_score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<String>,
+    pub metadata: AnalysisMetadata,
+}
+
+impl AnalysisResult {
+    pub fn new(id: impl Into<String>, output: impl Into<String>, reasoning_chain: Vec<String>) -> Self {
+        let quality_metrics = QualityMetrics::compute(&reasoning_chain);
+        let uncertainty_score = quality_metrics.credibility.map(|c| 1.0 - c);
+        AnalysisResult {
+            id: id.into(),
+            output: output.into(),
+            status: NodeStatus::Active,
+            quality_metrics,
+            reasoning_chain,
+            uncertainty_score,
+            explanation: None,
+            links: vec![],
+            metadata: AnalysisMetadata {
+                schema: "1.0.0".into(),
+            },
+        }
+    }
+}
+
+pub trait AnalysisNode {
+    fn id(&self) -> &str;
+    fn analysis_type(&self) -> &str;
+    fn status(&self) -> NodeStatus;
+    fn links(&self) -> &[String];
+    fn confidence_threshold(&self) -> f32;
+    fn analyze(&self, input: &str) -> AnalysisResult;
+    fn explain(&self) -> String;
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod node_template;
 pub mod node_registry;
+pub mod analysis_node;

--- a/tests/analysis_result_serialization_test.rs
+++ b/tests/analysis_result_serialization_test.rs
@@ -1,0 +1,11 @@
+use backend::analysis_node::AnalysisResult;
+use serde_json::json;
+
+#[test]
+fn analysis_result_serializes_reasoning_chain_and_metrics() {
+    let result = AnalysisResult::new("example", "output", vec!["step1".into(), "step2".into()]);
+    let value = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(value["reasoning_chain"], json!(["step1", "step2"]));
+    assert_eq!(value["quality_metrics"]["demand"], json!(2));
+    assert_eq!(value["quality_metrics"]["credibility"], json!(1.0));
+}


### PR DESCRIPTION
## Summary
- define `AnalysisNode` trait and `AnalysisResult` structure with quality metrics
- include reasoning chain field and automatic quality metric calculation
- add serialization test for analysis results

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aeea0993ec8323b2c325c35ede507b