### PR TITLE
Fix stray closing brace in backend main

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -116,8 +116,6 @@ async fn main() {
     hub.add_auth_token("secret");
     hub.add_trigger_keyword("echo");
     registry.register_action_node(Arc::new(PreloadAction::default()));
-}
-
     // Пример узла анализа
     struct EchoNode;
     impl AnalysisNode for EchoNode {


### PR DESCRIPTION
## Summary
- remove stray closing brace in backend main

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68afe5e539c08323976341c13332a0fe