### PR TITLE
feat: add adjustable metrics collector intervals

### DIFF
--- a/backend/src/action/metrics_collector_node.rs
+++ b/backend/src/action/metrics_collector_node.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
@@ -14,16 +15,34 @@ pub struct MetricsRecord {
 }
 
 /// Узел, который принимает записи метрик и пересылает их как сообщения через канал.
-#[derive(Clone)]
 pub struct MetricsCollectorNode {
     tx: UnboundedSender<MetricsRecord>,
+    fast_interval_ms: u64,
+    slow_interval_ms: u64,
+    current_interval_ms: AtomicU64,
 }
 
 impl MetricsCollectorNode {
     /// Создаёт узел и возвращает связанный с ним приёмник для сообщений.
     pub fn channel() -> (Arc<Self>, UnboundedReceiver<MetricsRecord>) {
         let (tx, rx) = unbounded_channel();
-        (Arc::new(Self { tx }), rx)
+        let fast = std::env::var("METRICS_FAST_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1_000);
+        let slow = std::env::var("METRICS_SLOW_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30_000);
+        (
+            Arc::new(Self {
+                tx,
+                fast_interval_ms: fast,
+                slow_interval_ms: slow,
+                current_interval_ms: AtomicU64::new(slow),
+            }),
+            rx,
+        )
     }
 
     /// Отправляет запись метрик для дальнейшей обработки.
@@ -33,6 +52,25 @@ impl MetricsCollectorNode {
         } else {
             metrics::counter!("metrics_collector_node_requests_total").increment(1);
         }
+    }
+
+    /// Текущий интервал опроса в миллисекундах.
+    pub fn get_interval_ms(&self) -> u64 {
+        self.current_interval_ms.load(Ordering::SeqCst)
+    }
+
+    /// Переключает коллектор в «быстрый» режим.
+    pub fn set_fast(&self) {
+        self
+            .current_interval_ms
+            .store(self.fast_interval_ms, Ordering::SeqCst);
+    }
+
+    /// Переключает коллектор в «медленный» режим.
+    pub fn set_slow(&self) {
+        self
+            .current_interval_ms
+            .store(self.slow_interval_ms, Ordering::SeqCst);
     }
 }
 

--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -34,7 +34,6 @@ pub struct InteractionHub {
     requests: RwLock<LruCache<String, String>>,
     idem: Option<IdempotentStore>,
     persist_require_session_id: bool,
-    _host_metrics_interval_ms: u64,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -84,10 +83,6 @@ impl InteractionHub {
         let persist_require_session_id = std::env::var("PERSIST_REQUIRE_SESSION_ID")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
-        let host_metrics_interval_ms = std::env::var("HOST_METRICS_INTERVAL_MS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(30_000);
         let io_watcher_enabled = std::env::var("IO_WATCHER_ENABLED")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
@@ -113,15 +108,15 @@ impl InteractionHub {
             requests: RwLock::new(LruCache::new(NonZeroUsize::new(10_000).unwrap())),
             idem,
             persist_require_session_id,
-            _host_metrics_interval_ms: host_metrics_interval_ms,
         };
 
         // Spawn host metrics polling loop
         let mut host_metrics = HostMetrics::new(metrics.clone());
+        let metrics_poll = metrics.clone();
         tokio::spawn(async move {
-            let mut interval_timer = interval(Duration::from_millis(host_metrics_interval_ms));
             loop {
-                interval_timer.tick().await;
+                let ms = metrics_poll.get_interval_ms();
+                sleep(Duration::from_millis(ms)).await;
                 host_metrics.poll();
             }
         });

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -801,7 +801,8 @@ async fn main() {
     let registry = Arc::new(NodeRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, metrics_rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(metrics_rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) =
+        DiagnosticsNode::new(metrics_rx, 5, metrics.clone());
     let hub = Arc::new(InteractionHub::new(
         registry.clone(),
         memory.clone(),

--- a/backend/tests/analysis_node_metrics_test.rs
+++ b/backend/tests/analysis_node_metrics_test.rs
@@ -44,7 +44,7 @@ async fn interaction_hub_records_analysis_metric() {
     registry.register_analysis_node(Arc::new(TestAnalysisNode));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
     let hub = InteractionHub::new(registry, memory, metrics, diagnostics);
     hub.add_auth_token("token");
     let cancel = CancellationToken::new();

--- a/backend/tests/chat_hub_test.rs
+++ b/backend/tests/chat_hub_test.rs
@@ -14,7 +14,7 @@ async fn chat_hub_rejects_empty_message() {
     let registry = Arc::new(NodeRegistry::new(templates_dir.path()).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
     let hub = InteractionHub::new(registry.clone(), memory, metrics, diagnostics);
     hub.add_auth_token("secret");
     registry.register_chat_node(Arc::new(EchoChatNode::default()));

--- a/backend/tests/diagnostics_anomaly_test.rs
+++ b/backend/tests/diagnostics_anomaly_test.rs
@@ -1,32 +1,29 @@
 use backend::action::diagnostics_node::{DiagnosticsNode, MAX_HISTORY};
-use backend::action::metrics_collector_node::MetricsRecord;
+use backend::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
 use backend::analysis_node::QualityMetrics;
-use tokio::sync::mpsc::unbounded_channel;
 use tokio::time::{timeout, Duration};
 
 #[tokio::test]
 async fn diagnostics_emits_alert_on_anomaly() {
-    let (tx, rx) = unbounded_channel();
-    let (_node, _dev_rx, mut alert_rx) = DiagnosticsNode::new(rx, 5);
+    let (metrics, rx) = MetricsCollectorNode::channel();
+    let (_node, _dev_rx, mut alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
 
     for i in 0..MAX_HISTORY {
-        tx.send(MetricsRecord {
+        metrics.record(MetricsRecord {
             id: format!("m{}", i),
             metrics: QualityMetrics {
                 credibility: Some(1.0),
                 ..Default::default()
             },
-        })
-        .unwrap();
+        });
     }
-    tx.send(MetricsRecord {
+    metrics.record(MetricsRecord {
         id: format!("m{}", MAX_HISTORY),
         metrics: QualityMetrics {
             credibility: Some(10.0),
             ..Default::default()
         },
-    })
-    .unwrap();
+    });
 
     let alert = timeout(Duration::from_millis(100), alert_rx.recv())
         .await

--- a/backend/tests/io_watcher_test.rs
+++ b/backend/tests/io_watcher_test.rs
@@ -8,7 +8,8 @@ use backend::system::io_watcher::IoWatcher;
 #[tokio::test]
 async fn io_watcher_triggers_diagnostics_on_delay() {
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (_diag, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
+    let (_diag, mut dev_rx, _alert_rx) =
+        DiagnosticsNode::new_with_fix(rx, 1, metrics.clone(), Arc::new(|| false));
 
     let watcher = IoWatcher::new(metrics, 1);
     watcher.record_keyboard_latency(Duration::from_millis(5));
@@ -23,7 +24,8 @@ async fn io_watcher_triggers_diagnostics_on_delay() {
 #[tokio::test]
 async fn io_watcher_ignores_small_latency() {
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (_diag, mut dev_rx, _alert_rx) = DiagnosticsNode::new_with_fix(rx, 1, Arc::new(|| false));
+    let (_diag, mut dev_rx, _alert_rx) =
+        DiagnosticsNode::new_with_fix(rx, 1, metrics.clone(), Arc::new(|| false));
 
     let watcher = IoWatcher::new(metrics, 100);
     watcher.record_keyboard_latency(Duration::from_millis(10));

--- a/tests/interaction_hub_cancel_test.rs
+++ b/tests/interaction_hub_cancel_test.rs
@@ -48,7 +48,7 @@ async fn interaction_hub_saves_checkpoint_on_cancel() {
     registry.register_analysis_node(Arc::new(CancelNode));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
     let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics);
     hub.add_auth_token("t");
     let token = CancellationToken::new();

--- a/tests/metrics_interval_test.rs
+++ b/tests/metrics_interval_test.rs
@@ -1,0 +1,52 @@
+use std::time::Duration;
+use backend::action::diagnostics_node::DiagnosticsNode;
+use backend::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
+use backend::analysis_node::QualityMetrics;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn diagnostics_switches_collector_interval() {
+    std::env::set_var("METRICS_SLOW_INTERVAL_MS", "100");
+    std::env::set_var("METRICS_FAST_INTERVAL_MS", "10");
+
+    let (metrics, rx) = MetricsCollectorNode::channel();
+    let (_diag, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 1, metrics.clone());
+
+    assert_eq!(metrics.get_interval_ms(), 100);
+
+    metrics.record(MetricsRecord {
+        id: "ok".into(),
+        metrics: QualityMetrics {
+            credibility: Some(1.0),
+            recency_days: None,
+            demand: None,
+        },
+    });
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(metrics.get_interval_ms(), 100);
+
+    metrics.record(MetricsRecord {
+        id: "bad".into(),
+        metrics: QualityMetrics {
+            credibility: Some(0.0),
+            recency_days: None,
+            demand: None,
+        },
+    });
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(metrics.get_interval_ms(), 10);
+
+    metrics.record(MetricsRecord {
+        id: "ok2".into(),
+        metrics: QualityMetrics {
+            credibility: Some(1.0),
+            recency_days: None,
+            demand: None,
+        },
+    });
+    sleep(Duration::from_millis(20)).await;
+    assert_eq!(metrics.get_interval_ms(), 100);
+
+    std::env::remove_var("METRICS_SLOW_INTERVAL_MS");
+    std::env::remove_var("METRICS_FAST_INTERVAL_MS");
+}

--- a/tests/time_metrics_test.rs
+++ b/tests/time_metrics_test.rs
@@ -45,7 +45,7 @@ async fn hub_tracks_time_metrics() {
     registry.register_analysis_node(Arc::new(SleepNode));
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
-    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5);
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
     let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics);
     hub.add_auth_token("t");
     let token = CancellationToken::new();


### PR DESCRIPTION
## Summary
- add configurable fast/slow polling intervals to `MetricsCollectorNode`
- let `DiagnosticsNode` toggle collector speed based on anomalies
- poll host metrics at dynamically adjusted interval
- test interval switching behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b13a3ca0488323994b2ddb757b71a9