### PR TITLE
fix: simplify equality check in eval_asserts

### DIFF
--- a/backend/src/action/scripted_training_node.rs
+++ b/backend/src/action/scripted_training_node.rs
@@ -363,7 +363,7 @@ impl ScriptedTrainingNode {
                 return Err(format!("jsonpath '{}' no match", a.path));
             }
             if let Some(eq) = &a.equals {
-                if !res.iter().any(|v| *v == eq) {
+                if !res.contains(&eq) {
                     return Err(format!("jsonpath '{}' equals failed", a.path));
                 }
             }


### PR DESCRIPTION
## Summary
- streamline assertion equality check using `Vec::contains`

## Testing
- `cargo clippy --no-deps`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b2678cd7a88323ab08c5d0729e389e