### PR TITLE
chore: add neira metadata to examples and scripts

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-180333-frontend-init
+intent: docs
+summary: |
+  Инициализирует PWA и возвращает приветствие.
+*/
+
 export function init() {
   return 'Hello PWA';
 }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-180333-frontend-main
+intent: docs
+summary: |
+  Пример простого PWA с формой и обработкой сообщений.
+*/
+
 /* global navigator, window, document, fetch, console */
 import './style.css';
 

--- a/scripts/check-duplicates.sh
+++ b/scripts/check-duplicates.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+: <<'neira:meta'
+id: NEI-20250829-180333-check-duplicates
+intent: docs
+summary: |
+  Скрипт проверяет наличие дублированных версий crate в зависимостях Cargo.
+neira:meta
+
 set -euo pipefail
 
 # Detect duplicate crate versions in Cargo dependencies.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
+/* neira:meta
+id: NEI-20250829-180333-ts-example
+intent: docs
+summary: |
+  Пример экспортирует функцию приветствия.
+*/
+
 export const hello = (): string => 'Hello, Neira!';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+/* neira:meta
+id: NEI-20250829-180333-rs-greet
+intent: docs
+summary: |
+  Демонстрационная функция возвращает приветствие.
+*/
+
 pub fn greet() -> &'static str {
     "Hello, Neira!"
 }


### PR DESCRIPTION
## Summary
- document sample greeting functions and PWA files with neira meta blocks
- note duplicate-crate check script with neira meta block

## Testing
- `npm test`
- `cargo test -q`
- `scripts/check-duplicates.sh`
- `rg -n "neira:meta" src frontend/src scripts`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb34ec28832382481c887d011a2f