### PR TITLE
fix: align voice organ spec with analysis speak adapter

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -222,5 +222,5 @@ Consistency & Taxonomy
 - В snapshot включить templates,state,models; журнал событий с diff dry‑run/спецификаций.
 
 5) Voice v1 pipeline
-- Узлы: `analysis.text_normalize.v1`, `analysis.text_to_phonemes.v1`, `action.speak_adapter.v1`.
+- Узлы: `analysis.text_normalize.v1`, `analysis.text_to_phonemes.v1`, `analysis.speak_adapter.v1`.
 - Орган: `organ.voice.v1` (normalize→phonemes→speak_adapter); dry‑run→canary; метрики organ_build_* и factory_*.

--- a/examples/factory/voice-v1/organ.voice.v1.json
+++ b/examples/factory/voice-v1/organ.voice.v1.json
@@ -1,14 +1,17 @@
 {
   "id": "organ.voice.v1",
   "version": "0.1.0",
-  "kind": "organ",
-  "pipeline": [
-    { "node": "analysis.text_normalize.v1" },
-    { "node": "analysis.text_to_phonemes.v1" },
-    { "node": "action.speak_adapter.v1" }
+  "roles": [
+    "text_normalize",
+    "text_to_phonemes",
+    "speak_adapter"
   ],
-  "metadata": { "schema": "v1" },
-  "policy": {
+  "nodes": [
+    "analysis.text_normalize.v1",
+    "analysis.text_to_phonemes.v1",
+    "analysis.speak_adapter.v1"
+  ],
+  "policies": {
     "stage": "draft",
     "hitl": true
   }

--- a/scripts/factory-shim/index.mjs
+++ b/scripts/factory-shim/index.mjs
@@ -5,7 +5,7 @@
  * summary: Внешний CLI-оркестратор фабрики с режимом LLM-агента (локальная модель), безопасные команды dry-run/create/approve/rollback.
  */
 
-/* eslint-disable no-console */
+/* global fetch, process, console */
 import fs from 'node:fs';
 
 // Minimal Node.js (>=18) CLI without external deps.
@@ -29,7 +29,7 @@ async function http(method, path, body) {
   });
   const text = await res.text();
   let json;
-  try { json = text ? JSON.parse(text) : {}; } catch (_) { json = { raw: text }; }
+  try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
   if (!res.ok) {
     const err = new Error(`HTTP ${res.status} ${res.statusText}`);
     err.status = res.status;
@@ -195,7 +195,7 @@ function toolsSpecString() {
 }
 
 function safeJsonParse(s) {
-  try { return JSON.parse(s); } catch (_) { return null; }
+  try { return JSON.parse(s); } catch { return null; }
 }
 
 async function cmdAgent(args) {


### PR DESCRIPTION
## Summary
- use `analysis.speak_adapter.v1` in Voice organ spec and roadmap
- declare global variables in factory shim to satisfy lint

## Testing
- `npx ajv-cli validate -s schemas/organ-template.schema.json -d examples/factory/voice-v1/organ.voice.v1.json --spec=draft2020`
- `npm test`
- `npm run lint`
- `cargo metadata --locked`
- `cargo clippy`
- `scripts/check-duplicates.sh`
- `cargo test` (pass)
- `cargo test --manifest-path backend/Cargo.toml` (fails: queue_config_test)


------
https://chatgpt.com/codex/tasks/task_e_68b3e62b13ac8323abc965ce958ea701