### PR TITLE
Require auth token for probe toggle endpoint

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -784,7 +784,12 @@ async fn masking_dry_run(
 async fn toggle_probe(
     State(state): State<AppState>,
     Path(name): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let token = auth_from_headers(&headers).unwrap_or_default();
+    if !state.hub.check_auth(&token) {
+        return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into()));
+    }
     let enabled = state
         .hub
         .toggle_probe(&name)


### PR DESCRIPTION
## Summary
- extract auth token from request headers in `/api/neira/probes/:name/toggle`
- validate token via `InteractionHub::check_auth` and respond with `401` if unauthorized

## Testing
- `cargo test` (backend)
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b15cc2cb588323b99d8543ae4af4db