### PR TITLE
Add probe enablement config and skip disabled probes

### DIFF
--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -1,10 +1,13 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 
 /// Configuration for optional components of the backend.
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     pub nervous_system: NervousSystemConfig,
+    #[serde(default)]
+    pub probes: HashMap<String, ProbeConfig>,
 }
 
 /// Settings for the nervous system subsystem.
@@ -25,14 +28,46 @@ impl Default for NervousSystemConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProbeConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for ProbeConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 impl Config {
     /// Load configuration from environment variables.
     pub fn from_env() -> Self {
         let enabled = std::env::var("NERVOUS_SYSTEM_ENABLED")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(true);
+        let host_metrics_enabled = std::env::var("PROBES_HOST_METRICS_ENABLED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        let io_watcher_enabled = std::env::var("PROBES_IO_WATCHER_ENABLED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let mut probes = HashMap::new();
+        probes.insert(
+            "host_metrics".to_string(),
+            ProbeConfig {
+                enabled: host_metrics_enabled,
+            },
+        );
+        probes.insert(
+            "io_watcher".to_string(),
+            ProbeConfig {
+                enabled: io_watcher_enabled,
+            },
+        );
         Self {
             nervous_system: NervousSystemConfig { enabled },
+            probes,
         }
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -810,6 +810,7 @@ async fn main() {
         memory.clone(),
         metrics,
         diagnostics,
+        &cfg,
     ));
     hub.add_auth_token("secret");
     hub.add_trigger_keyword("echo");

--- a/backend/tests/analysis_node_metrics_test.rs
+++ b/backend/tests/analysis_node_metrics_test.rs
@@ -2,6 +2,7 @@ use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::interaction_hub::InteractionHub;
+use backend::config::Config;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use std::sync::Arc;
@@ -45,7 +46,8 @@ async fn interaction_hub_records_analysis_metric() {
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
-    let hub = InteractionHub::new(registry, memory, metrics, diagnostics);
+    let cfg = Config::default();
+    let hub = InteractionHub::new(registry, memory, metrics, diagnostics, &cfg);
     hub.add_auth_token("token");
     let cancel = CancellationToken::new();
     let _ = hub

--- a/backend/tests/chat_hub_test.rs
+++ b/backend/tests/chat_hub_test.rs
@@ -5,6 +5,7 @@ use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::context::context_storage::FileContextStorage;
 use backend::interaction_hub::InteractionHub;
+use backend::config::Config;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 
@@ -15,7 +16,8 @@ async fn chat_hub_rejects_empty_message() {
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
-    let hub = InteractionHub::new(registry.clone(), memory, metrics, diagnostics);
+    let cfg = Config::default();
+    let hub = InteractionHub::new(registry.clone(), memory, metrics, diagnostics, &cfg);
     hub.add_auth_token("secret");
     registry.register_chat_node(Arc::new(EchoChatNode::default()));
 

--- a/tests/interaction_hub_cancel_test.rs
+++ b/tests/interaction_hub_cancel_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
+use backend::config::Config;
 use backend::interaction_hub::InteractionHub;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
@@ -49,7 +50,8 @@ async fn interaction_hub_saves_checkpoint_on_cancel() {
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
-    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics);
+    let cfg = Config::default();
+    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics, &cfg);
     hub.add_auth_token("t");
     let token = CancellationToken::new();
     token.cancel();

--- a/tests/time_metrics_test.rs
+++ b/tests/time_metrics_test.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::action::metrics_collector_node::MetricsCollectorNode;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
+use backend::config::Config;
 use backend::interaction_hub::InteractionHub;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
@@ -46,7 +47,8 @@ async fn hub_tracks_time_metrics() {
     let memory = Arc::new(MemoryNode::new());
     let (metrics, rx) = MetricsCollectorNode::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(rx, 5, metrics.clone());
-    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics);
+    let cfg = Config::default();
+    let hub = InteractionHub::new(registry.clone(), memory.clone(), metrics, diagnostics, &cfg);
     hub.add_auth_token("t");
     let token = CancellationToken::new();
     hub.analyze("sleep", "", "t", &token).await.unwrap();


### PR DESCRIPTION
## Summary
- add `probes.<name>.enabled` configuration with defaults for host metrics and IO watcher
- InteractionHub skips registering disabled probes via the new config
- adjust construction and tests for new config

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b14d9b854c8323a7e1f0e58eaa6d23