### PR TITLE
Add metrics collector node for metrics forwarding

### DIFF
--- a/backend/src/action/metrics_collector_node.rs
+++ b/backend/src/action/metrics_collector_node.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+use crate::action_node::ActionNode;
+use crate::analysis_node::QualityMetrics;
+use crate::memory_node::MemoryNode;
+
+/// Запись метрик, пересылаемая `MetricsCollectorNode`.
+#[derive(Debug, Clone)]
+pub struct MetricsRecord {
+    pub id: String,
+    pub metrics: QualityMetrics,
+}
+
+/// Узел, который принимает записи метрик и пересылает их как сообщения через канал.
+#[derive(Clone)]
+pub struct MetricsCollectorNode {
+    tx: UnboundedSender<MetricsRecord>,
+}
+
+impl MetricsCollectorNode {
+    /// Создаёт узел и возвращает связанный с ним приёмник для сообщений.
+    pub fn channel() -> (Arc<Self>, UnboundedReceiver<MetricsRecord>) {
+        let (tx, rx) = unbounded_channel();
+        (Arc::new(Self { tx }), rx)
+    }
+
+    /// Отправляет запись метрик для дальнейшей обработки.
+    pub fn record(&self, record: MetricsRecord) {
+        let _ = self.tx.send(record);
+    }
+}
+
+impl ActionNode for MetricsCollectorNode {
+    fn id(&self) -> &str {
+        "metrics.collector"
+    }
+
+    fn preload(&self, _triggers: &[String], _memory: &Arc<MemoryNode>) {}
+}
+

--- a/backend/src/action/mod.rs
+++ b/backend/src/action/mod.rs
@@ -1,2 +1,3 @@
 pub mod chat_node;
 pub mod scripted_training_node;
+pub mod metrics_collector_node;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,6 +18,7 @@ use tokio::net::TcpListener;
 use tracing::{error, info};
 
 use backend::action::chat_node::EchoChatNode;
+use backend::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
 use backend::action_node::PreloadAction;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::context::context_storage::FileContextStorage;
@@ -798,7 +799,13 @@ async fn main() {
     let _ = std::fs::create_dir_all(&templates_dir);
     let registry = Arc::new(NodeRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
-    let hub = Arc::new(InteractionHub::new(registry.clone(), memory.clone()));
+    let (metrics, mut metrics_rx) = MetricsCollectorNode::channel();
+    let hub = Arc::new(InteractionHub::new(registry.clone(), memory.clone(), metrics));
+    tokio::spawn(async move {
+        while let Some(record) = metrics_rx.recv().await {
+            info!(id=%record.id, "metrics forwarded");
+        }
+    });
     hub.add_auth_token("secret");
     hub.add_trigger_keyword("echo");
     registry.register_action_node(Arc::new(PreloadAction::default()));

--- a/backend/src/memory_node.rs
+++ b/backend/src/memory_node.rs
@@ -97,7 +97,8 @@ impl MemoryNode {
         key.sort();
         let cache_key = key.join("|");
         if let Some(records) = self.preload_cache.write().unwrap().get(&cache_key).cloned() {
-            metrics::histogram!("memory_node_preload_duration_ms", start.elapsed().as_secs_f64() * 1000.0);
+            metrics::histogram!("memory_node_preload_duration_ms")
+                .record(start.elapsed().as_secs_f64() * 1000.0);
             return records;
         }
 
@@ -121,7 +122,8 @@ impl MemoryNode {
             .write()
             .unwrap()
             .put(cache_key, matched.clone());
-        metrics::histogram!("memory_node_preload_duration_ms", start.elapsed().as_secs_f64() * 1000.0);
+        metrics::histogram!("memory_node_preload_duration_ms")
+            .record(start.elapsed().as_secs_f64() * 1000.0);
         matched
     }
 

--- a/backend/tests/analysis_node_metrics_test.rs
+++ b/backend/tests/analysis_node_metrics_test.rs
@@ -1,5 +1,6 @@
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::interaction_hub::InteractionHub;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use std::sync::Arc;
@@ -29,7 +30,8 @@ async fn interaction_hub_records_analysis_metric() {
     let registry = Arc::new(NodeRegistry::new(tmp.path()).expect("registry"));
     registry.register_analysis_node(Arc::new(TestAnalysisNode));
     let memory = Arc::new(MemoryNode::new());
-    let hub = InteractionHub::new(registry, memory);
+    let (metrics, _rx) = MetricsCollectorNode::channel();
+    let hub = InteractionHub::new(registry, memory, metrics);
     hub.add_auth_token("token");
     let cancel = CancellationToken::new();
     let _ = hub

--- a/backend/tests/chat_hub_test.rs
+++ b/backend/tests/chat_hub_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use backend::interaction_hub::InteractionHub;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use backend::action::chat_node::EchoChatNode;
@@ -11,7 +12,8 @@ async fn chat_hub_rejects_empty_message() {
     let templates_dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(NodeRegistry::new(templates_dir.path()).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
-    let hub = InteractionHub::new(registry.clone(), memory);
+    let (metrics, _rx) = MetricsCollectorNode::channel();
+    let hub = InteractionHub::new(registry.clone(), memory, metrics);
     hub.add_auth_token("secret");
     registry.register_chat_node(Arc::new(EchoChatNode::default()));
 

--- a/tests/interaction_hub_cancel_test.rs
+++ b/tests/interaction_hub_cancel_test.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::interaction_hub::InteractionHub;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use tokio_util::sync::CancellationToken;
@@ -43,7 +44,8 @@ async fn interaction_hub_saves_checkpoint_on_cancel() {
     let registry = Arc::new(NodeRegistry::new(dir.path()).unwrap());
     registry.register_analysis_node(Arc::new(CancelNode));
     let memory = Arc::new(MemoryNode::new());
-    let hub = InteractionHub::new(registry.clone(), memory.clone());
+    let (metrics, _rx) = MetricsCollectorNode::channel();
+    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics);
     hub.add_auth_token("t");
     let token = CancellationToken::new();
     token.cancel();

--- a/tests/time_metrics_test.rs
+++ b/tests/time_metrics_test.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::interaction_hub::InteractionHub;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use tokio_util::sync::CancellationToken;
@@ -28,7 +29,8 @@ async fn hub_tracks_time_metrics() {
     let registry = Arc::new(NodeRegistry::new(dir.path()).unwrap());
     registry.register_analysis_node(Arc::new(SleepNode));
     let memory = Arc::new(MemoryNode::new());
-    let hub = InteractionHub::new(registry.clone(), memory.clone());
+    let (metrics, _rx) = MetricsCollectorNode::channel();
+    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics);
     hub.add_auth_token("t");
     let token = CancellationToken::new();
     hub.analyze("sleep", "", "t", &token).await.unwrap();


### PR DESCRIPTION
## Summary
- add MetricsCollectorNode to relay metrics records over a channel
- wire MetricsCollectorNode into InteractionHub and startup
- adjust histogram recording to use `.record`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b08e10c4048323a942a7f703d8dde4