### PR TITLE
feat(queue): adjust threshold recomputation

### DIFF
--- a/backend/tests/queue_config_test.rs
+++ b/backend/tests/queue_config_test.rs
@@ -2,9 +2,15 @@ use backend::analysis_node::AnalysisResult;
 use backend::memory_node::MemoryNode;
 use backend::queue_config::QueueConfig;
 use backend::task_scheduler::Queue;
+use std::sync::Mutex;
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
 #[test]
 fn queue_config_recalculates() {
+    let _guard = ENV_MUTEX.lock().unwrap();
+    std::env::remove_var("ANALYSIS_QUEUE_FAST_MS");
+    std::env::remove_var("ANALYSIS_QUEUE_LONG_MS");
     std::env::set_var("ANALYSIS_QUEUE_RECALC_MIN", "2");
     let memory = MemoryNode::new();
 
@@ -24,18 +30,21 @@ fn queue_config_recalculates() {
     memory.update_time("c", 2000);
 
     let q = cfg.classify(1500, &memory);
-    assert_eq!(q, Queue::Long);
+    assert_eq!(q, Queue::Standard);
     assert_eq!(cfg.thresholds(), (500, 2000));
     std::env::remove_var("ANALYSIS_QUEUE_RECALC_MIN");
+    std::env::remove_var("ANALYSIS_QUEUE_FAST_MS");
+    std::env::remove_var("ANALYSIS_QUEUE_LONG_MS");
 }
 
 #[test]
 fn queue_config_env_override() {
+    let _guard = ENV_MUTEX.lock().unwrap();
     std::env::set_var("ANALYSIS_QUEUE_FAST_MS", "150");
     std::env::set_var("ANALYSIS_QUEUE_LONG_MS", "1500");
     let memory = MemoryNode::new();
 
-    let mut r = AnalysisResult::new("a", "", vec![]);
+    let r = AnalysisResult::new("a", "", vec![]);
     memory.push_metrics(&r);
     memory.update_time("a", 50);
 


### PR DESCRIPTION
## Summary
- compute queue thresholds with as few as two latency samples
- respect a configurable `min_samples` during initial and subsequent recalculations
- stabilize queue config tests and verify new threshold behavior

## Testing
- `cargo clippy -p backend -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b28c308afc8323a43e3acbc1b3dade