### PR TITLE
Enable env-filter feature for tracing-subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,10 +1929,14 @@ name = "tracing-subscriber"
 version = "0.3.19"
 source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -984,6 +984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,10 +1915,14 @@ name = "tracing-subscriber"
 version = "0.3.19"
 source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1"
 jsonschema-valid = "0.5.2"
 once_cell = "1"
 tracing = "0.1"
-tracing-subscriber = "0.3" # direct file logging without tracing-appender
+tracing-subscriber = { version = "0.3", features = ["env-filter"] } # direct file logging without tracing-appender
 
 
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "f71cebe41e4c12735b1d19ca804428d4ff7d905d", package = "tracing-appender" }


### PR DESCRIPTION
## Summary
- enable `env-filter` feature for `tracing-subscriber`
- update Cargo.lock files after dependency change

## Testing
- `cargo build --manifest-path backend/Cargo.toml`
- `cargo test --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68afef2a22608323885741e54818ca51