### PR TITLE
ci: specify cargo metadata format version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Validate Cargo files
-        run: cargo metadata --locked
+        run: cargo metadata --locked --format-version 1
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
## Summary
- ensure GitHub CI calls cargo metadata with a fixed format version

## Testing
- `cargo metadata --locked --format-version 1 >/tmp/meta.json 2>/tmp/meta.err`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68af9848a6f48323b3c1495396cd82d3