### PR TITLE
Make ChatNode async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "jsonschema-valid",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
 name = "backend"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "jsonschema-valid",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,6 +21,7 @@ metrics-exporter-prometheus = "0.17"
 chrono = { version = "0.4", features = ["serde", "alloc"] }
 tokio-util = "0.7"
 lru = "0.12"
+async-trait = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/src/action/chat_node.rs
+++ b/backend/src/action/chat_node.rs
@@ -1,20 +1,24 @@
+use async_trait::async_trait;
+
 /// Узел для простого чата.
+#[async_trait]
 pub trait ChatNode: Send + Sync {
     /// Идентификатор узла.
     fn id(&self) -> &str;
     /// Обрабатывает текстовый запрос и возвращает ответ.
-    fn chat(&self, input: &str) -> String;
+    async fn chat(&self, input: &str) -> String;
 }
 
 /// Простейшая реализация узла чата, возвращающая входной текст.
 pub struct EchoChatNode;
 
+#[async_trait]
 impl ChatNode for EchoChatNode {
     fn id(&self) -> &str {
         "echo.chat"
     }
 
-    fn chat(&self, input: &str) -> String {
+    async fn chat(&self, input: &str) -> String {
         input.to_string()
     }
 }


### PR DESCRIPTION
## Summary
- add `async-trait` dependency
- convert `ChatNode` trait and `EchoChatNode` implementation to async
- update lockfiles

## Testing
- `cargo check -p backend`


------
https://chatgpt.com/codex/tasks/task_e_68af6df378c88323825e3287527f72dd