### PR TITLE
fix(scripts): respect NEIRA_BIND_ADDR host

### DIFF
--- a/scripts/backend-dev.mjs
+++ b/scripts/backend-dev.mjs
@@ -2,17 +2,22 @@
 /* neira:meta
 id: NEI-20250831-backend-dev
 intent: utility
-summary: Запуск backend с выбором порта через NEIRA_BIND_ADDR.
+summary: Запуск backend с выбором адреса и порта через NEIRA_BIND_ADDR.
 */
 /* global process */
 import { spawn } from "node:child_process";
 
 const args = process.argv.slice(2);
-let port = process.env.npm_config_port || "3000";
+const addr = process.env.NEIRA_BIND_ADDR ?? "127.0.0.1:3000";
+const sep = addr.lastIndexOf(":");
+const host = sep !== -1 ? addr.slice(0, sep) : addr;
+const defaultPort = sep !== -1 ? addr.slice(sep + 1) : "3000";
+
+let port = process.env.npm_config_port || defaultPort;
 const idx = args.indexOf("--port");
 if (idx !== -1 && args[idx + 1]) port = args[idx + 1];
 
-const env = { ...process.env, NEIRA_BIND_ADDR: `0.0.0.0:${port}` };
+const env = { ...process.env, NEIRA_BIND_ADDR: `${host}:${port}` };
 const child = spawn("cargo", ["run", "--manifest-path", "backend/Cargo.toml"], {
   stdio: "inherit",
   env,


### PR DESCRIPTION
## Summary
- preserve host portion of NEIRA_BIND_ADDR when choosing backend dev port

## Testing
- `npm run lint`
- `npm test`
- ⚠️ `npm run backend:dev` (fails: spawn cargo ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_68b42b43e7248323a1bfc8e4fd297699