### PR TITLE
Bound diagnostics history with fixed window

### DIFF
--- a/backend/tests/diagnostics_anomaly_test.rs
+++ b/backend/tests/diagnostics_anomaly_test.rs
@@ -1,4 +1,4 @@
-use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::diagnostics_node::{DiagnosticsNode, MAX_HISTORY};
 use backend::action::metrics_collector_node::MetricsRecord;
 use backend::analysis_node::QualityMetrics;
 use tokio::sync::mpsc::unbounded_channel;
@@ -9,16 +9,24 @@ async fn diagnostics_emits_alert_on_anomaly() {
     let (tx, rx) = unbounded_channel();
     let (_node, _dev_rx, mut alert_rx) = DiagnosticsNode::new(rx, 5);
 
-    for (i, val) in [1.0, 1.0, 1.0, 10.0].into_iter().enumerate() {
+    for i in 0..MAX_HISTORY {
         tx.send(MetricsRecord {
             id: format!("m{}", i),
             metrics: QualityMetrics {
-                credibility: Some(val),
+                credibility: Some(1.0),
                 ..Default::default()
             },
         })
         .unwrap();
     }
+    tx.send(MetricsRecord {
+        id: format!("m{}", MAX_HISTORY),
+        metrics: QualityMetrics {
+            credibility: Some(10.0),
+            ..Default::default()
+        },
+    })
+    .unwrap();
 
     let alert = timeout(Duration::from_millis(100), alert_rx.recv())
         .await


### PR DESCRIPTION
## Summary
- bound diagnostics credibility history with a VecDeque and limit its size
- use windowed history when checking for anomalies
- extend anomaly test to fill and overflow the history buffer

## Testing
- `cargo test --manifest-path backend/Cargo.toml --test diagnostics_anomaly_test --test diagnostics_node_test`

------
https://chatgpt.com/codex/tasks/task_e_68b12c2d13408323ae78031110cbbdcb