### PR TITLE
feat(context): adapt storage limits based on disk telemetry

### DIFF
--- a/backend/ENV.md
+++ b/backend/ENV.md
@@ -1,3 +1,9 @@
+<!-- neira:meta
+id: NEI-20250915-adaptive-storage-backend-env
+intent: docs
+summary: Контекстное хранилище теперь подбирает лимиты по диску; переменные можно переопределить.
+-->
+
 Backend environment variables
 
 Note
@@ -5,8 +11,8 @@ Note
 - Этот файл сохраняет обзор и пример `.env`, но при расхождениях доверяйте справочнику.
 
 - CONTEXT_DIR: base dir for chat history (default: context)
-- CONTEXT_MAX_LINES: max lines kept in a file before trimming (default: 500)
-- CONTEXT_MAX_BYTES: max bytes per file before trimming (default: 1_000_000)
+- CONTEXT_MAX_LINES: max lines kept in a file before trimming (default: adaptive via storage_metrics.json)
+- CONTEXT_MAX_BYTES: max bytes per file before trimming (default: adaptive via storage_metrics.json)
 - CONTEXT_DAILY_ROTATION: if true, rotate files daily with -YYYYMMDD suffix (default: true)
 - CONTEXT_ARCHIVE_GZ: if true, gzip previous days’ files (default: true)
 - CONTEXT_FLUSH_MS: buffered write flush interval in ms; 0 disables buffering (default: 0)
@@ -22,6 +28,10 @@ Note
 - INTEGRITY_ROOT: base dir for integrity config and files (default: current working directory; set explicitly if the service runs outside `backend/`)
 - INTEGRITY_CONFIG_PATH: path to integrity config file relative to INTEGRITY_ROOT or absolute (default: config/integrity.json)
 - INTEGRITY_CHECK_INTERVAL_MS: integrity check interval in ms (default: 60000)
+
+When `CONTEXT_MAX_LINES` or `CONTEXT_MAX_BYTES` are not set, the service
+estimates safe limits based on disk space and message size telemetry. Results
+are stored in `<CONTEXT_DIR>/storage_metrics.json` and updated over time.
 
 Idempotency and persist policy
 - IDEMPOTENT_PERSIST: enable persistent idempotency storage for request_id (default: false)

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -1,10 +1,16 @@
+<!-- neira:meta
+id: NEI-20250915-adaptive-storage-env-docs
+intent: docs
+summary: Обновлено описание CONTEXT_MAX_LINES/CONTEXT_MAX_BYTES: адаптивные лимиты со storage_metrics.json.
+-->
+
 # ENV Reference (Истина)
 
 | Ключ | Тип | По умолчанию | Где используется | Влияние |
 |---|---|---|---|---|
 | CONTEXT_DIR | string | context | backend context storage | База для истории чатов |
-| CONTEXT_MAX_LINES | int | 500 | storage trim | Ограничение строк при тримме |
-| CONTEXT_MAX_BYTES | int | 1_000_000 | storage trim | Ограничение размера файла |
+| CONTEXT_MAX_LINES | int | adaptive | storage trim | Ограничение строк (автоподбор, можно переопределить) |
+| CONTEXT_MAX_BYTES | int | adaptive | storage trim | Ограничение размера файла (автоподбор, можно переопределить) |
 | CONTEXT_DAILY_ROTATION | bool | true | storage rotation | Ротация по дням |
 | CONTEXT_ARCHIVE_GZ | bool | true | storage rotation | Архивирование .gz прошлых дней |
 | CONTEXT_FLUSH_MS | int | 0 | storage buffering | Буферизованная запись, 0=выкл |
@@ -30,6 +36,10 @@
 | SSE_WARN_AFTER_MS | int | 60000 | SSE | Варнинг при долгом стриме |
 | NERVOUS_SYSTEM_JSON_LOGS | bool | false | logging | JSON‑логи включить |
 | MASK_PRESETS_DIR | string | config/mask_presets | masking | Каталог пресетов масок |
+
+Лимиты `CONTEXT_MAX_LINES` и `CONTEXT_MAX_BYTES` при отсутствии в окружении
+оцениваются автоматически на основе свободного места диска и средней длины
+сообщения. Метрики сохраняются и обновляются в `<CONTEXT_DIR>/storage_metrics.json`.
 
 ### Anti‑Idle System
 | Ключ | Тип | По умолчанию | Где используется | Влияние |


### PR DESCRIPTION
## Summary
- derive context storage max_lines and max_bytes from disk space and message telemetry
- persist storage metrics in storage_metrics.json for adaptive updates
- document adaptive defaults and env overrides

## Testing
- `cargo clippy -p backend -- -D warnings`
- `cd backend && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b2843345dc832380e3d3a1fcc5eb52