### PR TITLE
Add cancellation-aware analysis hub with memory preloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +159,7 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "jsonschema-valid",
  "metrics-exporter-prometheus",
  "notify",
@@ -153,6 +169,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -251,7 +268,13 @@ version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -343,6 +366,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -587,6 +616,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -864,6 +917,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1046,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1302,8 +1363,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1575,6 +1649,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1858,6 +1945,7 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
@@ -1926,7 +2014,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -1961,10 +2049,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ once_cell = "1"
 
 [dev-dependencies]
 serde_yaml = "0.9"
+tempfile = "3"
+tokio-util = "0.7"
 [package.metadata]
 rustflags = ["-Dwarnings"]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,6 +18,8 @@ serde_yaml = "0.9"
 notify = { version = "8.2", default-features = false }
 semver = "1"
 metrics-exporter-prometheus = "0.17"
+chrono = { version = "0.4", features = ["serde", "alloc"] }
+tokio-util = "0.7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/src/analysis_node.rs
+++ b/backend/src/analysis_node.rs
@@ -1,0 +1,113 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeStatus {
+    Draft,
+    Active,
+    Deprecated,
+    Error,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct QualityMetrics {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credibility: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recency_days: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub demand: Option<u32>,
+}
+
+impl QualityMetrics {
+    pub fn compute(reasoning_chain: &[ReasoningStep]) -> Self {
+        let credibility = if reasoning_chain.is_empty() { 0.0 } else { 1.0 };
+        let demand = reasoning_chain.len() as u32;
+        QualityMetrics {
+            credibility: Some(credibility),
+            recency_days: Some(0),
+            demand: Some(demand),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReasoningStep {
+    pub timestamp: DateTime<Utc>,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnalysisMetadata {
+    pub schema: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct AnalysisResult {
+    pub id: String,
+    pub output: String,
+    pub status: NodeStatus,
+    pub quality_metrics: QualityMetrics,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_chain: Vec<ReasoningStep>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uncertainty_score: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<String>,
+    pub metadata: AnalysisMetadata,
+}
+
+impl AnalysisResult {
+    pub fn new(id: impl Into<String>, output: impl Into<String>, steps: Vec<String>) -> Self {
+        let reasoning_chain = steps
+            .into_iter()
+            .map(|s| ReasoningStep {
+                timestamp: Utc::now(),
+                content: s,
+            })
+            .collect::<Vec<_>>();
+        let quality_metrics = QualityMetrics::compute(&reasoning_chain);
+        let uncertainty_score = quality_metrics.credibility.map(|c| 1.0 - c);
+        AnalysisResult {
+            id: id.into(),
+            output: output.into(),
+            status: NodeStatus::Active,
+            quality_metrics,
+            reasoning_chain,
+            uncertainty_score,
+            explanation: None,
+            links: vec![],
+            metadata: AnalysisMetadata {
+                schema: "1.0.0".into(),
+            },
+        }
+    }
+
+    pub fn add_step(&mut self, step: impl Into<String>) {
+        self.reasoning_chain.push(ReasoningStep {
+            timestamp: Utc::now(),
+            content: step.into(),
+        });
+        self.update_metrics();
+    }
+
+    fn update_metrics(&mut self) {
+        self.quality_metrics = QualityMetrics::compute(&self.reasoning_chain);
+        self.uncertainty_score = self.quality_metrics.credibility.map(|c| 1.0 - c);
+    }
+}
+
+pub trait AnalysisNode {
+    fn id(&self) -> &str;
+    fn analysis_type(&self) -> &str;
+    fn status(&self) -> NodeStatus;
+    fn links(&self) -> &[String];
+    fn confidence_threshold(&self) -> f32;
+    fn analyze(&self, input: &str, cancel_token: &CancellationToken) -> AnalysisResult;
+    fn explain(&self) -> String;
+}

--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+use crate::analysis_node::{AnalysisResult, NodeStatus};
+use crate::memory_node::MemoryNode;
+use crate::node_registry::NodeRegistry;
+
+pub struct InteractionHub {
+    pub registry: Arc<NodeRegistry>,
+    pub memory: Arc<MemoryNode>,
+}
+
+impl InteractionHub {
+    pub fn new(registry: Arc<NodeRegistry>, memory: Arc<MemoryNode>) -> Self {
+        Self { registry, memory }
+    }
+
+    pub fn analyze(
+        &self,
+        id: &str,
+        input: &str,
+        cancel_token: &CancellationToken,
+    ) -> Option<AnalysisResult> {
+        let triggers: Vec<String> =
+            input.split_whitespace().map(|s| s.to_lowercase()).collect();
+        let _ = self.memory.preload_by_trigger(&triggers);
+        let node = self.registry.get_analysis_node(id)?;
+        let result = node.analyze(input, cancel_token);
+        if result.status == NodeStatus::Error {
+            self.memory.save_checkpoint(id, &result);
+        } else {
+            self.memory.push_metrics(&result);
+        }
+        Some(result)
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,2 +1,5 @@
 pub mod node_template;
 pub mod node_registry;
+pub mod analysis_node;
+pub mod memory_node;
+pub mod interaction_hub;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,12 +9,15 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::net::TcpListener;
 use tracing::{error, info};
 
+use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
+use backend::interaction_hub::InteractionHub;
+use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use backend::node_template::NodeTemplate;
 
 #[derive(Clone)]
 struct AppState {
-    registry: Arc<NodeRegistry>,
+    hub: Arc<InteractionHub>,
 }
 
 async fn register_node(
@@ -22,6 +25,7 @@ async fn register_node(
     Json(tpl): Json<NodeTemplate>,
 ) -> Result<String, (axum::http::StatusCode, String)> {
     state
+        .hub
         .registry
         .register_template(tpl)
         .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e))?;
@@ -32,7 +36,7 @@ async fn get_node(
     State(state): State<AppState>,
     Path((id, version)): Path<(String, String)>,
 ) -> Result<Json<NodeTemplate>, axum::http::StatusCode> {
-    match state.registry.get(&id) {
+    match state.hub.registry.get(&id) {
         Some(tpl) if tpl.version == version => Ok(Json(tpl)),
         _ => Err(axum::http::StatusCode::NOT_FOUND),
     }
@@ -43,10 +47,29 @@ async fn get_node_latest(
     Path(id): Path<String>,
 ) -> Result<Json<NodeTemplate>, axum::http::StatusCode> {
     state
+        .hub
         .registry
         .get(&id)
         .map(Json)
         .ok_or(axum::http::StatusCode::NOT_FOUND)
+}
+
+#[derive(serde::Deserialize)]
+struct AnalysisRequest {
+    id: String,
+    input: String,
+}
+
+async fn analyze_request(
+    State(state): State<AppState>,
+    Json(req): Json<AnalysisRequest>,
+) -> Result<Json<AnalysisResult>, axum::http::StatusCode> {
+    let token = tokio_util::sync::CancellationToken::new();
+    let result = state
+        .hub
+        .analyze(&req.id, &req.input, &token)
+        .ok_or(axum::http::StatusCode::NOT_FOUND)?;
+    Ok(Json(result))
 }
 
 #[tokio::main]
@@ -57,20 +80,46 @@ async fn main() {
         std::env::var("NODE_TEMPLATES_DIR").unwrap_or_else(|_| "./templates".into());
     let _ = std::fs::create_dir_all(&templates_dir);
     let registry = Arc::new(NodeRegistry::new(&templates_dir).expect("registry"));
+    let memory = Arc::new(MemoryNode::new());
+    let hub = Arc::new(InteractionHub::new(registry.clone(), memory.clone()));
+
+    // Пример узла анализа
+    struct EchoNode;
+    impl AnalysisNode for EchoNode {
+        fn id(&self) -> &str { "example.analysis" }
+        fn analysis_type(&self) -> &str { "summary" }
+        fn status(&self) -> NodeStatus { NodeStatus::Active }
+        fn links(&self) -> &[String] { &[] }
+        fn confidence_threshold(&self) -> f32 { 0.0 }
+        fn analyze(
+            &self,
+            input: &str,
+            cancel_token: &tokio_util::sync::CancellationToken,
+        ) -> AnalysisResult {
+            if cancel_token.is_cancelled() {
+                let mut r = AnalysisResult::new(self.id(), input, vec![]);
+                r.status = NodeStatus::Error;
+                return r;
+            }
+            AnalysisResult::new(self.id(), input, vec!["echo".into()])
+        }
+        fn explain(&self) -> String { "Echoes input".into() }
+    }
+
+    registry.register_analysis_node(Arc::new(EchoNode));
 
     let handle = PrometheusBuilder::new()
         .install_recorder()
         .expect("metrics");
 
-    let state = AppState {
-        registry: registry.clone(),
-    };
+    let state = AppState { hub: hub.clone() };
 
     let app = Router::new()
         .route("/", get(|| async { "Hello, world!" }))
         .route("/nodes", post(register_node))
         .route("/nodes/:id", get(get_node_latest))
         .route("/nodes/:id/:version", get(get_node))
+        .route("/api/neira/analysis", post(analyze_request))
         .route("/metrics", get(move || async move { handle.render() }))
         .with_state(state);
 

--- a/backend/src/memory_node.rs
+++ b/backend/src/memory_node.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use crate::analysis_node::{AnalysisResult, QualityMetrics, ReasoningStep};
+
+#[derive(Debug, Clone)]
+pub struct MemoryRecord {
+    pub id: String,
+    pub quality_metrics: QualityMetrics,
+    pub reasoning_chain: Vec<ReasoningStep>,
+}
+
+#[derive(Debug, Default)]
+pub struct MemoryNode {
+    records: RwLock<Vec<MemoryRecord>>,
+    checkpoints: RwLock<HashMap<String, AnalysisResult>>,
+}
+
+impl MemoryNode {
+    pub fn new() -> Self {
+        Self {
+            records: RwLock::new(Vec::new()),
+            checkpoints: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn push_metrics(&self, result: &AnalysisResult) {
+        let record = MemoryRecord {
+            id: result.id.clone(),
+            quality_metrics: result.quality_metrics.clone(),
+            reasoning_chain: result.reasoning_chain.clone(),
+        };
+        self.records.write().unwrap().push(record);
+    }
+
+    pub fn records(&self) -> Vec<MemoryRecord> {
+        self.records.read().unwrap().clone()
+    }
+
+    pub fn save_checkpoint(&self, id: &str, result: &AnalysisResult) {
+        self
+            .checkpoints
+            .write()
+            .unwrap()
+            .insert(id.to_string(), result.clone());
+    }
+
+    pub fn load_checkpoint(&self, id: &str) -> Option<AnalysisResult> {
+        self.checkpoints.read().unwrap().get(id).cloned()
+    }
+
+    pub fn preload_by_trigger(&self, triggers: &[String]) -> Vec<MemoryRecord> {
+        let records = self.records.read().unwrap();
+        records
+            .iter()
+            .filter(|rec| {
+                triggers.iter().any(|t| {
+                    rec.id.contains(t)
+                        || rec
+                            .reasoning_chain
+                            .iter()
+                            .any(|step| step.content.contains(t))
+                })
+            })
+            .cloned()
+            .collect()
+    }
+}

--- a/tests/analysis_result_serialization_test.rs
+++ b/tests/analysis_result_serialization_test.rs
@@ -1,0 +1,13 @@
+use backend::analysis_node::AnalysisResult;
+use serde_json::json;
+
+#[test]
+fn analysis_result_serializes_reasoning_chain_and_metrics() {
+    let mut result = AnalysisResult::new("example", "output", vec!["step1".into()]);
+    result.add_step("step2");
+    let value = serde_json::to_value(&result).expect("serialize");
+    assert_eq!(value["reasoning_chain"][0]["content"], json!("step1"));
+    assert_eq!(value["reasoning_chain"][1]["content"], json!("step2"));
+    assert_eq!(value["quality_metrics"]["demand"], json!(2));
+    assert_eq!(value["quality_metrics"]["credibility"], json!(1.0));
+}

--- a/tests/interaction_hub_cancel_test.rs
+++ b/tests/interaction_hub_cancel_test.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
+use backend::interaction_hub::InteractionHub;
+use backend::memory_node::MemoryNode;
+use backend::node_registry::NodeRegistry;
+use tokio_util::sync::CancellationToken;
+
+struct CancelNode;
+
+impl AnalysisNode for CancelNode {
+    fn id(&self) -> &str {
+        "cancel.node"
+    }
+    fn analysis_type(&self) -> &str {
+        "test"
+    }
+    fn status(&self) -> NodeStatus {
+        NodeStatus::Active
+    }
+    fn links(&self) -> &[String] {
+        &[]
+    }
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
+    fn analyze(&self, _input: &str, cancel: &CancellationToken) -> AnalysisResult {
+        if cancel.is_cancelled() {
+            let mut r = AnalysisResult::new(self.id(), "", vec![]);
+            r.status = NodeStatus::Error;
+            return r;
+        }
+        AnalysisResult::new(self.id(), "ok", vec![])
+    }
+    fn explain(&self) -> String {
+        String::new()
+    }
+}
+
+#[test]
+fn interaction_hub_saves_checkpoint_on_cancel() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(NodeRegistry::new(dir.path()).unwrap());
+    registry.register_analysis_node(Arc::new(CancelNode));
+    let memory = Arc::new(MemoryNode::new());
+    let hub = InteractionHub::new(registry.clone(), memory.clone());
+    let token = CancellationToken::new();
+    token.cancel();
+    let result = hub.analyze("cancel.node", "", &token).unwrap();
+    assert_eq!(result.status, NodeStatus::Error);
+    assert!(memory.load_checkpoint("cancel.node").is_some());
+}

--- a/tests/memory_node_metrics_test.rs
+++ b/tests/memory_node_metrics_test.rs
@@ -1,0 +1,18 @@
+use backend::analysis_node::AnalysisResult;
+use backend::memory_node::MemoryNode;
+
+#[test]
+fn memory_node_stores_metrics_and_chain() {
+    let mut result = AnalysisResult::new("id", "out", vec!["rust".into()]);
+    result.add_step("first");
+    let memory = MemoryNode::new();
+    memory.push_metrics(&result);
+    memory.save_checkpoint("id", &result);
+    assert!(memory.load_checkpoint("id").is_some());
+    let preloaded = memory.preload_by_trigger(&vec!["rust".into()]);
+    assert_eq!(preloaded.len(), 1);
+    let records = memory.records();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].quality_metrics.demand, Some(2));
+    assert_eq!(records[0].reasoning_chain[0].content, "rust");
+}

--- a/tests/node_registry_analysis_test.rs
+++ b/tests/node_registry_analysis_test.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
+use backend::node_registry::NodeRegistry;
+use tokio_util::sync::CancellationToken;
+
+struct DummyNode;
+
+impl AnalysisNode for DummyNode {
+    fn id(&self) -> &str {
+        "dummy"
+    }
+    fn analysis_type(&self) -> &str {
+        "dummy"
+    }
+    fn status(&self) -> NodeStatus {
+        NodeStatus::Active
+    }
+    fn links(&self) -> &[String] {
+        &[]
+    }
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
+    fn analyze(&self, _input: &str, _cancel: &CancellationToken) -> AnalysisResult {
+        AnalysisResult::new(self.id(), "out", vec![])
+    }
+    fn explain(&self) -> String {
+        String::new()
+    }
+}
+
+#[test]
+fn registry_registers_analysis_nodes() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = NodeRegistry::new(dir.path()).unwrap();
+    registry.register_analysis_node(Arc::new(DummyNode));
+    assert!(registry.get_analysis_node("dummy").is_some());
+}


### PR DESCRIPTION
## Summary
- support cancellation tokens in `AnalysisNode` and recompute metrics after each reasoning step
- store checkpoints and provide trigger-based preloading in `MemoryNode`
- introduce `InteractionHub` orchestrator and wire backend server through it

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aeea0993ec8323b2c325c35ede507b