### PR TITLE
feat: validate organ specs and document node ids

### DIFF
--- a/docs/node-ids.md
+++ b/docs/node-ids.md
@@ -1,0 +1,7 @@
+# Node IDs
+
+## organ.voice.v1
+
+- analysis.text_normalize.v1
+- analysis.text_to_phonemes.v1
+- analysis.speak_adapter.v1

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -222,5 +222,5 @@ Consistency & Taxonomy
 - В snapshot включить templates,state,models; журнал событий с diff dry‑run/спецификаций.
 
 5) Voice v1 pipeline
-- Узлы: `analysis.text_normalize.v1`, `analysis.text_to_phonemes.v1`, `action.speak_adapter.v1`.
+- Узлы: `analysis.text_normalize.v1`, `analysis.text_to_phonemes.v1`, `analysis.speak_adapter.v1`.
 - Орган: `organ.voice.v1` (normalize→phonemes→speak_adapter); dry‑run→canary; метрики organ_build_* и factory_*.

--- a/examples/factory/voice-v1/organ.voice.v1.json
+++ b/examples/factory/voice-v1/organ.voice.v1.json
@@ -1,14 +1,23 @@
 {
   "id": "organ.voice.v1",
   "version": "0.1.0",
-  "kind": "organ",
-  "pipeline": [
-    { "node": "analysis.text_normalize.v1" },
-    { "node": "analysis.text_to_phonemes.v1" },
-    { "node": "action.speak_adapter.v1" }
+  "roles": [
+    "text_normalize",
+    "text_to_phonemes",
+    "speak_adapter"
   ],
-  "metadata": { "schema": "v1" },
-  "policy": {
+  "nodes": [
+    "analysis.text_normalize.v1",
+    "analysis.text_to_phonemes.v1",
+    "analysis.speak_adapter.v1"
+  ],
+  "channels": [
+    {
+      "name": "speech",
+      "nodes": ["analysis.speak_adapter.v1"]
+    }
+  ],
+  "policies": {
     "stage": "draft",
     "hitl": true
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
+        "ajv": "^8.17.1",
         "eslint": "^9.34.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
@@ -622,6 +623,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -641,6 +659,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.34.0",
@@ -1617,16 +1642,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2439,6 +2464,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2481,6 +2523,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -2728,6 +2777,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -3997,9 +4063,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -4964,6 +5030,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "backend:dev": "cargo run --manifest-path backend/Cargo.toml",
     "backend:test": "cargo test --manifest-path backend/Cargo.toml",
     "frontend:dev": "npm run dev --prefix frontend",
-    "frontend:test": "npm test --prefix frontend"
+    "frontend:test": "npm test --prefix frontend",
+    "check-examples": "node scripts/validate-examples.mjs",
+    "generate-node-docs": "node scripts/generate-node-docs.mjs"
   },
   "devDependencies": {
     "@types/jest": "^29.5.11",
@@ -21,7 +23,8 @@
     "lint-staged": "^16.1.5",
     "prettier": "^3.6.2",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "ajv": "^8.17.1"
   },
   "overrides": {
     "p-limit": "^2.3.0",
@@ -44,7 +47,8 @@
     ]
   },
   "lint-staged": {
-    "*.{ts,md}": "prettier --write",
+    "*.ts": ["prettier --write", "eslint --fix", "jest --bail --findRelatedTests"],
+    "*.md": "prettier --write",
     "*.rs": "cargo fmt --"
   }
 }

--- a/schemas/organ-template.schema.json
+++ b/schemas/organ-template.schema.json
@@ -9,7 +9,27 @@
     "version": { "type": "string", "default": "0.1.0" },
     "roles": { "type": "array", "items": { "type": "string" } },
     "nodes": { "type": "array", "items": { "type": "string" } },
-    "channels": { "type": "array", "items": { "type": "string" } },
+    "channels": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "nodes": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["name", "nodes"]
+      },
+      "examples": [
+        [
+          {
+            "name": "speech",
+            "nodes": ["analysis.speak_adapter.v1"]
+          }
+        ]
+      ]
+    },
     "policies": { "type": "object" }
   },
   "required": ["id", "roles", "nodes"]

--- a/scripts/factory-shim/index.mjs
+++ b/scripts/factory-shim/index.mjs
@@ -5,7 +5,7 @@
  * summary: Внешний CLI-оркестратор фабрики с режимом LLM-агента (локальная модель), безопасные команды dry-run/create/approve/rollback.
  */
 
-/* eslint-disable no-console */
+/* global fetch, process, console */
 import fs from 'node:fs';
 
 // Minimal Node.js (>=18) CLI without external deps.
@@ -29,7 +29,7 @@ async function http(method, path, body) {
   });
   const text = await res.text();
   let json;
-  try { json = text ? JSON.parse(text) : {}; } catch (_) { json = { raw: text }; }
+  try { json = text ? JSON.parse(text) : {}; } catch { json = { raw: text }; }
   if (!res.ok) {
     const err = new Error(`HTTP ${res.status} ${res.statusText}`);
     err.status = res.status;
@@ -195,7 +195,7 @@ function toolsSpecString() {
 }
 
 function safeJsonParse(s) {
-  try { return JSON.parse(s); } catch (_) { return null; }
+  try { return JSON.parse(s); } catch { return null; }
 }
 
 async function cmdAgent(args) {

--- a/scripts/generate-node-docs.mjs
+++ b/scripts/generate-node-docs.mjs
@@ -1,0 +1,38 @@
+/* neira:meta
+id: NEI-20250101-000003-generate-node-docs
+intent: docs
+summary: |
+  Generate markdown listing organs with their node identifiers.
+*/
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+async function collectJsonFiles(dir) {
+  const dirents = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map((dirent) => {
+      const res = path.resolve(dir, dirent.name);
+      if (dirent.isDirectory()) return collectJsonFiles(res);
+      if (dirent.isFile() && dirent.name.startsWith('organ.') && dirent.name.endsWith('.json'))
+        return [res];
+      return [];
+    })
+  );
+  return files.flat();
+}
+
+async function main() {
+  const files = await collectJsonFiles('examples');
+  const lines = ['# Node IDs', ''];
+  for (const file of files) {
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    lines.push(`## ${data.id}`, '');
+    for (const node of data.nodes ?? []) {
+      lines.push(`- ${node}`);
+    }
+    lines.push('');
+  }
+  await fs.writeFile('docs/node-ids.md', lines.join('\n'));
+}
+
+main();

--- a/scripts/validate-examples.mjs
+++ b/scripts/validate-examples.mjs
@@ -1,0 +1,47 @@
+/* neira:meta
+id: NEI-20250101-000002-validate-examples
+intent: utility
+summary: |
+  Validate all example organ specs against OrganTemplate schema.
+*/
+/* global console, process */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import Ajv from 'ajv/dist/2020.js';
+
+async function collectJsonFiles(dir) {
+  const dirents = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map((dirent) => {
+      const res = path.resolve(dir, dirent.name);
+      if (dirent.isDirectory()) return collectJsonFiles(res);
+      if (dirent.isFile() && dirent.name.startsWith('organ.') && dirent.name.endsWith('.json'))
+        return [res];
+      return [];
+    })
+  );
+  return files.flat();
+}
+
+async function main() {
+  const schema = JSON.parse(
+    await fs.readFile('schemas/organ-template.schema.json', 'utf8')
+  );
+  const ajv = new Ajv({ strict: false });
+  const validate = ajv.compile(schema);
+  const files = await collectJsonFiles('examples');
+  let ok = true;
+  for (const file of files) {
+    const data = JSON.parse(await fs.readFile(file, 'utf8'));
+    if (!validate(data)) {
+      console.error(`\u274c  ${file}`);
+      console.error(validate.errors);
+      ok = false;
+    } else {
+      console.log(`\u2705  ${file}`);
+    }
+  }
+  if (!ok) process.exit(1);
+}
+
+main();

--- a/tests/organ-template.test.ts
+++ b/tests/organ-template.test.ts
@@ -1,0 +1,22 @@
+/* neira:meta
+id: NEI-20250101-000001-organ-template-test
+intent: test
+summary: |
+  Validate example organs against schema.
+*/
+import { readFileSync } from 'node:fs';
+import Ajv from 'ajv/dist/2020.js';
+
+describe('organ template examples', () => {
+  const schema = JSON.parse(readFileSync('schemas/organ-template.schema.json', 'utf8'));
+  const ajv = new Ajv({ strict: false });
+  const validate = ajv.compile(schema);
+
+  const example = JSON.parse(
+    readFileSync('examples/factory/voice-v1/organ.voice.v1.json', 'utf8')
+  );
+
+  it('voice-v1 organ conforms to schema', () => {
+    expect(validate(example)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- define structured `channels` in organ template schema and voice example
- add CLI to validate examples and generate node ID docs
- run lint/tests only on touched files via lint-staged

## Testing
- `npx ajv-cli validate -s schemas/organ-template.schema.json -d examples/factory/voice-v1/organ.voice.v1.json --spec=draft2020`
- `npm test`
- `npm run lint`
- `npm run check-examples`
- `npm run generate-node-docs`
- `cargo metadata --locked`
- `cargo clippy`
- `scripts/check-duplicates.sh`
- `cargo test`
- `cargo test --manifest-path backend/Cargo.toml` (fails: queue_config_test)


------
https://chatgpt.com/codex/tasks/task_e_68b3e62b13ac8323abc965ce958ea701