### PR TITLE
Fix unmatched closing brace in AnalysisResult

### DIFF
--- a/backend/src/analysis_node.rs
+++ b/backend/src/analysis_node.rs
@@ -88,9 +88,7 @@ impl AnalysisResult {
             },
         }
     }
-}
-
-
+    
     pub fn add_step(&mut self, step: impl Into<String>) {
         self.reasoning_chain.push(ReasoningStep {
             timestamp: Utc::now(),


### PR DESCRIPTION
## Summary
- fix unmatched `}` in `AnalysisResult` impl and expose `add_step`
- keep quality metrics updated after each new reasoning step

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af1344c61c8323847a3cac60bbdc23