### PR TITLE
fix: remove stray character from backend dependencies

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,7 +13,6 @@ serde_json = "1"
 jsonschema-valid = "0.5.2"
 once_cell = "1"
 tracing = "0.1"
-<
 tracing-subscriber = "0.3" # direct file logging without tracing-appender
 
 


### PR DESCRIPTION
## Summary
- remove stray character before `tracing-subscriber`

## Testing
- `cargo metadata --locked --format-version 1 | jq '.packages | length'`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af8f856e448323b2d4b7ac915006f8