### PR TITLE
chore: add pre-commit hooks and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# neira:meta
+# id: NEI-20250214-120000-pre-commit
+# intent: chore
+# summary: |
+#   Добавлен конфиг pre-commit с форматированием и линтерами.
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: npx eslint
+        language: system
+        types_or: [javascript, jsx, ts, tsx]

--- a/README.md
+++ b/README.md
@@ -446,6 +446,20 @@ time_slice_ms = 10
 
 - [Интеграция IDE](docs/guides/ide-integration.md)
 
+<!-- neira:meta
+id: NEI-20250214-120100-pre-commit-doc
+intent: docs
+summary: |
+  Добавлены инструкции по установке локальных pre-commit хуков.
+-->
+### Pre-commit
+
+Установите локальные хуки для форматирования и линтинга:
+
+```bash
+pre-commit install
+```
+
 ## Схемы
 
 JSON‑схемы расположены в каталоге [schemas](schemas). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.


### PR DESCRIPTION
## Summary
- configure pre-commit with formatters and linters
- document local pre-commit hook installation

## Testing
- `pre-commit run --files .pre-commit-config.yaml README.md`
- `npm test`
- `cargo test` *(fails: terminated after long compile)*

------
https://chatgpt.com/codex/tasks/task_e_68b27e8fcdac83239cb48fab98a377f7