### PR TITLE
docs: annotate backend nodes with neira meta blocks

### DIFF
--- a/backend/src/action/diagnostics_node.rs
+++ b/backend/src/action/diagnostics_node.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-diagnostics-node
+intent: docs
+summary: |
+  Анализирует поток метрик, фиксирует аномалии и уведомляет разработчика.
+*/
+
 use std::{
     collections::VecDeque,
     sync::{

--- a/backend/src/action/metrics_collector_node.rs
+++ b/backend/src/action/metrics_collector_node.rs
@@ -1,3 +1,14 @@
+/* neira:meta
+id: NEI-20250829-175425-metrics-collector
+intent: docs
+scope: backend/action
+summary: |
+  Сборщик метрик с динамическим интервалом опроса.
+env:
+  - METRICS_NORMAL_INTERVAL_MS
+  - METRICS_LOW_INTERVAL_MS
+*/
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/backend/src/action/scripted_training_node.rs
+++ b/backend/src/action/scripted_training_node.rs
@@ -1,3 +1,15 @@
+/* neira:meta
+id: NEI-20250829-175425-scripted-training
+intent: docs
+scope: backend/action
+summary: |
+  Выполняет сценарии обучения; пути и режим задаются через переменные окружения.
+env:
+  - TRAINING_SCRIPT
+  - TRAINING_PROGRESS
+  - TRAINING_DRY_RUN
+*/
+
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/backend/src/action_node.rs
+++ b/backend/src/action_node.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-action-node
+intent: docs
+summary: |
+  Базовый интерфейс узлов действий и стандартная реализация предзагрузки.
+*/
+
 use std::sync::Arc;
 
 use crate::memory_node::MemoryNode;

--- a/backend/src/analysis_node.rs
+++ b/backend/src/analysis_node.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-analysis-node
+intent: docs
+summary: |
+  Общие структуры и интерфейсы для аналитических узлов.
+*/
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;

--- a/backend/src/memory_node.rs
+++ b/backend/src/memory_node.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-memory-node
+intent: docs
+summary: |
+  Хранит результаты анализа и метаданные, поддерживает предзагрузку и приоритизацию.
+*/
+
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};

--- a/backend/src/node_registry.rs
+++ b/backend/src/node_registry.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-node-registry
+intent: docs
+summary: |
+  Отслеживает файлы шаблонов узлов и регистрирует реализации в системе.
+*/
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/backend/src/node_template.rs
+++ b/backend/src/node_template.rs
@@ -1,3 +1,13 @@
+/* neira:meta
+id: NEI-20250829-175425-node-template
+intent: docs
+scope: backend/core
+summary: |
+  Загружает и валидирует шаблоны узлов по JSON‑схеме.
+env:
+  - NODE_TEMPLATE_SCHEMAS_DIR
+*/
+
 use jsonschema_valid::{self, Config};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};

--- a/backend/src/security/init_config_node.rs
+++ b/backend/src/security/init_config_node.rs
@@ -1,3 +1,13 @@
+/* neira:meta
+id: NEI-20250829-175425-init-config
+intent: docs
+scope: backend/security
+summary: |
+  Инициализирует переменные конфигурации, устанавливая INTEGRITY_ROOT.
+env:
+  - INTEGRITY_ROOT
+*/
+
 use std::sync::Arc;
 
 use crate::action_node::ActionNode;

--- a/backend/src/security/integrity_checker_node.rs
+++ b/backend/src/security/integrity_checker_node.rs
@@ -1,3 +1,14 @@
+/* neira:meta
+id: NEI-20250829-175425-integrity-checker
+intent: docs
+scope: backend/security
+summary: |
+  Проверяет контрольные суммы файлов и отправляет подозрительные в карантин.
+env:
+  - INTEGRITY_CONFIG_PATH
+  - INTEGRITY_CHECK_INTERVAL_MS
+*/
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;

--- a/backend/src/security/quarantine_node.rs
+++ b/backend/src/security/quarantine_node.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-quarantine-node
+intent: docs
+summary: |
+  Переводит подозрительные модули в карантин и активирует безопасный режим.
+*/
+
 use std::sync::Arc;
 
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};

--- a/backend/src/security/safe_mode_controller.rs
+++ b/backend/src/security/safe_mode_controller.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-safe-mode
+intent: docs
+summary: |
+  Контролирует переход системы в безопасный режим.
+*/
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::warn;

--- a/backend/src/system/base_path_resolver.rs
+++ b/backend/src/system/base_path_resolver.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-base-path-resolver
+intent: docs
+summary: |
+  Определяет базовый путь проекта и сохраняет его в памяти.
+*/
+
 use std::path::{PathBuf};
 use std::sync::Arc;
 

--- a/backend/src/system/host_metrics.rs
+++ b/backend/src/system/host_metrics.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-host-metrics
+intent: docs
+summary: |
+  Собирает метрики хоста и пересылает их коллектору.
+*/
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/backend/src/system/io_watcher.rs
+++ b/backend/src/system/io_watcher.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-io-watcher
+intent: docs
+summary: |
+  Отслеживает задержки ввода-вывода и публикует метрики при превышении порога.
+*/
+
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/backend/src/task_scheduler.rs
+++ b/backend/src/task_scheduler.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-task-scheduler
+intent: docs
+summary: |
+  Планировщик задач с очередями по длительности и приоритетам.
+*/
+
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::time::Instant;

--- a/backend/src/trigger_detector.rs
+++ b/backend/src/trigger_detector.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-175425-trigger-detector
+intent: docs
+summary: |
+  Выявляет ключевые слова и запускает микрорефлексы.
+*/
+
 use std::sync::RwLock;
 
 type ReflexAction = Box<dyn Fn() + Send + Sync>;


### PR DESCRIPTION
## Summary
- document roles and env hooks for backend nodes via neira:meta blocks
- cover action, security, system utilities, scheduler and trigger detector

## Testing
- `cargo test` (fails: no method named `json` in `SubscriberBuilder`)


------
https://chatgpt.com/codex/tasks/task_e_68b1e9173c6083238a2c75cf1c05f639