### PR TITLE
Add p95 and p99 duration histograms

### DIFF
--- a/backend/src/action/chat_node.rs
+++ b/backend/src/action/chat_node.rs
@@ -96,7 +96,15 @@ impl ChatNode for EchoChatNode {
 
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
         metrics::histogram!("chat_node_request_duration_ms").record(elapsed_ms);
-        info!(chat_id=%chat_id, session_id=%sid_log, duration_ms=elapsed_ms, "chat response: {}", response);
+        metrics::histogram!("chat_node_request_duration_ms_p95").record(elapsed_ms);
+        metrics::histogram!("chat_node_request_duration_ms_p99").record(elapsed_ms);
+        info!(
+            chat_id=%chat_id,
+            session_id=%sid_log,
+            duration_ms=elapsed_ms,
+            "chat response: {}",
+            response
+        );
         response
     }
 }

--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -448,6 +448,10 @@ impl InteractionHub {
                     }
                     metrics::histogram!("analysis_node_request_duration_ms")
                         .record(elapsed as f64);
+                    metrics::histogram!("analysis_node_request_duration_ms_p95")
+                        .record(elapsed as f64);
+                    metrics::histogram!("analysis_node_request_duration_ms_p99")
+                        .record(elapsed as f64);
                     info!(analysis_id=%id, duration_ms=elapsed, "analysis completed");
                     Some(result)
                 } else {

--- a/backend/src/memory_node.rs
+++ b/backend/src/memory_node.rs
@@ -101,9 +101,17 @@ impl MemoryNode {
         let mut key = triggers.to_vec();
         key.sort();
         let cache_key = key.join("|");
-        if let Some(records) = self.preload_cache.write().unwrap().get(&cache_key).cloned() {
-            metrics::histogram!("memory_node_preload_duration_ms")
-                .record(start.elapsed().as_secs_f64() * 1000.0);
+        if let Some(records) = self
+            .preload_cache
+            .write()
+            .unwrap()
+            .get(&cache_key)
+            .cloned()
+        {
+            let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+            metrics::histogram!("memory_node_preload_duration_ms").record(elapsed);
+            metrics::histogram!("memory_node_preload_duration_ms_p95").record(elapsed);
+            metrics::histogram!("memory_node_preload_duration_ms_p99").record(elapsed);
             return records;
         }
 
@@ -127,8 +135,10 @@ impl MemoryNode {
             .write()
             .unwrap()
             .put(cache_key, matched.clone());
-        metrics::histogram!("memory_node_preload_duration_ms")
-            .record(start.elapsed().as_secs_f64() * 1000.0);
+        let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+        metrics::histogram!("memory_node_preload_duration_ms").record(elapsed);
+        metrics::histogram!("memory_node_preload_duration_ms_p95").record(elapsed);
+        metrics::histogram!("memory_node_preload_duration_ms_p99").record(elapsed);
         matched
     }
 

--- a/backend/tests/analysis_node_metrics_test.rs
+++ b/backend/tests/analysis_node_metrics_test.rs
@@ -41,5 +41,22 @@ async fn interaction_hub_records_analysis_metric() {
         .await
         .expect("analysis");
     let records = data.lock().unwrap();
-    assert!(records.iter().any(|(n, _)| n == "analysis_node_request_duration_ms"), "no histogram recorded");
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "analysis_node_request_duration_ms"),
+        "no histogram recorded"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "analysis_node_request_duration_ms_p95"),
+        "no p95 histogram recorded"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "analysis_node_request_duration_ms_p99"),
+        "no p99 histogram recorded"
+    );
 }

--- a/backend/tests/chat_node_metrics_test.rs
+++ b/backend/tests/chat_node_metrics_test.rs
@@ -57,4 +57,16 @@ async fn chat_node_records_duration_metric() {
         records.iter().any(|(n, _)| n == "chat_node_request_duration_ms"),
         "no histogram recorded"
     );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "chat_node_request_duration_ms_p95"),
+        "no p95 histogram recorded"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "chat_node_request_duration_ms_p99"),
+        "no p99 histogram recorded"
+    );
 }

--- a/backend/tests/memory_node_metrics_test.rs
+++ b/backend/tests/memory_node_metrics_test.rs
@@ -9,5 +9,22 @@ fn memory_node_records_preload_metric() {
     let mem = MemoryNode::new();
     mem.preload_by_trigger(&["test".into()]);
     let records = data.lock().unwrap();
-    assert!(records.iter().any(|(n, _)| n == "memory_node_preload_duration_ms"), "no histogram recorded");
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "memory_node_preload_duration_ms"),
+        "no histogram recorded"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "memory_node_preload_duration_ms_p95"),
+        "no p95 histogram recorded"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|(n, _)| n == "memory_node_preload_duration_ms_p99"),
+        "no p99 histogram recorded"
+    );
 }


### PR DESCRIPTION
## Summary
- track p95 and p99 latency histograms for chat, memory preload, and analysis requests
- extend metrics tests to assert recording of new histograms

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c35b7a708323b4c0cdcd759c2471