### PR TITLE
Add InitConfigNode for integrity root setup

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -28,6 +28,7 @@ use backend::interaction_hub::InteractionHub;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use backend::node_template::NodeTemplate;
+use backend::security::init_config_node::InitConfigNode;
 mod http {
     pub mod training_routes;
 }
@@ -818,6 +819,7 @@ async fn main() {
     let _ = std::fs::create_dir_all(&templates_dir);
     let registry = Arc::new(NodeRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryNode::new());
+    registry.register_init_node(Arc::new(InitConfigNode::new()), &memory);
     let (metrics, metrics_rx) = MetricsCollectorNode::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsNode::new(metrics_rx, 5, metrics.clone());
     let hub = Arc::new(InteractionHub::new(

--- a/backend/src/memory_node.rs
+++ b/backend/src/memory_node.rs
@@ -54,6 +54,12 @@ impl MemoryNode {
         }
     }
 
+    pub fn base_path(&self) -> String {
+        std::env::current_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| ".".into())
+    }
+
     pub fn set_cache_capacity(&self, capacity: usize) {
         *self.preload_cache.write().unwrap() =
             LruCache::new(NonZeroUsize::new(capacity.max(1)).unwrap());

--- a/backend/src/node_registry.rs
+++ b/backend/src/node_registry.rs
@@ -11,6 +11,7 @@ use crate::action::chat_node::ChatNode;
 use crate::action::scripted_training_node::ScriptedTrainingNode;
 use crate::action_node::ActionNode;
 use crate::analysis_node::AnalysisNode;
+use crate::memory_node::MemoryNode;
 use crate::node_template::{validate_template, NodeTemplate};
 
 /// Загружает `NodeTemplate` из файла JSON или YAML.
@@ -118,6 +119,11 @@ impl NodeRegistry {
     pub fn register_scripted_training_node(&self) {
         self.register_action_node(Arc::new(ScriptedTrainingNode::default()));
         info!("Registered scripted training node");
+    }
+
+    pub fn register_init_node(&self, node: Arc<dyn ActionNode>, memory: &Arc<MemoryNode>) {
+        node.preload(&[], memory);
+        self.action_nodes.write().unwrap().insert(0, node);
     }
 
     /// Регистрация или обновление узла из файла.

--- a/backend/src/security/init_config_node.rs
+++ b/backend/src/security/init_config_node.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use crate::action_node::ActionNode;
+use crate::memory_node::MemoryNode;
+
+/// Node responsible for initializing configuration variables.
+/// Ensures `INTEGRITY_ROOT` is set based on `MemoryNode` base path.
+pub struct InitConfigNode;
+
+impl InitConfigNode {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn ensure_integrity_root(&self, memory: &Arc<MemoryNode>) {
+        if std::env::var("INTEGRITY_ROOT").is_err() {
+            let base = memory.base_path();
+            std::env::set_var("INTEGRITY_ROOT", base);
+        }
+    }
+}
+
+impl ActionNode for InitConfigNode {
+    fn id(&self) -> &str {
+        "system.init_config"
+    }
+
+    fn preload(&self, _triggers: &[String], memory: &Arc<MemoryNode>) {
+        self.ensure_integrity_root(memory);
+    }
+}

--- a/backend/src/security/mod.rs
+++ b/backend/src/security/mod.rs
@@ -1,1 +1,2 @@
 pub mod integrity_checker_node;
+pub mod init_config_node;


### PR DESCRIPTION
## Summary
- add InitConfigNode to ensure INTEGRITY_ROOT is set from memory base path
- run InitConfigNode before other action nodes via NodeRegistry
- expose MemoryNode base path helper

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b178a251988323ad9eb64cd6134142