### PR TITLE
refactor(validate_template): simplify format detection

### DIFF
--- a/backend/src/bin/validate_template.rs
+++ b/backend/src/bin/validate_template.rs
@@ -1,3 +1,9 @@
+/* neira:meta
+id: NEI-20250829-195800-validate-template
+intent: refactor
+summary: |
+  Заменили match на if let для определения формата шаблона.
+*/
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -18,13 +24,13 @@ fn run() -> Result<(), String> {
         .nth(1)
         .ok_or_else(|| "usage: cargo run --bin validate_template <path>".to_string())?;
     let path = PathBuf::from(path);
-    let content = fs::read_to_string(&path)
-        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
-    let value: Value = match path.extension().and_then(|e| e.to_str()) {
-        Some("yaml") | Some("yml") => {
-            serde_yaml::from_str(&content).map_err(|e| format!("invalid YAML: {e}"))?
-        }
-        _ => serde_json::from_str(&content).map_err(|e| format!("invalid JSON: {e}"))?,
+    let content =
+        fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let value: Value = if let Some("yaml") | Some("yml") = path.extension().and_then(|e| e.to_str())
+    {
+        serde_yaml::from_str(&content).map_err(|e| format!("invalid YAML: {e}"))?
+    } else {
+        serde_json::from_str(&content).map_err(|e| format!("invalid JSON: {e}"))?
     };
     node_template::validate_template(&value).map_err(|errs| errs.join("\n"))?;
     println!("Template is valid");


### PR DESCRIPTION
## Summary
- simplify template format detection in `validate_template` using `if let`

## Testing
- `cargo clippy --manifest-path backend/Cargo.toml -- -D warnings` *(fails: clippy::single-match, clippy::manual-contains, ...)*
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b2060810a083238ae2f3b5478c119a