### PR TITLE
Add async chat node tests with logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ serde_yaml = "0.9"
 tempfile = "3"
 tokio-util = "0.7"
 tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [package.metadata]
 rustflags = ["-Dwarnings"]

--- a/tests/chat_node_test.rs
+++ b/tests/chat_node_test.rs
@@ -1,4 +1,48 @@
-#[test]
-fn placeholder() {
-    assert!(true);
+use backend::action::chat_node::{ChatNode, EchoChatNode};
+use std::sync::{Arc, Mutex};
+use std::io::Write;
+
+fn init_subscriber() -> (Arc<Mutex<Vec<u8>>>, tracing::subscriber::DefaultGuard) {
+    struct VecWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for VecWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let writer_buffer = buffer.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(move || VecWriter(writer_buffer.clone()))
+        .with_ansi(false)
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    (buffer, guard)
+}
+
+#[tokio::test]
+async fn chat_node_logs_request_and_response() {
+    let (buffer, _guard) = init_subscriber();
+    let node = EchoChatNode::default();
+    let input = "hello";
+    let response = node.chat(input).await;
+    assert_eq!(response, input);
+    let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    assert!(logs.contains(&format!("chat request: {}", input)));
+    assert!(logs.contains(&format!("chat response: {}", input)));
+}
+
+#[tokio::test]
+async fn chat_node_handles_empty_input() {
+    let (buffer, _guard) = init_subscriber();
+    let node = EchoChatNode::default();
+    let input = "";
+    let response = node.chat(input).await;
+    assert!(response.is_empty());
+    let logs = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
+    assert!(logs.contains("chat request: "));
+    assert!(logs.contains("chat response: "));
 }


### PR DESCRIPTION
## Summary
- test chat node logs for request and response using tracing subscriber
- add test for handling empty input
- include tracing dependencies for tests

## Testing
- `cargo test chat_node`


------
https://chatgpt.com/codex/tasks/task_e_68aff29e4b848323b42cee33fd69bae2