### PR TITLE
fix: clean warnings and enable json logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,6 +2030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
@@ -2038,12 +2047,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2015,6 +2015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
@@ -2023,12 +2032,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,7 +14,7 @@ dotenvy = "0.15"
 jsonschema-valid = "0.5.2"
 once_cell = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] } # direct file logging without tracing-appender
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] } # direct file logging without tracing-appender
 
 
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "f71cebe41e4c12735b1d19ca804428d4ff7d905d", package = "tracing-appender" }

--- a/backend/src/context/context_storage.rs
+++ b/backend/src/context/context_storage.rs
@@ -133,11 +133,14 @@ pub fn mask_preview(
 pub fn load_mask_preset(name: &str) -> Result<Vec<String>, String> {
     let dir = std::env::var("MASK_PRESETS_DIR").unwrap_or_else(|_| "config/mask_presets".into());
     let path = std::path::Path::new(&dir).join(format!("{}.txt", name));
-    let data = std::fs::read_to_string(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let data =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
     let mut out = Vec::new();
     for line in data.lines() {
         let lt = line.trim();
-        if lt.is_empty() || lt.starts_with('#') { continue; }
+        if lt.is_empty() || lt.starts_with('#') {
+            continue;
+        }
         out.push(lt.to_string());
     }
     Ok(out)
@@ -225,21 +228,6 @@ impl FileContextStorage {
                 cfg,
                 tx: None,
             }
-        }
-    }
-
-    fn session_path(&self, chat_id: &str, session_id: &str) -> PathBuf {
-        let dir = self.root.join(chat_id);
-        if self.cfg.daily_rotation {
-            let date = format!(
-                "{:04}{:02}{:02}",
-                Utc::now().year(),
-                Utc::now().month(),
-                Utc::now().day()
-            );
-            dir.join(format!("{}-{}.ndjson", session_id, date))
-        } else {
-            dir.join(format!("{}.ndjson", session_id))
         }
     }
 }
@@ -365,21 +353,6 @@ impl FileContextStorage {
         });
         Ok(())
     }
-    fn extract_keywords(content: &str) -> Vec<String> {
-        content
-            .split(|c: char| !c.is_alphanumeric())
-            .filter_map(|w| {
-                let lw = w.to_lowercase();
-                if lw.len() >= 4 {
-                    Some(lw)
-                } else {
-                    None
-                }
-            })
-            .take(16)
-            .collect()
-    }
-
     pub fn mask_content_custom(content: &str, custom: &[Regex]) -> String {
         let mut s = content.to_string();
         // Mask emails
@@ -455,7 +428,7 @@ fn write_one(
     cfg: &Config,
     chat: &str,
     sess: &str,
-    mut msg: ChatMessage,
+    msg: ChatMessage,
 ) -> Result<(), String> {
     let dir = root.join(chat);
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- clean up unused context storage helpers
- drop unused diagnostics field in InteractionHub
- enable JSON logging in tracing setup

## Testing
- `cargo check -p backend`
- `cargo clippy --all-targets` *(fails: unresolved imports and outdated tests)*
- `cargo test` *(fails: outdated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f4839a648323aa193cf7d02ee3a5