### PR TITLE
fix: bind backend dev server to all interfaces

### DIFF
--- a/scripts/backend-dev.mjs
+++ b/scripts/backend-dev.mjs
@@ -2,13 +2,14 @@
 /* neira:meta
 id: NEI-20250831-backend-dev
 intent: utility
-summary: Запуск backend с выбором адреса и порта через NEIRA_BIND_ADDR.
+summary: Запуск backend с выбором адреса и порта через NEIRA_BIND_ADDR,
+  по умолчанию "0.0.0.0:3000".
 */
 /* global process */
 import { spawn } from "node:child_process";
 
 const args = process.argv.slice(2);
-const addr = process.env.NEIRA_BIND_ADDR ?? "127.0.0.1:3000";
+const addr = process.env.NEIRA_BIND_ADDR ?? "0.0.0.0:3000";
 const sep = addr.lastIndexOf(":");
 const host = sep !== -1 ? addr.slice(0, sep) : addr;
 const defaultPort = sep !== -1 ? addr.slice(sep + 1) : "3000";


### PR DESCRIPTION
## Summary
- default backend dev script to `0.0.0.0:3000`
- document default bind address in meta comment

## Testing
- `npm run lint`
- `npm test`
- `npm run backend:test`
- `npm run backend:dev` *(fails: cargo run could not determine which binary to run)*
- `cargo run --bin backend --manifest-path backend/Cargo.toml`
- `curl -I 0.0.0.0:3000`

------
https://chatgpt.com/codex/tasks/task_e_68b4313467ac83238afcdc77cc4db740