### PR TITLE
Add anomaly detection to diagnostics node

### DIFF
--- a/backend/tests/diagnostics_anomaly_test.rs
+++ b/backend/tests/diagnostics_anomaly_test.rs
@@ -1,0 +1,8 @@
+use backend::action::diagnostics_node::detect_anomaly;
+
+#[test]
+fn detect_anomaly_triggers_alert() {
+    let data = vec![1.0, 1.0, 1.0, 10.0];
+    let alert = detect_anomaly(&data);
+    assert!(alert.is_some(), "expected alert for anomaly");
+}


### PR DESCRIPTION
## Summary
- detect anomalies by 3σ rule and emit `Alert`
- log anomalies and provide test coverage

## Testing
- `npm test`
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b0ecbf8d088323a47fd3aa44c5f89c