### PR TITLE
fix: simplify keyword presence check

### DIFF
--- a/backend/src/context/context_storage.rs
+++ b/backend/src/context/context_storage.rs
@@ -570,7 +570,7 @@ fn append_messages_and_update_index(
         .unwrap_or_default();
     let new_kws = super_keywords(&msgs.last().map(|m| m.content.as_str()).unwrap_or(""));
     for k in new_kws {
-        if !kws.iter().any(|x| x.as_str() == Some(&k)) && kws.len() < 32 {
+        if !kws.contains(&serde_json::json!(k)) && kws.len() < 32 {
             kws.push(serde_json::json!(k));
         }
     }


### PR DESCRIPTION
## Summary
- use `contains` to avoid manual iteration when adding keywords

## Testing
- `cargo clippy -p backend -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b26ca5e35883239fe5ecb556690ad3