### PR TITLE
Add anomaly detection and alerting to DiagnosticsNode

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -18,8 +18,8 @@ use tokio::net::TcpListener;
 use tracing::{error, info};
 
 use backend::action::chat_node::EchoChatNode;
-use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::action_node::PreloadAction;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::context::context_storage::FileContextStorage;
@@ -801,7 +801,7 @@ async fn main() {
     let registry = Arc::new(NodeRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, metrics_rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx) = DiagnosticsNode::new(metrics_rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(metrics_rx, 5);
     let hub = Arc::new(InteractionHub::new(
         registry.clone(),
         memory.clone(),

--- a/backend/tests/analysis_node_metrics_test.rs
+++ b/backend/tests/analysis_node_metrics_test.rs
@@ -1,7 +1,7 @@
+use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::interaction_hub::InteractionHub;
-use backend::action::metrics_collector_node::MetricsCollectorNode;
-use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use std::sync::Arc;
@@ -13,15 +13,27 @@ use common::init_recorder;
 struct TestAnalysisNode;
 
 impl AnalysisNode for TestAnalysisNode {
-    fn id(&self) -> &str { "test.analysis" }
-    fn analysis_type(&self) -> &str { "test" }
-    fn status(&self) -> NodeStatus { NodeStatus::Active }
-    fn links(&self) -> &[String] { &[] }
-    fn confidence_threshold(&self) -> f32 { 0.0 }
+    fn id(&self) -> &str {
+        "test.analysis"
+    }
+    fn analysis_type(&self) -> &str {
+        "test"
+    }
+    fn status(&self) -> NodeStatus {
+        NodeStatus::Active
+    }
+    fn links(&self) -> &[String] {
+        &[]
+    }
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
     fn analyze(&self, input: &str, _cancel: &CancellationToken) -> AnalysisResult {
         AnalysisResult::new(self.id(), input, vec![])
     }
-    fn explain(&self) -> String { "test".into() }
+    fn explain(&self) -> String {
+        "test".into()
+    }
 }
 
 #[tokio::test]
@@ -32,7 +44,7 @@ async fn interaction_hub_records_analysis_metric() {
     registry.register_analysis_node(Arc::new(TestAnalysisNode));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
     let hub = InteractionHub::new(registry, memory, metrics, diagnostics);
     hub.add_auth_token("token");
     let cancel = CancellationToken::new();

--- a/backend/tests/chat_hub_test.rs
+++ b/backend/tests/chat_hub_test.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use backend::interaction_hub::InteractionHub;
-use backend::action::metrics_collector_node::MetricsCollectorNode;
+use backend::action::chat_node::EchoChatNode;
 use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::metrics_collector_node::MetricsCollectorNode;
+use backend::context::context_storage::FileContextStorage;
+use backend::interaction_hub::InteractionHub;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
-use backend::action::chat_node::EchoChatNode;
-use backend::context::context_storage::FileContextStorage;
 
 #[tokio::test]
 async fn chat_hub_rejects_empty_message() {
@@ -14,7 +14,7 @@ async fn chat_hub_rejects_empty_message() {
     let registry = Arc::new(NodeRegistry::new(templates_dir.path()).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
     let hub = InteractionHub::new(registry.clone(), memory, metrics, diagnostics);
     hub.add_auth_token("secret");
     registry.register_chat_node(Arc::new(EchoChatNode::default()));

--- a/backend/tests/diagnostics_anomaly_test.rs
+++ b/backend/tests/diagnostics_anomaly_test.rs
@@ -1,8 +1,31 @@
-use backend::action::diagnostics_node::detect_anomaly;
+use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::metrics_collector_node::MetricsRecord;
+use backend::analysis_node::QualityMetrics;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::time::{timeout, Duration};
 
-#[test]
-fn detect_anomaly_triggers_alert() {
-    let data = vec![1.0, 1.0, 1.0, 10.0];
-    let alert = detect_anomaly(&data);
-    assert!(alert.is_some(), "expected alert for anomaly");
+#[tokio::test]
+async fn diagnostics_emits_alert_on_anomaly() {
+    let (tx, rx) = unbounded_channel();
+    let (_node, _dev_rx, mut alert_rx) = DiagnosticsNode::new(rx, 5);
+
+    for (i, val) in [1.0, 1.0, 1.0, 10.0].into_iter().enumerate() {
+        tx.send(MetricsRecord {
+            id: format!("m{}", i),
+            metrics: QualityMetrics {
+                credibility: Some(val),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    }
+
+    let alert = timeout(Duration::from_millis(100), alert_rx.recv())
+        .await
+        .expect("alert expected")
+        .expect("alert");
+    assert!(
+        alert.message.contains("deviates"),
+        "unexpected alert message"
+    );
 }

--- a/backend/tests/diagnostics_node_test.rs
+++ b/backend/tests/diagnostics_node_test.rs
@@ -9,7 +9,7 @@ use tokio::time::{sleep, Duration};
 #[tokio::test]
 async fn diagnostics_attempts_fix_success() {
     let (tx, rx) = unbounded_channel();
-    let (_node, mut dev_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| true));
+    let (_node, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| true));
 
     tx.send(MetricsRecord {
         id: "m1".into(),
@@ -27,7 +27,7 @@ async fn diagnostics_attempts_fix_success() {
 #[tokio::test]
 async fn diagnostics_emits_developer_request_on_failed_fix() {
     let (tx, rx) = unbounded_channel();
-    let (_node, mut dev_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
+    let (_node, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
 
     tx.send(MetricsRecord {
         id: "m2".into(),
@@ -44,4 +44,3 @@ async fn diagnostics_emits_developer_request_on_failed_fix() {
         .expect("developer request");
     assert!(req.description.contains("credibility below threshold"));
 }
-

--- a/backend/tests/io_watcher_test.rs
+++ b/backend/tests/io_watcher_test.rs
@@ -8,7 +8,7 @@ use backend::system::io_watcher::IoWatcher;
 #[tokio::test]
 async fn io_watcher_triggers_diagnostics_on_delay() {
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (_diag, mut dev_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
+    let (_diag, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
 
     let watcher = IoWatcher::new(metrics, 1);
     watcher.record_keyboard_latency(Duration::from_millis(5));
@@ -23,7 +23,7 @@ async fn io_watcher_triggers_diagnostics_on_delay() {
 #[tokio::test]
 async fn io_watcher_ignores_small_latency() {
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (_diag, mut dev_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
+    let (_diag, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
 
     let watcher = IoWatcher::new(metrics, 100);
     watcher.record_keyboard_latency(Duration::from_millis(10));


### PR DESCRIPTION
## Summary
- call `detect_anomaly` during metrics processing to publish `Alert` events with logs
- expose alert channel from `DiagnosticsNode`
- test DiagnosticsNode's alert cycle

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b1238386e48323b7e7261d0e6132cd