### PR TITLE
docs: describe disabling monitoring options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@
 - [Структура управления Нейры](docs/system/governance-structure.md)
 - [Мотивация и прогресс Нейры](docs/meta/motivation.md)
 - [Сбор и диагностика метрик](docs/metrics_nodes.md)
+- [Как отключить или ограничить мониторинг](docs/metrics_nodes.md#как-отключить-или-ограничить-мониторинг)
+
+Пример отключения мониторинга в `.env`:
+
+```
+NERVOUS_SYSTEM_ENABLED=false
+PROBES_HOST_METRICS_ENABLED=false
+PROBES_IO_WATCHER_ENABLED=false
+```
+
+Подробнее см. [Как отключить или ограничить мониторинг](docs/metrics_nodes.md#как-отключить-или-ограничить-мониторинг).
 
 ## Оглавление
 

--- a/docs/metrics_nodes.md
+++ b/docs/metrics_nodes.md
@@ -16,6 +16,7 @@
 - [MetricsCollectorNode](#metricscollectornode)
 - [DiagnosticsNode](#diagnosticsnode)
 - [Механизм автоисправления](#механизм-автоисправления)
+- [Как отключить или ограничить мониторинг](#как-отключить-или-ограничить-мониторинг)
 
 ---
 
@@ -43,4 +44,23 @@
 разработчику (`DeveloperRequest`) с описанием проблемы. Это позволяет
 сначала пробовать быстрые исправления, а затем привлекать человека при
 необходимости.
+
+### Как отключить или ограничить мониторинг
+
+Сбор метрик можно полностью отключить или ограничить через переменные
+окружения:
+
+- `NERVOUS_SYSTEM_ENABLED=false` — выключает публикацию всех метрик и
+  эндпоинт `/metrics`.
+- `PROBES_HOST_METRICS_ENABLED=false` — отключает метрики хоста.
+- `PROBES_IO_WATCHER_ENABLED=false` — отключает наблюдатель задержек
+  ввода‑вывода.
+
+Пример файла `.env`:
+
+```
+NERVOUS_SYSTEM_ENABLED=false
+PROBES_HOST_METRICS_ENABLED=false
+PROBES_IO_WATCHER_ENABLED=false
+```
 


### PR DESCRIPTION
## Summary
- document how to disable or limit monitoring
- reference monitoring section in README with .env example

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b162eb559c8323b6f78f2d3710d57d