### PR TITLE
docs: clarify simplified neira:meta block usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Sizing & Structure
 
 Comments & Language
 - neira:meta blocks with YAML keys in English, free text in Russian.
+- Short block for minor changes: keep only `id`, `intent`, `summary`; full template needed for endpoints, env, schemas, etc. Examples in [COMMENTING.md](COMMENTING.md).
 - Handover: short Russian summary — what, why, how to verify.
 - Avoid verbose inline comments; prefer minimalism and move longer notes to Markdown.
 


### PR DESCRIPTION
## Summary
- document simplified `neira:meta` block for minor changes with required fields
- link to `COMMENTING.md` for short and full templates

## Testing
- `npm test`
- `cargo metadata --locked` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e60c2a708323b2e27d898c0e870f