### PR TITLE
feat: resolve base path via node

### DIFF
--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -100,7 +100,8 @@ impl InteractionHub {
 
         registry.register_action_node(metrics.clone());
         registry.register_action_node(diagnostics.clone());
-        registry.register_action_node(IntegrityCheckerNode::new());
+        registry.register_action_node(Arc::new(crate::system::base_path_resolver::BasePathResolverNode::new()));
+        registry.register_action_node(IntegrityCheckerNode::new(memory.clone()));
 
         let hub = Self {
             registry,

--- a/backend/src/system/base_path_resolver.rs
+++ b/backend/src/system/base_path_resolver.rs
@@ -1,0 +1,49 @@
+use std::path::{PathBuf};
+use std::sync::Arc;
+
+use crate::action_node::ActionNode;
+use crate::analysis_node::AnalysisResult;
+use crate::memory_node::MemoryNode;
+
+/// Resolve the base path of the project by walking up from the current
+/// executable location until a `config/integrity.json` file is found.
+pub fn resolve_base_path() -> Option<PathBuf> {
+    let mut exe = std::env::current_exe().ok()?;
+    exe.pop();
+    loop {
+        if exe.join("config/integrity.json").exists() {
+            return Some(exe);
+        }
+        if !exe.pop() {
+            break;
+        }
+    }
+    None
+}
+
+/// Node that resolves the base path once and stores it in the `MemoryNode`
+/// under the `base_path` key.
+#[derive(Default)]
+pub struct BasePathResolverNode;
+
+impl BasePathResolverNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ActionNode for BasePathResolverNode {
+    fn id(&self) -> &str {
+        "system.base_path_resolver"
+    }
+
+    fn preload(&self, _triggers: &[String], memory: &Arc<MemoryNode>) {
+        if memory.load_checkpoint("base_path").is_some() {
+            return;
+        }
+        if let Some(base) = resolve_base_path() {
+            let result = AnalysisResult::new("base_path", base.display().to_string(), vec![]);
+            memory.save_checkpoint("base_path", &result);
+        }
+    }
+}

--- a/backend/src/system/mod.rs
+++ b/backend/src/system/mod.rs
@@ -16,3 +16,4 @@ pub trait SystemProbe: Send + Sync {
 
 pub mod host_metrics;
 pub mod io_watcher;
+pub mod base_path_resolver;


### PR DESCRIPTION
## Summary
- add BasePathResolverNode to discover project root by searching for `config/integrity.json`
- store discovered path in MemoryNode under `base_path` key
- use stored base path in IntegrityCheckerNode instead of `INTEGRITY_ROOT`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b1754545288323a5423fe4a7021ef6