### PR TITLE
feat: add staged organ builder

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,3 +1,8 @@
+<!-- neira:meta
+id: NEI-20251010-organ-builder-cap-doc
+intent: docs
+summary: добавлены примеры активации орган-билдера.
+-->
 # Neira Capabilities & Feature Gates
 
 Purpose
@@ -62,8 +67,11 @@ capabilities:
   organs_builder:
     state: experimental
     notes: Сборка органов из OrganTemplate (dry‑run→canary→experimental)
-    signals: [organ_build_attempts_total, organ_build_failures_total]
+    signals: [organ_build_attempts_total, organ_build_failures_total, organ_build_status_queries_total, organ_build_duration_ms, organ_status_not_found_total]
 ```
+
+### Пример
+- «Разблокируй organs_builder» — включает капабилити на уровне experimental
 
 ## Persona & Control (дополнение)
 

--- a/backend/ENV.md
+++ b/backend/ENV.md
@@ -9,6 +9,11 @@ id: NEI-20250922-analysis-queue-env
 intent: docs
 summary: Добавлены переменные управления порогами очередей анализа.
 -->
+<!-- neira:meta
+id: NEI-20251010-organ-builder-env
+intent: docs
+summary: описаны переменные ORGANS_BUILDER_ENABLED и ORGANS_BUILDER_TEMPLATES_DIR.
+-->
 
 Backend environment variables
 
@@ -58,6 +63,8 @@ SSE and logging
 
 Masking presets
 - MASK_PRESETS_DIR: directory with regex preset files named <preset>.txt (default: config/mask_presets)
+- ORGANS_BUILDER_ENABLED: enable organ builder module (default: false)
+- ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates (default: organ_templates)
 
 ## Автоматическое определение `INTEGRITY_ROOT`
 
@@ -95,3 +102,5 @@ INDEX_COMPACT_INTERVAL_MS=300000
 SSE_WARN_AFTER_MS=60000
 NERVOUS_SYSTEM_JSON_LOGS=false
 MASK_PRESETS_DIR=./config/mask_presets
+ORGANS_BUILDER_ENABLED=false
+ORGANS_BUILDER_TEMPLATES_DIR=./organ_templates

--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -12,8 +12,9 @@ use crate::action::diagnostics_node::DiagnosticsNode;
 use crate::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
 use crate::config::Config;
 use crate::context::context_storage::{ChatMessage, ContextStorage, Role};
+use crate::factory::{FabricatorNode, FactoryService, SelectorNode};
 use crate::idempotent_store::IdempotentStore;
-use crate::factory::{FactoryService, FabricatorNode, SelectorNode};
+use crate::organ_builder::{OrganBuilder, OrganState};
 use crate::security::integrity_checker_node::IntegrityCheckerNode;
 use crate::security::quarantine_node::QuarantineNode;
 use crate::security::safe_mode_controller::SafeModeController;
@@ -77,6 +78,7 @@ pub struct InteractionHub {
     anti_idle_enabled: AtomicBool,
     // Factory service (adapter-only for now)
     factory: Arc<FactoryService>,
+    organ_builder: Arc<OrganBuilder>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -176,11 +178,23 @@ impl InteractionHub {
             cancels: RwLock::new(std::collections::HashMap::new()),
             analysis_cancels: RwLock::new(std::collections::HashMap::new()),
             traces: RwLock::new(std::collections::HashMap::new()),
-            trace_enabled: AtomicBool::new(std::env::var("TRACE_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false)),
-            trace_max_events: std::env::var("TRACE_MAX_EVENTS").ok().and_then(|v| v.parse().ok()).unwrap_or(200),
+            trace_enabled: AtomicBool::new(
+                std::env::var("TRACE_ENABLED")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false),
+            ),
+            trace_max_events: std::env::var("TRACE_MAX_EVENTS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(200),
             last_activity_secs: std::sync::atomic::AtomicU64::new(now_secs),
-            anti_idle_enabled: AtomicBool::new(std::env::var("ANTI_IDLE_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true)),
+            anti_idle_enabled: AtomicBool::new(
+                std::env::var("ANTI_IDLE_ENABLED")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(true),
+            ),
             factory: FactoryService::new(),
+            organ_builder: OrganBuilder::new(),
         };
 
         // Spawn host metrics polling loop
@@ -208,8 +222,10 @@ impl InteractionHub {
         }
 
         // Register factory helper nodes (Adapter + Selector)
-        hub.registry.register_action_node(Arc::new(FabricatorNode::default()));
-        hub.registry.register_analysis_node(Arc::new(SelectorNode::new(hub.registry.clone())));
+        hub.registry
+            .register_action_node(Arc::new(FabricatorNode::default()));
+        hub.registry
+            .register_analysis_node(Arc::new(SelectorNode::new(hub.registry.clone())));
 
         hub
     }
@@ -244,14 +260,20 @@ impl InteractionHub {
     /// Отметить пользовательскую активность (chat/analysis/API вызовы)
     pub fn mark_activity(&self) {
         use std::time::{SystemTime, UNIX_EPOCH};
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         self.last_activity_secs.store(now, Ordering::Relaxed);
     }
 
     /// Сколько секунд прошло с момента последней зафиксированной активности
     pub fn seconds_since_last_activity(&self) -> u64 {
         use std::time::{SystemTime, UNIX_EPOCH};
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let last = self.last_activity_secs.load(Ordering::Relaxed);
         now.saturating_sub(last)
     }
@@ -265,16 +287,57 @@ impl InteractionHub {
     }
 
     // Factory service accessors (adapter-only for now)
-    pub fn factory_is_adapter_enabled(&self) -> bool { self.factory.is_adapter_enabled() }
-    pub fn factory_dry_run(&self, tpl: &crate::node_template::NodeTemplate) -> serde_json::Value { self.factory.dry_run(tpl) }
-    pub fn factory_create(&self, backend: &str, tpl: &crate::node_template::NodeTemplate) -> crate::factory::FactoryRecord { self.factory.create_record(backend, tpl) }
-    pub fn factory_advance(&self, id: &str) -> Option<crate::factory::FabricationState> { self.factory.advance(id) }
-    pub fn factory_disable(&self, id: &str) -> Option<crate::factory::FabricationState> { self.factory.disable(id) }
-    pub fn factory_rollback(&self, id: &str) -> Option<crate::factory::FabricationState> { self.factory.rollback(id) }
-    pub fn factory_counts(&self) -> (usize, usize) { self.factory.counts() }
+    pub fn factory_is_adapter_enabled(&self) -> bool {
+        self.factory.is_adapter_enabled()
+    }
+    pub fn factory_dry_run(&self, tpl: &crate::node_template::NodeTemplate) -> serde_json::Value {
+        self.factory.dry_run(tpl)
+    }
+    pub fn factory_create(
+        &self,
+        backend: &str,
+        tpl: &crate::node_template::NodeTemplate,
+    ) -> crate::factory::FactoryRecord {
+        self.factory.create_record(backend, tpl)
+    }
+    pub fn factory_advance(&self, id: &str) -> Option<crate::factory::FabricationState> {
+        self.factory.advance(id)
+    }
+    pub fn factory_disable(&self, id: &str) -> Option<crate::factory::FabricationState> {
+        self.factory.disable(id)
+    }
+    pub fn factory_rollback(&self, id: &str) -> Option<crate::factory::FabricationState> {
+        self.factory.rollback(id)
+    }
+    pub fn factory_counts(&self) -> (usize, usize) {
+        self.factory.counts()
+    }
 
-    pub fn is_trace_enabled(&self) -> bool { self.trace_enabled.load(Ordering::Relaxed) }
-    pub fn set_trace_enabled(&self, enabled: bool) { self.trace_enabled.store(enabled, Ordering::Relaxed) }
+    // Organ builder accessors
+    pub fn organ_builder_enabled(&self) -> bool {
+        self.organ_builder.is_enabled()
+    }
+    /* neira:meta
+    id: NEI-20251010-organ-builder-update
+    intent: code
+    summary: добавлены методы обновления и получения статусов органа.
+    */
+    pub fn organ_build(&self, tpl: serde_json::Value) -> String {
+        self.organ_builder.start_build(tpl)
+    }
+    pub fn organ_status(&self, id: &str) -> Option<OrganState> {
+        self.organ_builder.status(id)
+    }
+    pub fn organ_update_status(&self, id: &str, st: OrganState) -> Option<OrganState> {
+        self.organ_builder.update_status(id, st)
+    }
+
+    pub fn is_trace_enabled(&self) -> bool {
+        self.trace_enabled.load(Ordering::Relaxed)
+    }
+    pub fn set_trace_enabled(&self, enabled: bool) {
+        self.trace_enabled.store(enabled, Ordering::Relaxed)
+    }
 
     /// Отмена всех активных SSE-стримов. Возвращает количество отменённых.
     pub fn cancel_all_streams(&self) -> usize {
@@ -309,7 +372,7 @@ impl InteractionHub {
     }
 
     pub fn backpressure_sum(&self) -> u64 {
-        let (a,b,c) = self.queue_lengths();
+        let (a, b, c) = self.queue_lengths();
         (a + b + c) as u64
     }
 
@@ -318,8 +381,13 @@ impl InteractionHub {
     }
 
     pub fn trace_event(&self, request_id: Option<&str>, event: &str, data: serde_json::Value) {
-        if !self.is_trace_enabled() { return; }
-        let id = match request_id { Some(s) if !s.is_empty() => s.to_string(), _ => return };
+        if !self.is_trace_enabled() {
+            return;
+        }
+        let id = match request_id {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => return,
+        };
         let ev = json!({
             "ts_ms": (std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() as i128),
             "event": event,
@@ -327,14 +395,20 @@ impl InteractionHub {
         });
         let mut store = self.traces.write().unwrap();
         let list = store.entry(id).or_insert_with(Vec::new);
-        if list.len() >= self.trace_max_events { list.remove(0); }
+        if list.len() >= self.trace_max_events {
+            list.remove(0);
+        }
         list.push(ev);
     }
 
     pub fn trace_dump(&self, request_id: &str) -> Option<serde_json::Value> {
-        if !self.is_trace_enabled() { return None; }
+        if !self.is_trace_enabled() {
+            return None;
+        }
         let store = self.traces.read().unwrap();
-        store.get(request_id).map(|v| json!({"request_id": request_id, "events": v}))
+        store
+            .get(request_id)
+            .map(|v| json!({"request_id": request_id, "events": v}))
     }
 
     fn authorize(&self, token: &str) -> bool {
@@ -689,12 +763,28 @@ impl InteractionHub {
         });
 
         // Watchdog timeouts from ENV (soft/hard) with per-node overrides
-        fn env_ms(key: &str, default_ms: u64) -> u64 { std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default_ms) }
+        fn env_ms(key: &str, default_ms: u64) -> u64 {
+            std::env::var(key)
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(default_ms)
+        }
         let base_soft = env_ms("WATCHDOG_REASONING_SOFT_MS", 30_000);
         let base_hard = env_ms("WATCHDOG_REASONING_HARD_MS", cfg.global_time_budget);
         // per-node override: WATCHDOG_SOFT_MS_<ID>, WATCHDOG_HARD_MS_<ID> (ID upcased, non-alnum -> '_')
-        let mut up = id.chars().map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_uppercase() } else { '_' }).collect::<String>();
-        if up.is_empty() { up = "DEFAULT".into(); }
+        let mut up = id
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() {
+                    c.to_ascii_uppercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+        if up.is_empty() {
+            up = "DEFAULT".into();
+        }
         let soft_key = format!("WATCHDOG_SOFT_MS_{}", up);
         let hard_key = format!("WATCHDOG_HARD_MS_{}", up);
         let soft_ms = env_ms(&soft_key, base_soft);
@@ -873,11 +963,7 @@ impl InteractionHub {
     }
 
     // Analysis cancellation registry
-    pub fn register_analysis_cancel(
-        &self,
-        id: &str,
-        token: tokio_util::sync::CancellationToken,
-    ) {
+    pub fn register_analysis_cancel(&self, id: &str, token: tokio_util::sync::CancellationToken) {
         self.analysis_cancels
             .write()
             .unwrap()

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -16,10 +16,11 @@ pub mod trigger_detector;
 // duplicates removed
 
 // Global hub reference (optional), used for lightweight signals like Anti-Idle activity marks
-use std::sync::{Arc, OnceLock, RwLock};
 use crate::interaction_hub::InteractionHub;
+use std::sync::{Arc, OnceLock, RwLock};
 
 pub static GLOBAL_HUB: OnceLock<RwLock<Option<Arc<InteractionHub>>>> = OnceLock::new();
 
 pub mod factory;
+pub mod organ_builder;
 pub mod policy;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,13 +9,13 @@ use axum::{
     Json, Router,
 };
 use backend::context::context_storage::set_runtime_mask_config;
-use std::io::Write;
-use regex::Regex;
 use dotenvy::dotenv;
 use futures_core::stream::Stream;
 use metrics_exporter_prometheus::PrometheusBuilder;
+use regex::Regex;
 use std::convert::Infallible;
-use std::sync::atomic::{AtomicU64, Ordering, AtomicBool};
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::net::TcpListener;
 use tracing::{error, info};
 
@@ -26,11 +26,11 @@ use backend::action_node::PreloadAction;
 use backend::analysis_node::{AnalysisNode, AnalysisResult, NodeStatus};
 use backend::config::Config;
 use backend::context::context_storage::FileContextStorage;
+use backend::factory::{AdapterBackend, FabricationState, NodeTemplateAdapter};
 use backend::interaction_hub::InteractionHub;
 use backend::memory_node::MemoryNode;
 use backend::node_registry::NodeRegistry;
 use backend::node_template::NodeTemplate;
-use backend::factory::{FabricationState, NodeTemplateAdapter, AdapterBackend};
 use backend::policy::{Capability, PolicyEngine};
 use backend::security::init_config_node::InitConfigNode;
 mod http {
@@ -111,9 +111,13 @@ async fn factory_dryrun(
     Json(body): Json<FactoryBody>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
     let backend = body.backend.as_deref().unwrap_or("adapter");
-    if backend != "adapter" { return Err(axum::http::StatusCode::BAD_REQUEST); }
+    if backend != "adapter" {
+        return Err(axum::http::StatusCode::BAD_REQUEST);
+    }
     let pe = PolicyEngine::new();
-    if let Err(_e) = pe.require_capability(&state.hub, Capability::FactoryAdapter) { return Err(axum::http::StatusCode::FORBIDDEN); }
+    if let Err(_e) = pe.require_capability(&state.hub, Capability::FactoryAdapter) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
     Ok(Json(state.hub.factory_dry_run(&body.tpl)))
 }
 
@@ -122,12 +126,20 @@ async fn factory_create(
     Json(body): Json<FactoryBody>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
     let backend = body.backend.as_deref().unwrap_or("adapter");
-    if backend != "adapter" { return Err(axum::http::StatusCode::BAD_REQUEST); }
+    if backend != "adapter" {
+        return Err(axum::http::StatusCode::BAD_REQUEST);
+    }
     let pe = PolicyEngine::new();
-    if let Err(_e) = pe.require_capability(&state.hub, Capability::FactoryAdapter) { return Err(axum::http::StatusCode::FORBIDDEN); }
-    let adapter = NodeTemplateAdapter{ tpl: &body.tpl };
-    adapter.validate().map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
-    adapter.register(&state.hub.registry).map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
+    if let Err(_e) = pe.require_capability(&state.hub, Capability::FactoryAdapter) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    let adapter = NodeTemplateAdapter { tpl: &body.tpl };
+    adapter
+        .validate()
+        .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
+    adapter
+        .register(&state.hub.registry)
+        .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
     let rec = state.hub.factory_create(backend, &body.tpl);
     Ok(Json(serde_json::json!({"id": rec.id, "state": "draft"})))
 }
@@ -137,7 +149,9 @@ async fn factory_approve(
     Path(fid): Path<String>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
     match state.hub.factory_advance(&fid) {
-        Some(st) => Ok(Json(serde_json::json!({"id": fid, "state": format_state(st)}))),
+        Some(st) => Ok(Json(
+            serde_json::json!({"id": fid, "state": format_state(st)}),
+        )),
         None => Err(axum::http::StatusCode::NOT_FOUND),
     }
 }
@@ -147,7 +161,9 @@ async fn factory_disable(
     Path(fid): Path<String>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
     match state.hub.factory_disable(&fid) {
-        Some(st) => Ok(Json(serde_json::json!({"id": fid, "state": format_state(st)}))),
+        Some(st) => Ok(Json(
+            serde_json::json!({"id": fid, "state": format_state(st)}),
+        )),
         None => Err(axum::http::StatusCode::NOT_FOUND),
     }
 }
@@ -157,8 +173,107 @@ async fn factory_rollback(
     Path(fid): Path<String>,
 ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
     match state.hub.factory_rollback(&fid) {
-        Some(st) => Ok(Json(serde_json::json!({"id": fid, "state": format_state(st)}))),
+        Some(st) => Ok(Json(
+            serde_json::json!({"id": fid, "state": format_state(st)}),
+        )),
         None => Err(axum::http::StatusCode::NOT_FOUND),
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct OrganBuildReq {
+    organ_template: serde_json::Value,
+    #[serde(default)]
+    dryrun: bool,
+}
+
+async fn organ_build(
+    State(state): State<AppState>,
+    Json(body): Json<OrganBuildReq>,
+) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    let pe = PolicyEngine::new();
+    if let Err(_e) = pe.require_capability(&state.hub, Capability::OrgansBuilder) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    if body.dryrun {
+        metrics::counter!("organ_build_dryrun_total").increment(1);
+        info!("organ build dry-run");
+        return Ok(Json(
+            serde_json::json!({"organ_id": serde_json::Value::Null, "state": "dry_run"}),
+        ));
+    }
+    let id = state.hub.organ_build(body.organ_template);
+    Ok(Json(serde_json::json!({"organ_id": id, "state": "draft"})))
+}
+
+async fn organ_status(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    let pe = PolicyEngine::new();
+    if let Err(_e) = pe.require_capability(&state.hub, Capability::OrgansBuilder) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    match state.hub.organ_status(&id) {
+        Some(st) => {
+            info!(organ_id = %id, "organ status queried");
+            Ok(Json(
+                serde_json::json!({"id": id, "state": format_organ_state(st)}),
+            ))
+        }
+        None => {
+            metrics::counter!("organ_status_not_found_total").increment(1);
+            tracing::warn!(organ_id = %id, reason = "not_found", "organ status missing");
+            Err(axum::http::StatusCode::NOT_FOUND)
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct OrganStatusUpdateReq {
+    state: String,
+}
+
+/* neira:meta
+id: NEI-20251010-organ-status-update-route
+intent: code
+summary: добавлен POST /organs/:id/status для ручного изменения стадии.
+*/
+async fn organ_update_status(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<OrganStatusUpdateReq>,
+) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    let pe = PolicyEngine::new();
+    if let Err(_e) = pe.require_capability(&state.hub, Capability::OrgansBuilder) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    let st = match body.state.as_str() {
+        "draft" => backend::organ_builder::OrganState::Draft,
+        "canary" => backend::organ_builder::OrganState::Canary,
+        "experimental" => backend::organ_builder::OrganState::Experimental,
+        "stable" => backend::organ_builder::OrganState::Stable,
+        "failed" => backend::organ_builder::OrganState::Failed,
+        _ => return Err(axum::http::StatusCode::BAD_REQUEST),
+    };
+    match state.hub.organ_update_status(&id, st) {
+        Some(st) => {
+            info!(organ_id = %id, new_state = %body.state, "organ status updated");
+            Ok(Json(
+                serde_json::json!({"id": id, "state": format_organ_state(st)}),
+            ))
+        }
+        None => Err(axum::http::StatusCode::NOT_FOUND),
+    }
+}
+
+fn format_organ_state(st: backend::organ_builder::OrganState) -> &'static str {
+    match st {
+        backend::organ_builder::OrganState::Draft => "draft",
+        backend::organ_builder::OrganState::Canary => "canary",
+        backend::organ_builder::OrganState::Experimental => "experimental",
+        backend::organ_builder::OrganState::Stable => "stable",
+        backend::organ_builder::OrganState::Failed => "failed",
     }
 }
 
@@ -200,14 +315,32 @@ async fn analyze_request(
     state.hub.mark_activity();
     // backpressure throttle for analysis
     let bp = state.hub.backpressure_sum();
-    let bp_high = std::env::var("BACKPRESSURE_HIGH_WATERMARK").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(100);
-    let bp_sleep = std::env::var("BACKPRESSURE_THROTTLE_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(0);
-    if bp_sleep > 0 && bp > bp_high { metrics::counter!("throttle_events_total").increment(1); tokio::time::sleep(std::time::Duration::from_millis(bp_sleep)).await; }
-    if std::env::var("AUTO_BACKOFF_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false) && bp > bp_high {
-        let max_backoff = std::env::var("BP_MAX_BACKOFF_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(200);
+    let bp_high = std::env::var("BACKPRESSURE_HIGH_WATERMARK")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    let bp_sleep = std::env::var("BACKPRESSURE_THROTTLE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+    if bp_sleep > 0 && bp > bp_high {
+        metrics::counter!("throttle_events_total").increment(1);
+        tokio::time::sleep(std::time::Duration::from_millis(bp_sleep)).await;
+    }
+    if std::env::var("AUTO_BACKOFF_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+        && bp > bp_high
+    {
+        let max_backoff = std::env::var("BP_MAX_BACKOFF_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(200);
         let over = (bp - bp_high) as f64 / (bp_high.max(1) as f64);
         let extra = ((bp_sleep as f64) * over).min(max_backoff as f64) as u64;
-        if extra > 0 { tokio::time::sleep(std::time::Duration::from_millis(extra)).await; }
+        if extra > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(extra)).await;
+        }
     }
     let req_id = headers
         .get("x-request-id")
@@ -218,12 +351,19 @@ async fn analyze_request(
             req.auth = h;
         }
     }
-    state.hub.trace_event(req_id.as_deref(), "analysis.start", serde_json::json!({"id": req.id, "len": req.input.len()}));
+    state.hub.trace_event(
+        req_id.as_deref(),
+        "analysis.start",
+        serde_json::json!({"id": req.id, "len": req.input.len()}),
+    );
     let token = tokio_util::sync::CancellationToken::new();
     state.hub.register_analysis_cancel(&req.id, token.clone());
     // per-request budget override via JSON or header x-reasoning-budget-ms
     if req.budget_ms.is_none() {
-        if let Some(h) = headers.get("x-reasoning-budget-ms").and_then(|v| v.to_str().ok()) {
+        if let Some(h) = headers
+            .get("x-reasoning-budget-ms")
+            .and_then(|v| v.to_str().ok())
+        {
             req.budget_ms = h.parse::<u64>().ok();
         }
     }
@@ -231,7 +371,10 @@ async fn analyze_request(
         let t = token.clone();
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
-            if !t.is_cancelled() { t.cancel(); metrics::counter!("analysis_budget_hits_total").increment(1); }
+            if !t.is_cancelled() {
+                t.cancel();
+                metrics::counter!("analysis_budget_hits_total").increment(1);
+            }
         });
     }
     let result = state
@@ -240,7 +383,11 @@ async fn analyze_request(
         .await
         .ok_or(axum::http::StatusCode::UNAUTHORIZED)?;
     state.hub.remove_analysis_cancel(&req.id);
-    state.hub.trace_event(req_id.as_deref(), "analysis.done", serde_json::json!({"id": req.id}));
+    state.hub.trace_event(
+        req_id.as_deref(),
+        "analysis.done",
+        serde_json::json!({"id": req.id}),
+    );
     Ok(Json(result))
 }
 
@@ -302,14 +449,32 @@ async fn chat_request(
     state.hub.mark_activity();
     // backpressure throttle for chat
     let bp = state.hub.backpressure_sum();
-    let bp_high = std::env::var("BACKPRESSURE_HIGH_WATERMARK").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(100);
-    let bp_sleep = std::env::var("BACKPRESSURE_THROTTLE_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(0);
-    if bp_sleep > 0 && bp > bp_high { metrics::counter!("throttle_events_total").increment(1); tokio::time::sleep(std::time::Duration::from_millis(bp_sleep)).await; }
-    if std::env::var("AUTO_BACKOFF_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false) && bp > bp_high {
-        let max_backoff = std::env::var("BP_MAX_BACKOFF_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(200);
+    let bp_high = std::env::var("BACKPRESSURE_HIGH_WATERMARK")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(100);
+    let bp_sleep = std::env::var("BACKPRESSURE_THROTTLE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0);
+    if bp_sleep > 0 && bp > bp_high {
+        metrics::counter!("throttle_events_total").increment(1);
+        tokio::time::sleep(std::time::Duration::from_millis(bp_sleep)).await;
+    }
+    if std::env::var("AUTO_BACKOFF_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+        && bp > bp_high
+    {
+        let max_backoff = std::env::var("BP_MAX_BACKOFF_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(200);
         let over = (bp - bp_high) as f64 / (bp_high.max(1) as f64);
         let extra = ((bp_sleep as f64) * over).min(max_backoff as f64) as u64;
-        if extra > 0 { tokio::time::sleep(std::time::Duration::from_millis(extra)).await; }
+        if extra > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(extra)).await;
+        }
     }
     if req.auth.trim().is_empty() {
         if let Some(h) = auth_from_headers(&headers) {
@@ -317,7 +482,11 @@ async fn chat_request(
         }
     }
     let used_context = req.session_id.is_some();
-    state.hub.trace_event(req.request_id.as_deref(), "chat.start", serde_json::json!({"node_id": req.node_id, "chat_id": req.chat_id, "persist": req.persist}));
+    state.hub.trace_event(
+        req.request_id.as_deref(),
+        "chat.start",
+        serde_json::json!({"node_id": req.node_id, "chat_id": req.chat_id, "persist": req.persist}),
+    );
     let out = state
         .hub
         .chat(
@@ -334,9 +503,10 @@ async fn chat_request(
         )
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e))?;
-    let (limit, remaining, used, key) = state
-        .hub
-        .rate_info(&req.auth, &req.chat_id, req.session_id.as_deref());
+    let (limit, remaining, used, key) =
+        state
+            .hub
+            .rate_info(&req.auth, &req.chat_id, req.session_id.as_deref());
     let mut h = axum::http::HeaderMap::new();
     h.insert(
         "X-RateLimit-Limit",
@@ -528,8 +698,15 @@ async fn new_session(
             req.auth = h;
         }
     }
-    if !state.hub.check_auth(&req.auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-    if !state.hub.check_scope(&req.auth, backend::interaction_hub::Scope::Write) { return Err(axum::http::StatusCode::FORBIDDEN); }
+    if !state.hub.check_auth(&req.auth) {
+        return Err(axum::http::StatusCode::UNAUTHORIZED);
+    }
+    if !state
+        .hub
+        .check_scope(&req.auth, backend::interaction_hub::Scope::Write)
+    {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
     let id = gen_session_id(req.prefix.as_deref());
     metrics::counter!("sessions_created_total").increment(1);
     metrics::gauge!("sessions_active").increment(1.0);
@@ -555,8 +732,15 @@ async fn delete_session(
             q.auth = h;
         }
     }
-    if !state.hub.check_auth(&q.auth) { return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into())); }
-    if !state.hub.check_scope(&q.auth, backend::interaction_hub::Scope::Write) { return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into())); }
+    if !state.hub.check_auth(&q.auth) {
+        return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into()));
+    }
+    if !state
+        .hub
+        .check_scope(&q.auth, backend::interaction_hub::Scope::Write)
+    {
+        return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into()));
+    }
     let base = std::env::var("CONTEXT_DIR").unwrap_or_else(|_| "context".into());
     let dir = std::path::Path::new(&base).join(&chat_id);
     if let Ok(rd) = std::fs::read_dir(&dir) {
@@ -611,8 +795,15 @@ async fn rename_session(
             req.auth = h;
         }
     }
-    if !state.hub.check_auth(&req.auth) { return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into())); }
-    if !state.hub.check_scope(&req.auth, backend::interaction_hub::Scope::Write) { return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into())); }
+    if !state.hub.check_auth(&req.auth) {
+        return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into()));
+    }
+    if !state
+        .hub
+        .check_scope(&req.auth, backend::interaction_hub::Scope::Write)
+    {
+        return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into()));
+    }
     if req.new_session_id.trim().is_empty() {
         return Err((
             axum::http::StatusCode::BAD_REQUEST,
@@ -672,7 +863,11 @@ async fn chat_stream(
     // Anti-Idle: mark user activity
     state.hub.mark_activity();
     let used_context = req.session_id.is_some();
-    state.hub.trace_event(req.request_id.as_deref(), "chat.stream.start", serde_json::json!({"node_id": req.node_id, "chat_id": req.chat_id}));
+    state.hub.trace_event(
+        req.request_id.as_deref(),
+        "chat.stream.start",
+        serde_json::json!({"node_id": req.node_id, "chat_id": req.chat_id}),
+    );
     let out = state
         .hub
         .chat(
@@ -689,11 +884,21 @@ async fn chat_stream(
         )
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_REQUEST, e))?;
-    let (limit, remaining, used, key) = state.hub.rate_info(&req.auth, &req.chat_id, req.session_id.as_deref());
+    let (limit, remaining, used, key) =
+        state
+            .hub
+            .rate_info(&req.auth, &req.chat_id, req.session_id.as_deref());
     let cancel = tokio_util::sync::CancellationToken::new();
-    if let Some(ref sid) = req.session_id { state.hub.register_stream_cancel(&req.chat_id, sid, cancel.clone()); }
+    if let Some(ref sid) = req.session_id {
+        state
+            .hub
+            .register_stream_cancel(&req.chat_id, sid, cancel.clone());
+    }
     metrics::gauge!("sse_active").increment(1.0);
-    let warn_after_ms = std::env::var("SSE_WARN_AFTER_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(60_000);
+    let warn_after_ms = std::env::var("SSE_WARN_AFTER_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(60_000);
     let hub_for_trace = state.hub.clone();
     let hub_for_idle = state.hub.clone();
     let req_id2 = req.request_id.clone();
@@ -786,7 +991,11 @@ async fn chat_stream(
 }
 
 #[derive(serde::Deserialize)]
-struct CancelStream { auth: String, chat_id: String, session_id: String }
+struct CancelStream {
+    auth: String,
+    chat_id: String,
+    session_id: String,
+}
 
 async fn cancel_stream(
     State(state): State<AppState>,
@@ -802,7 +1011,9 @@ async fn cancel_stream(
         return Err(axum::http::StatusCode::FORBIDDEN);
     }
     let ok = state.hub.cancel_stream(&req.chat_id, &req.session_id);
-    if ok { metrics::counter!("sse_cancellations_total").increment(1); }
+    if ok {
+        metrics::counter!("sse_cancellations_total").increment(1);
+    }
     Ok(Json(serde_json::json!({"cancelled": ok})))
 }
 
@@ -900,11 +1111,18 @@ async fn search_chat(
                                 "assistant" => vr.eq_ignore_ascii_case("assistant"),
                                 _ => true,
                             };
-                            if !ok_role { continue; }
+                            if !ok_role {
+                                continue;
+                            }
                         }
-                        let text_ok = v.get("content").and_then(|x| x.as_str()).map(|text| {
-                            (params.prefix && text.starts_with(&q)) || (!params.prefix && regex.is_match(text))
-                        }).unwrap_or(false);
+                        let text_ok = v
+                            .get("content")
+                            .and_then(|x| x.as_str())
+                            .map(|text| {
+                                (params.prefix && text.starts_with(&q))
+                                    || (!params.prefix && regex.is_match(text))
+                            })
+                            .unwrap_or(false);
                         if text_ok {
                             let ts = v.get("timestamp_ms").and_then(|x| x.as_i64()).unwrap_or(0);
                             matches.push((ts, lt.to_string()));
@@ -917,12 +1135,18 @@ async fn search_chat(
     // sort by timestamp
     let asc = !matches!(params.sort.as_deref(), Some("desc"));
     matches.sort_by_key(|(ts, _)| *ts);
-    if !asc { matches.reverse(); }
+    if !asc {
+        matches.reverse();
+    }
     let offset = params.offset.unwrap_or(0);
     let limit = params.limit.unwrap_or(usize::MAX);
     for (i, (_ts, line)) in matches.into_iter().enumerate() {
-        if i < offset { continue; }
-        if i >= offset + limit { break; }
+        if i < offset {
+            continue;
+        }
+        if i >= offset + limit {
+            break;
+        }
         out.push_str(&line);
         out.push('\n');
     }
@@ -996,9 +1220,20 @@ async fn import_chat(
     if state.paused.load(std::sync::atomic::Ordering::Relaxed) {
         return Err((axum::http::StatusCode::SERVICE_UNAVAILABLE, "paused".into()));
     }
-    if q.auth.trim().is_empty() { if let Some(h) = auth_from_headers(&headers) { q.auth = h; } }
-    if !state.hub.check_auth(&q.auth) { return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into())); }
-    if !state.hub.check_scope(&q.auth, backend::interaction_hub::Scope::Write) { return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into())); }
+    if q.auth.trim().is_empty() {
+        if let Some(h) = auth_from_headers(&headers) {
+            q.auth = h;
+        }
+    }
+    if !state.hub.check_auth(&q.auth) {
+        return Err((axum::http::StatusCode::UNAUTHORIZED, "unauthorized".into()));
+    }
+    if !state
+        .hub
+        .check_scope(&q.auth, backend::interaction_hub::Scope::Write)
+    {
+        return Err((axum::http::StatusCode::FORBIDDEN, "forbidden".into()));
+    }
     let mut msgs = Vec::new();
     for line in body.lines() {
         if line.trim().is_empty() {
@@ -1128,7 +1363,9 @@ async fn main() {
 
     let file_appender = tracing_appender::rolling::daily(logs_dir, "backend.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-    let json_logs = std::env::var("NERVOUS_SYSTEM_JSON_LOGS").map(|v| v=="1" || v.eq_ignore_ascii_case("true")).unwrap_or(false);
+    let json_logs = std::env::var("NERVOUS_SYSTEM_JSON_LOGS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
     let fmt_builder = tracing_subscriber::fmt()
         .with_writer(non_blocking)
         .with_ansi(false)
@@ -1157,7 +1394,11 @@ async fn main() {
     ));
     // Expose hub globally for lightweight activity signals (optional)
     backend::GLOBAL_HUB.get_or_init(|| std::sync::RwLock::new(None));
-    if let Some(lock) = backend::GLOBAL_HUB.get() { let _ = lock.write().map(|mut w| { *w = Some(hub.clone()); }); }
+    if let Some(lock) = backend::GLOBAL_HUB.get() {
+        let _ = lock.write().map(|mut w| {
+            *w = Some(hub.clone());
+        });
+    }
     hub.add_auth_token("secret");
     hub.add_trigger_keyword("echo");
     registry.register_action_node(Arc::new(PreloadAction::default()));
@@ -1177,7 +1418,9 @@ async fn main() {
                 if p.exists() {
                     if let Ok(s) = std::fs::read_to_string(&p) {
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) {
-                            if let Some(obj) = v.as_object() { total += obj.len() as u64; }
+                            if let Some(obj) = v.as_object() {
+                                total += obj.len() as u64;
+                            }
                         }
                     }
                 }
@@ -1248,7 +1491,10 @@ async fn main() {
     if let Ok(write) = std::env::var("NEIRA_WRITE_TOKEN") {
         hub.add_token_with_scopes(
             write,
-            &[backend::interaction_hub::Scope::Write, backend::interaction_hub::Scope::Read],
+            &[
+                backend::interaction_hub::Scope::Write,
+                backend::interaction_hub::Scope::Read,
+            ],
         );
     }
     if let Ok(read) = std::env::var("NEIRA_READ_TOKEN") {
@@ -1257,46 +1503,87 @@ async fn main() {
 
     // Anti-Idle core (dry-run): update idle_state and idle_minutes_today
     {
-        let enabled = std::env::var("ANTI_IDLE_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true);
+        let enabled = std::env::var("ANTI_IDLE_ENABLED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
         if enabled {
             let hub_for_idle = hub.clone();
             tokio::spawn(async move {
                 use std::time::Duration;
-        let idle_secs: u64 = std::env::var("IDLE_THRESHOLD_SECONDS").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
-        let long_min: u64 = std::env::var("LONG_IDLE_THRESHOLD_MINUTES").ok().and_then(|v| v.parse().ok()).unwrap_or(5);
-        let deep_min: u64 = std::env::var("DEEP_IDLE_THRESHOLD_MINUTES").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
-        let long_secs = long_min.saturating_mul(60);
-        let deep_secs = deep_min.saturating_mul(60);
-        let alpha: f64 = std::env::var("IDLE_EMA_ALPHA").ok().and_then(|v| v.parse().ok()).unwrap_or(0.3);
-        let dry_depth_env: u64 = std::env::var("IDLE_DRYRUN_QUEUE_DEPTH").ok().and_then(|v| v.parse().ok()).unwrap_or(0);
-        let dryrun_enabled = std::env::var("LEARNING_MICROTASKS_DRYRUN").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false);
-        let mut accum_idle_secs: u64 = 0;
-        let mut idle_ema: f64 = 0.0;
-        loop {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            if !hub_for_idle.is_anti_idle_enabled() {
-                metrics::gauge!("idle_state").set(0.0);
-                metrics::gauge!("microtask_queue_depth").set(0.0);
-                metrics::gauge!("time_since_activity_seconds").set(0.0);
-                metrics::counter!("autonomous_time_spent_seconds").increment(0);
-                continue;
-            }
-            let since = hub_for_idle.seconds_since_last_activity();
-            let sse = hub_for_idle.active_streams();
-            let state_idx = if sse > 0 || since < idle_secs { 0 } else if since < long_secs { 1 } else if since < deep_secs { 2 } else { 3 };
-            metrics::gauge!("idle_state").set(state_idx as f64);
-            let dry_depth = if dryrun_enabled && state_idx > 0 { dry_depth_env } else { 0 };
-            metrics::gauge!("microtask_queue_depth").set(dry_depth as f64);
-            metrics::gauge!("time_since_activity_seconds").set(since as f64);
-            metrics::counter!("autonomous_time_spent_seconds").increment(0);
-            // EMA smoothing for idle_state
-            idle_ema = if idle_ema == 0.0 { state_idx as f64 } else { alpha * (state_idx as f64) + (1.0 - alpha) * idle_ema };
-            metrics::gauge!("idle_state_smoothed").set(idle_ema);
-            if state_idx > 0 {
-                accum_idle_secs += 5;
-                if accum_idle_secs >= 60 { let mins = accum_idle_secs / 60; accum_idle_secs %= 60; metrics::counter!("idle_minutes_today").increment(mins as u64); }
-            } else { accum_idle_secs = 0; }
-        }
+                let idle_secs: u64 = std::env::var("IDLE_THRESHOLD_SECONDS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30);
+                let long_min: u64 = std::env::var("LONG_IDLE_THRESHOLD_MINUTES")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(5);
+                let deep_min: u64 = std::env::var("DEEP_IDLE_THRESHOLD_MINUTES")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30);
+                let long_secs = long_min.saturating_mul(60);
+                let deep_secs = deep_min.saturating_mul(60);
+                let alpha: f64 = std::env::var("IDLE_EMA_ALPHA")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0.3);
+                let dry_depth_env: u64 = std::env::var("IDLE_DRYRUN_QUEUE_DEPTH")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0);
+                let dryrun_enabled = std::env::var("LEARNING_MICROTASKS_DRYRUN")
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                let mut accum_idle_secs: u64 = 0;
+                let mut idle_ema: f64 = 0.0;
+                loop {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                    if !hub_for_idle.is_anti_idle_enabled() {
+                        metrics::gauge!("idle_state").set(0.0);
+                        metrics::gauge!("microtask_queue_depth").set(0.0);
+                        metrics::gauge!("time_since_activity_seconds").set(0.0);
+                        metrics::counter!("autonomous_time_spent_seconds").increment(0);
+                        continue;
+                    }
+                    let since = hub_for_idle.seconds_since_last_activity();
+                    let sse = hub_for_idle.active_streams();
+                    let state_idx = if sse > 0 || since < idle_secs {
+                        0
+                    } else if since < long_secs {
+                        1
+                    } else if since < deep_secs {
+                        2
+                    } else {
+                        3
+                    };
+                    metrics::gauge!("idle_state").set(state_idx as f64);
+                    let dry_depth = if dryrun_enabled && state_idx > 0 {
+                        dry_depth_env
+                    } else {
+                        0
+                    };
+                    metrics::gauge!("microtask_queue_depth").set(dry_depth as f64);
+                    metrics::gauge!("time_since_activity_seconds").set(since as f64);
+                    metrics::counter!("autonomous_time_spent_seconds").increment(0);
+                    // EMA smoothing for idle_state
+                    idle_ema = if idle_ema == 0.0 {
+                        state_idx as f64
+                    } else {
+                        alpha * (state_idx as f64) + (1.0 - alpha) * idle_ema
+                    };
+                    metrics::gauge!("idle_state_smoothed").set(idle_ema);
+                    if state_idx > 0 {
+                        accum_idle_secs += 5;
+                        if accum_idle_secs >= 60 {
+                            let mins = accum_idle_secs / 60;
+                            accum_idle_secs %= 60;
+                            metrics::counter!("idle_minutes_today").increment(mins as u64);
+                        }
+                    } else {
+                        accum_idle_secs = 0;
+                    }
+                }
             });
         }
     }
@@ -1342,6 +1629,12 @@ async fn main() {
         .route("/factory/nodes/:fid/approve", post(factory_approve))
         .route("/factory/nodes/:fid/disable", post(factory_disable))
         .route("/factory/nodes/:fid/rollback", post(factory_rollback))
+        // Organ builder
+        .route("/organs/build", post(organ_build))
+        .route(
+            "/organs/:id/status",
+            get(organ_status).post(organ_update_status),
+        )
         .route("/api/neira/analysis", post(analyze_request))
         .route("/api/neira/analysis/resume", post(resume_request))
         .route("/api/neira/chat", post(chat_request))
@@ -1409,20 +1702,43 @@ async fn main() {
             "/api/neira/chat/:chat_id/:session_id/search",
             get(search_chat),
         )
-        .route(
-            "/api/neira/chat/stream/cancel",
-            post(cancel_stream),
-        );
+        .route("/api/neira/chat/stream/cancel", post(cancel_stream));
     // Control Plane (admin)
-    async fn control_pause(State(state): State<AppState>, Json(mut body): Json<serde_json::Value>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        let auth = body.get_mut("auth").and_then(|v| v.as_str().map(|s| s.to_string())).unwrap_or_default();
-        if !state.hub.check_auth(&auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let allow = std::env::var("CONTROL_ALLOW_PAUSE").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true);
-        if !allow { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let reason = body.get("reason").and_then(|v| v.as_str()).unwrap_or("").to_string();
-        let request_id = body.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
-        state.paused.store(true, std::sync::atomic::Ordering::Relaxed);
+    async fn control_pause(
+        State(state): State<AppState>,
+        Json(mut body): Json<serde_json::Value>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        let auth = body
+            .get_mut("auth")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_default();
+        if !state.hub.check_auth(&auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&auth, backend::interaction_hub::Scope::Admin)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let allow = std::env::var("CONTROL_ALLOW_PAUSE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        if !allow {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let reason = body
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let request_id = body
+            .get("request_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        state
+            .paused
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         metrics::gauge!("paused_state").set(1.0);
         metrics::counter!("pause_events_total").increment(1);
         // причина как лейбл (осторожно с кардинальностью)
@@ -1431,29 +1747,61 @@ async fn main() {
             let mut g = state.pause_info.lock().unwrap();
             *g = Some((std::time::Instant::now(), reason.clone()));
         }
-        if body.get("drain_active_streams").and_then(|v| v.as_bool()).unwrap_or(false) {
+        if body
+            .get("drain_active_streams")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
             let n = state.hub.cancel_all_streams();
-            if n > 0 { metrics::counter!("sse_cancellations_total").increment(n as u64); }
+            if n > 0 {
+                metrics::counter!("sse_cancellations_total").increment(n as u64);
+            }
             metrics::counter!("pause_drain_events_total").increment(1);
             tracing::info!(auth=%auth, reason=%reason, cancelled_streams=n, "control: pause with drain");
         }
         tracing::info!(request_id=%request_id, auth=%auth, reason=%reason, "control: pause");
         let now_ms = chrono::Utc::now().timestamp_millis();
-        Ok(Json(serde_json::json!({"paused": true, "reason": reason, "paused_since_ts_ms": now_ms})))
+        Ok(Json(
+            serde_json::json!({"paused": true, "reason": reason, "paused_since_ts_ms": now_ms}),
+        ))
     }
-    async fn control_resume(State(state): State<AppState>, Json(mut body): Json<serde_json::Value>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        let auth = body.get_mut("auth").and_then(|v| v.as_str().map(|s| s.to_string())).unwrap_or_default();
-        if !state.hub.check_auth(&auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let allow = std::env::var("CONTROL_ALLOW_PAUSE").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true);
-        if !allow { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let request_id = body.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
-        state.paused.store(false, std::sync::atomic::Ordering::Relaxed);
+    async fn control_resume(
+        State(state): State<AppState>,
+        Json(mut body): Json<serde_json::Value>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        let auth = body
+            .get_mut("auth")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_default();
+        if !state.hub.check_auth(&auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&auth, backend::interaction_hub::Scope::Admin)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let allow = std::env::var("CONTROL_ALLOW_PAUSE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        if !allow {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let request_id = body
+            .get("request_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        state
+            .paused
+            .store(false, std::sync::atomic::Ordering::Relaxed);
         metrics::gauge!("paused_state").set(0.0);
         tracing::info!(request_id=%request_id, auth=%auth, "control: resume");
         Ok(Json(serde_json::json!({"paused": false})))
     }
-    async fn control_status(State(state): State<AppState>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    async fn control_status(
+        State(state): State<AppState>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         let (paused, since_ms, reason) = {
             let p = state.paused.load(std::sync::atomic::Ordering::Relaxed);
             let mut since_ms: u128 = 0;
@@ -1478,14 +1826,37 @@ async fn main() {
             "queues": {"fast": qf, "standard": qs, "long": ql}
         })))
     }
-    async fn control_kill(State(state): State<AppState>, Json(mut body): Json<serde_json::Value>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        let auth = body.get_mut("auth").and_then(|v| v.as_str().map(|s| s.to_string())).unwrap_or_default();
-        if !state.hub.check_auth(&auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let allow = std::env::var("CONTROL_ALLOW_KILL").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true);
-        if !allow { return Err(axum::http::StatusCode::FORBIDDEN); }
-        let grace_ms = body.get("grace_ms").and_then(|v| v.as_u64()).unwrap_or(1_000);
-        let request_id = body.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
+    async fn control_kill(
+        State(state): State<AppState>,
+        Json(mut body): Json<serde_json::Value>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        let auth = body
+            .get_mut("auth")
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_default();
+        if !state.hub.check_auth(&auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&auth, backend::interaction_hub::Scope::Admin)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let allow = std::env::var("CONTROL_ALLOW_KILL")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        if !allow {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
+        let grace_ms = body
+            .get("grace_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1_000);
+        let request_id = body
+            .get("request_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         tracing::warn!(request_id=%request_id, auth=%auth, grace_ms=grace_ms, "control: kill (graceful)");
         metrics::counter!("kill_switch_total").increment(1);
         // Инициируем graceful shutdown сервера
@@ -1495,25 +1866,37 @@ async fn main() {
             tokio::time::sleep(std::time::Duration::from_millis(grace_ms)).await;
             std::process::exit(0);
         });
-        Ok(Json(serde_json::json!({"stopping": true, "grace_ms": grace_ms})))
+        Ok(Json(
+            serde_json::json!({"stopping": true, "grace_ms": grace_ms}),
+        ))
     }
-    async fn inspect_snapshot(State(state): State<AppState>, axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String,String>>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    async fn inspect_snapshot(
+        State(state): State<AppState>,
+        axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         let dir = std::env::var("CONTROL_SNAPSHOT_DIR").unwrap_or_else(|_| "./snapshots".into());
         let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
         let path = std::path::Path::new(&dir).join(format!("snapshot-{}.json", ts));
         let mut obj = serde_json::json!({
             "created_at": chrono::Utc::now().to_rfc3339(),
         });
-        if q.get("include").map(|s| s.contains("metrics")).unwrap_or(false) {
+        if q.get("include")
+            .map(|s| s.contains("metrics"))
+            .unwrap_or(false)
+        {
             if let Ok(resp) = reqwest::get("http://127.0.0.1:3000/metrics").await {
                 if let Ok(text) = resp.text().await {
                     obj["metrics_prom"] = serde_json::json!(text);
                 }
             }
         }
-        if q.get("include").map(|s| s.contains("context")).unwrap_or(false) {
+        if q.get("include")
+            .map(|s| s.contains("context"))
+            .unwrap_or(false)
+        {
             let base = std::env::var("CONTEXT_DIR").unwrap_or_else(|_| "context".into());
-            let mut index: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+            let mut index: std::collections::HashMap<String, Vec<String>> =
+                std::collections::HashMap::new();
             if let Ok(rd) = std::fs::read_dir(&base) {
                 for e in rd.flatten() {
                     if e.path().is_dir() {
@@ -1521,7 +1904,9 @@ async fn main() {
                         let mut files = Vec::new();
                         if let Ok(r2) = std::fs::read_dir(e.path()) {
                             for f in r2.flatten() {
-                                if let Some(name) = f.file_name().to_str() { files.push(name.to_string()); }
+                                if let Some(name) = f.file_name().to_str() {
+                                    files.push(name.to_string());
+                                }
                             }
                         }
                         files.sort();
@@ -1532,22 +1917,36 @@ async fn main() {
             obj["context_index"] = serde_json::to_value(index).unwrap_or(serde_json::json!({}));
         }
         let mut logs_file_out: Option<std::path::PathBuf> = None;
-        if q.get("include").map(|s| s.contains("logs")).unwrap_or(false) {
+        if q.get("include")
+            .map(|s| s.contains("logs"))
+            .unwrap_or(false)
+        {
             let log_path = std::path::Path::new("logs").join("backend.log");
-            let lines = std::env::var("LOGS_TAIL_LINES").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(200);
+            let lines = std::env::var("LOGS_TAIL_LINES")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(200);
             if let Ok(data) = std::fs::read_to_string(&log_path) {
                 let level_filter = q.get("level").cloned();
                 let since_ms = q.get("since_ts_ms").and_then(|v| v.parse::<i64>().ok());
                 let mut tail: Vec<&str> = Vec::new();
                 for ln in data.lines().rev() {
-                    if tail.len() >= lines { break; }
-                    if let Some(ref lev) = level_filter { if !ln.contains(lev) { continue; } }
+                    if tail.len() >= lines {
+                        break;
+                    }
+                    if let Some(ref lev) = level_filter {
+                        if !ln.contains(lev) {
+                            continue;
+                        }
+                    }
                     if let Some(since) = since_ms {
                         // попытка фильтра по времени для JSON-логов с полем timestamp (RFC3339)
                         if let Ok(v) = serde_json::from_str::<serde_json::Value>(ln) {
                             if let Some(ts) = v.get("timestamp").and_then(|x| x.as_str()) {
                                 if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
-                                    if dt.timestamp_millis() < since { continue; }
+                                    if dt.timestamp_millis() < since {
+                                        continue;
+                                    }
                                 }
                             }
                         }
@@ -1556,7 +1955,8 @@ async fn main() {
                 }
                 tail.reverse();
                 let joined = tail.join("\n");
-                let masked = backend::context::context_storage::mask_preview(&joined, None, None).unwrap_or(joined);
+                let masked = backend::context::context_storage::mask_preview(&joined, None, None)
+                    .unwrap_or(joined);
                 let lf = std::path::Path::new(&dir).join(format!("snapshot-{}-logs-tail.log", ts));
                 let _ = std::fs::write(&lf, masked.as_bytes());
                 logs_file_out = Some(lf.clone());
@@ -1567,20 +1967,26 @@ async fn main() {
         }
         if let Some(req_id) = q.get("request_id") {
             if let Some(v) = state.hub.trace_dump(req_id) {
-                let tf = std::path::Path::new(&dir).join(format!("snapshot-{}-trace-{}.json", ts, req_id));
-                let _ = std::fs::write(&tf, serde_json::to_string_pretty(&v).unwrap_or("{}".into()));
+                let tf = std::path::Path::new(&dir)
+                    .join(format!("snapshot-{}-trace-{}.json", ts, req_id));
+                let _ =
+                    std::fs::write(&tf, serde_json::to_string_pretty(&v).unwrap_or("{}".into()));
                 obj["trace_file"] = serde_json::json!(tf.to_string_lossy());
             }
         }
         tracing::info!("control: snapshot created");
         let _ = std::fs::create_dir_all(&dir);
-        let _ = std::fs::write(&path, serde_json::to_string_pretty(&obj).unwrap_or("{}".into()));
+        let _ = std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&obj).unwrap_or("{}".into()),
+        );
         let fname = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
         obj["file"] = serde_json::json!(path.to_string_lossy());
         obj["public_url"] = serde_json::json!(format!("/snapshots/{}", fname));
-        if q.get("zip").map(|v| v=="1").unwrap_or(false) {
+        if q.get("zip").map(|v| v == "1").unwrap_or(false) {
             let zip_path = std::path::Path::new(&dir).join(format!("snapshot-{}.zip", ts));
-            let f = std::fs::File::create(&zip_path).map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
+            let f = std::fs::File::create(&zip_path)
+                .map_err(|_| axum::http::StatusCode::INTERNAL_SERVER_ERROR)?;
             let mut zip = zip::ZipWriter::new(f);
             use zip::write::FileOptions;
             let opts = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
@@ -1589,20 +1995,40 @@ async fn main() {
             let _ = zip.start_file("snapshot.json", opts.clone());
             let _ = zip.write_all(json_str.as_bytes());
             // add logs tail
-            if let Some(lf) = logs_file_out.as_ref() { if let Ok(data) = std::fs::read(&lf) { let _ = zip.start_file("logs-tail.log", opts.clone()); let _ = zip.write_all(&data); } }
+            if let Some(lf) = logs_file_out.as_ref() {
+                if let Ok(data) = std::fs::read(&lf) {
+                    let _ = zip.start_file("logs-tail.log", opts.clone());
+                    let _ = zip.write_all(&data);
+                }
+            }
             // add trace
-            if let Some(tfv) = obj.get("trace_file").and_then(|v| v.as_str()) { if let Ok(data) = std::fs::read(tfv) { let _ = zip.start_file("trace.json", opts.clone()); let _ = zip.write_all(&data); } }
+            if let Some(tfv) = obj.get("trace_file").and_then(|v| v.as_str()) {
+                if let Ok(data) = std::fs::read(tfv) {
+                    let _ = zip.start_file("trace.json", opts.clone());
+                    let _ = zip.write_all(&data);
+                }
+            }
             let _ = zip.finish();
             let zname = zip_path.file_name().and_then(|s| s.to_str()).unwrap_or("");
             obj["zip_file"] = serde_json::json!(zip_path.to_string_lossy());
             obj["zip_url"] = serde_json::json!(format!("/snapshots/{}", zname));
-            let _ = std::fs::write(&path, serde_json::to_string_pretty(&obj).unwrap_or("{}".into()));
+            let _ = std::fs::write(
+                &path,
+                serde_json::to_string_pretty(&obj).unwrap_or("{}".into()),
+            );
         }
         metrics::counter!("snapshots_created_total").increment(1);
         Ok(Json(obj))
     }
-    async fn trace_request(State(state): State<AppState>, Path(request_id): Path<String>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        if let Some(v) = state.hub.trace_dump(&request_id) { Ok(Json(v)) } else { Err(axum::http::StatusCode::NOT_FOUND) }
+    async fn trace_request(
+        State(state): State<AppState>,
+        Path(request_id): Path<String>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        if let Some(v) = state.hub.trace_dump(&request_id) {
+            Ok(Json(v))
+        } else {
+            Err(axum::http::StatusCode::NOT_FOUND)
+        }
     }
     app = app
         .route("/api/neira/control/pause", post(control_pause))
@@ -1612,7 +2038,9 @@ async fn main() {
         .route("/api/neira/inspect/snapshot", get(inspect_snapshot))
         .route("/api/neira/trace/:request_id", get(trace_request));
 
-    async fn queues_status(State(state): State<AppState>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    async fn queues_status(
+        State(state): State<AppState>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         let (qf, qs, ql) = state.hub.queue_lengths();
         let active = state.hub.active_streams();
         let bp = state.hub.backpressure_sum();
@@ -1626,31 +2054,57 @@ async fn main() {
 
     // Cancel analysis endpoint
     #[derive(serde::Deserialize)]
-    struct CancelAnalysis { auth: String, id: String }
-    async fn analysis_cancel(State(state): State<AppState>, Json(req): Json<CancelAnalysis>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        if !state.hub.check_auth(&req.auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&req.auth, backend::interaction_hub::Scope::Write) { return Err(axum::http::StatusCode::FORBIDDEN); }
+    struct CancelAnalysis {
+        auth: String,
+        id: String,
+    }
+    async fn analysis_cancel(
+        State(state): State<AppState>,
+        Json(req): Json<CancelAnalysis>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        if !state.hub.check_auth(&req.auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&req.auth, backend::interaction_hub::Scope::Write)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
         let ok = state.hub.cancel_analysis(&req.id);
         Ok(Json(serde_json::json!({"cancelled": ok})))
     }
     app = app.route("/api/neira/analysis/cancel", post(analysis_cancel));
 
     // Logs tail endpoint with filters: /api/neira/logs/tail?lines=&level=&since_ts_ms=
-    async fn logs_tail(axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String,String>>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    async fn logs_tail(
+        axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         let log_path = std::path::Path::new("logs").join("backend.log");
-        let lines = q.get("lines").and_then(|v| v.parse::<usize>().ok()).unwrap_or(200);
+        let lines = q
+            .get("lines")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(200);
         let level = q.get("level").cloned();
         let since_ms = q.get("since_ts_ms").and_then(|v| v.parse::<i64>().ok());
         if let Ok(data) = std::fs::read_to_string(&log_path) {
             let mut out: Vec<String> = Vec::new();
             for ln in data.lines().rev() {
-                if out.len() >= lines { break; }
-                if let Some(ref lev) = level { if !ln.contains(lev) { continue; } }
+                if out.len() >= lines {
+                    break;
+                }
+                if let Some(ref lev) = level {
+                    if !ln.contains(lev) {
+                        continue;
+                    }
+                }
                 if let Some(since) = since_ms {
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(ln) {
                         if let Some(ts) = v.get("timestamp").and_then(|x| x.as_str()) {
                             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
-                                if dt.timestamp_millis() < since { continue; }
+                                if dt.timestamp_millis() < since {
+                                    continue;
+                                }
                             }
                         }
                     }
@@ -1658,7 +2112,9 @@ async fn main() {
                 out.push(ln.to_string());
             }
             out.reverse();
-            return Ok(Json(serde_json::json!({"file": log_path.to_string_lossy(), "lines": out })));
+            return Ok(Json(
+                serde_json::json!({"file": log_path.to_string_lossy(), "lines": out }),
+            ));
         }
         Err(axum::http::StatusCode::NOT_FOUND)
     }
@@ -1669,11 +2125,28 @@ async fn main() {
         // discover port from bind addr
         let bind = std::env::var("NEIRA_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".into());
         let metrics_url = format!("http://{}/metrics", bind);
-        let txt = match reqwest::get(&metrics_url).await { Ok(r) => r.text().await.unwrap_or_default(), Err(_) => String::new() };
+        let txt = match reqwest::get(&metrics_url).await {
+            Ok(r) => r.text().await.unwrap_or_default(),
+            Err(_) => String::new(),
+        };
         let re_gauge = |name: &str, labels: Option<&str>| -> f64 {
-            let pat = if let Some(lbl) = labels { format!(r"(?m)^{}\{{[^}}]*{}[^}}]*\}}\s+([0-9]+(?:\.[0-9]+)?)$", regex::escape(name), lbl) } else { format!(r"(?m)^{}\s+([0-9]+(?:\.[0-9]+)?)$", regex::escape(name)) };
+            let pat = if let Some(lbl) = labels {
+                format!(
+                    r"(?m)^{}\{{[^}}]*{}[^}}]*\}}\s+([0-9]+(?:\.[0-9]+)?)$",
+                    regex::escape(name),
+                    lbl
+                )
+            } else {
+                format!(r"(?m)^{}\s+([0-9]+(?:\.[0-9]+)?)$", regex::escape(name))
+            };
             let rg = Regex::new(&pat).unwrap();
-            if let Some(c) = rg.captures(&txt) { c.get(1).and_then(|m| m.as_str().parse::<f64>().ok()).unwrap_or(0.0) } else { 0.0 }
+            if let Some(c) = rg.captures(&txt) {
+                c.get(1)
+                    .and_then(|m| m.as_str().parse::<f64>().ok())
+                    .unwrap_or(0.0)
+            } else {
+                0.0
+            }
         };
         let hard_to = re_gauge("watchdog_timeouts_total", Some("kind=\"hard\""));
         let soft_to = re_gauge("watchdog_timeouts_total", Some("kind=\"soft\""));
@@ -1684,14 +2157,25 @@ async fn main() {
         // queues/backpressure via JSON
         let queues_url = format!("http://{}/api/neira/queues/status", bind);
         let (backpressure, qf, qs, ql) = match reqwest::get(&queues_url).await {
-            Ok(r) => match r.json::<serde_json::Value>().await { Ok(v) => {
-                (v.get("backpressure").and_then(|x| x.as_u64()).unwrap_or(0),
-                v.get("queues").and_then(|x| x.get("fast")).and_then(|x| x.as_u64()).unwrap_or(0),
-                v.get("queues").and_then(|x| x.get("standard")).and_then(|x| x.as_u64()).unwrap_or(0),
-                v.get("queues").and_then(|x| x.get("long")).and_then(|x| x.as_u64()).unwrap_or(0)) }
-                Err(_) => (0,0,0,0)
+            Ok(r) => match r.json::<serde_json::Value>().await {
+                Ok(v) => (
+                    v.get("backpressure").and_then(|x| x.as_u64()).unwrap_or(0),
+                    v.get("queues")
+                        .and_then(|x| x.get("fast"))
+                        .and_then(|x| x.as_u64())
+                        .unwrap_or(0),
+                    v.get("queues")
+                        .and_then(|x| x.get("standard"))
+                        .and_then(|x| x.as_u64())
+                        .unwrap_or(0),
+                    v.get("queues")
+                        .and_then(|x| x.get("long"))
+                        .and_then(|x| x.as_u64())
+                        .unwrap_or(0),
+                ),
+                Err(_) => (0, 0, 0, 0),
             },
-            Err(_) => (0,0,0,0)
+            Err(_) => (0, 0, 0, 0),
         };
 
         let mut recs: Vec<serde_json::Value> = Vec::new();
@@ -1714,22 +2198,46 @@ async fn main() {
             "sse_active": sse_active,
             "queues": {"fast": qf, "standard": qs, "long": ql, "backpressure": backpressure}
         });
-        Ok(Json(serde_json::json!({"signals": signals, "recommendations": recs})))
+        Ok(Json(
+            serde_json::json!({"signals": signals, "recommendations": recs}),
+        ))
     }
-    app = app.route("/api/neira/limits/recommendations", get(limits_recommendations));
+    app = app.route(
+        "/api/neira/limits/recommendations",
+        get(limits_recommendations),
+    );
 
     // Analysis streaming progress (SSE) — прогноз прогресса по времени/бюджету
-    async fn analysis_stream(State(state): State<AppState>, headers: HeaderMap, Json(mut req): Json<AnalysisRequest>) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, axum::http::StatusCode> {
+    async fn analysis_stream(
+        State(state): State<AppState>,
+        headers: HeaderMap,
+        Json(mut req): Json<AnalysisRequest>,
+    ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, axum::http::StatusCode> {
         // Anti-Idle: mark user activity
         state.hub.mark_activity();
-        if req.auth.trim().is_empty() { if let Some(h) = auth_from_headers(&headers) { req.auth = h; } }
+        if req.auth.trim().is_empty() {
+            if let Some(h) = auth_from_headers(&headers) {
+                req.auth = h;
+            }
+        }
         let token = tokio_util::sync::CancellationToken::new();
         // per-request budget via header fallback
-        if req.budget_ms.is_none() { if let Some(h) = headers.get("x-reasoning-budget-ms").and_then(|v| v.to_str().ok()) { req.budget_ms = h.parse::<u64>().ok(); } }
+        if req.budget_ms.is_none() {
+            if let Some(h) = headers
+                .get("x-reasoning-budget-ms")
+                .and_then(|v| v.to_str().ok())
+            {
+                req.budget_ms = h.parse::<u64>().ok();
+            }
+        }
         let start = std::time::Instant::now();
-        let auth = req.auth.clone(); let id = req.id.clone(); let input = req.input.clone();
-        let hub = state.hub.clone(); let t2 = token.clone();
-        let mut handle = tokio::task::spawn(async move { hub.analyze(&id, &input, &auth, &t2).await });
+        let auth = req.auth.clone();
+        let id = req.id.clone();
+        let input = req.input.clone();
+        let hub = state.hub.clone();
+        let t2 = token.clone();
+        let mut handle =
+            tokio::task::spawn(async move { hub.analyze(&id, &input, &auth, &t2).await });
         let hub_for_progress = state.hub.clone();
         state.hub.register_analysis_cancel(&req.id, token.clone());
         let stream = async_stream::stream! {
@@ -1765,10 +2273,23 @@ async fn main() {
 
     // Trace runtime toggle (admin)
     #[derive(serde::Deserialize)]
-    struct TraceToggle { auth: String, enabled: Option<bool> }
-    async fn trace_toggle(State(state): State<AppState>, Json(req): Json<TraceToggle>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        if !state.hub.check_auth(&req.auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&req.auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
+    struct TraceToggle {
+        auth: String,
+        enabled: Option<bool>,
+    }
+    async fn trace_toggle(
+        State(state): State<AppState>,
+        Json(req): Json<TraceToggle>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        if !state.hub.check_auth(&req.auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&req.auth, backend::interaction_hub::Scope::Admin)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
         let new_state = req.enabled.unwrap_or(!state.hub.is_trace_enabled());
         state.hub.set_trace_enabled(new_state);
         Ok(Json(serde_json::json!({"enabled": new_state})))
@@ -1779,7 +2300,8 @@ async fn main() {
     app = app.route(
         "/snapshots/*path",
         get(|Path(path): Path<String>| async move {
-            let base = std::env::var("CONTROL_SNAPSHOT_DIR").unwrap_or_else(|_| "./snapshots".into());
+            let base =
+                std::env::var("CONTROL_SNAPSHOT_DIR").unwrap_or_else(|_| "./snapshots".into());
             let full = std::path::Path::new(&base).join(path);
             match std::fs::read(&full) {
                 Ok(bytes) => {
@@ -1799,20 +2321,47 @@ async fn main() {
     );
 
     // Introspection Status
-    async fn introspection_status(State(state): State<AppState>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+    async fn introspection_status(
+        State(state): State<AppState>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         metrics::counter!("introspection_status_requests_total").increment(1);
         let (qf, qs, ql) = state.hub.queue_lengths();
         let active = state.hub.active_streams();
         let bp = state.hub.backpressure_sum();
-        let soft_ms: u64 = std::env::var("WATCHDOG_REASONING_SOFT_MS").ok().and_then(|v| v.parse().ok()).unwrap_or(30_000);
-        let hard_ms: u64 = std::env::var("WATCHDOG_REASONING_HARD_MS").ok().and_then(|v| v.parse().ok()).unwrap_or(300_000);
+        let soft_ms: u64 = std::env::var("WATCHDOG_REASONING_SOFT_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30_000);
+        let hard_ms: u64 = std::env::var("WATCHDOG_REASONING_HARD_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(300_000);
         // Anti-Idle snapshot
         let anti_idle_enabled = state.hub.is_anti_idle_enabled();
         let since = state.hub.seconds_since_last_activity();
-        let idle_threshold = std::env::var("IDLE_THRESHOLD_SECONDS").ok().and_then(|v| v.parse().ok()).unwrap_or(30);
-        let long_secs = std::env::var("LONG_IDLE_THRESHOLD_MINUTES").ok().and_then(|v| v.parse().ok()).unwrap_or(5) * 60;
-        let deep_secs = std::env::var("DEEP_IDLE_THRESHOLD_MINUTES").ok().and_then(|v| v.parse().ok()).unwrap_or(30) * 60;
-        let idle_state = if active > 0 || since < idle_threshold { 0 } else if since < long_secs { 1 } else if since < deep_secs { 2 } else { 3 };
+        let idle_threshold = std::env::var("IDLE_THRESHOLD_SECONDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+        let long_secs = std::env::var("LONG_IDLE_THRESHOLD_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(5)
+            * 60;
+        let deep_secs = std::env::var("DEEP_IDLE_THRESHOLD_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30)
+            * 60;
+        let idle_state = if active > 0 || since < idle_threshold {
+            0
+        } else if since < long_secs {
+            1
+        } else if since < deep_secs {
+            2
+        } else {
+            3
+        };
         metrics::gauge!("time_since_activity_seconds").set(since as f64);
         let caps = serde_json::json!({
             "trace_requests": state.hub.is_trace_enabled(),
@@ -1820,7 +2369,8 @@ async fn main() {
             "control_pause_resume": std::env::var("CONTROL_ALLOW_PAUSE").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true),
             "control_kill_switch": std::env::var("CONTROL_ALLOW_KILL").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true),
             "dev_routes": std::env::var("DEV_ROUTES_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false),
-            "factory_adapter": state.hub.factory_is_adapter_enabled()
+            "factory_adapter": state.hub.factory_is_adapter_enabled(),
+            "organs_builder": state.hub.organ_builder_enabled()
         });
         let (factory_total, factory_active) = state.hub.factory_counts();
         Ok(Json(serde_json::json!({
@@ -1840,10 +2390,23 @@ async fn main() {
 
     // Anti-Idle runtime toggle (admin)
     #[derive(serde::Deserialize)]
-    struct AntiIdleToggle { auth: String, enabled: Option<bool> }
-    async fn anti_idle_toggle(State(state): State<AppState>, Json(req): Json<AntiIdleToggle>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
-        if !state.hub.check_auth(&req.auth) { return Err(axum::http::StatusCode::UNAUTHORIZED); }
-        if !state.hub.check_scope(&req.auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
+    struct AntiIdleToggle {
+        auth: String,
+        enabled: Option<bool>,
+    }
+    async fn anti_idle_toggle(
+        State(state): State<AppState>,
+        Json(req): Json<AntiIdleToggle>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        if !state.hub.check_auth(&req.auth) {
+            return Err(axum::http::StatusCode::UNAUTHORIZED);
+        }
+        if !state
+            .hub
+            .check_scope(&req.auth, backend::interaction_hub::Scope::Admin)
+        {
+            return Err(axum::http::StatusCode::FORBIDDEN);
+        }
         let new_state = req.enabled.unwrap_or(!state.hub.is_anti_idle_enabled());
         state.hub.set_anti_idle_enabled(new_state);
         Ok(Json(serde_json::json!({"enabled": new_state})))
@@ -1854,79 +2417,158 @@ async fn main() {
     async fn list_plugins() -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         fn list_dir(path: &str) -> Vec<String> {
             let p = std::path::Path::new(path);
-            if !p.exists() { return Vec::new(); }
-            match std::fs::read_dir(p) { Ok(rd) => rd.flatten().filter_map(|e| e.file_name().into_string().ok()).collect(), Err(_) => Vec::new() }
+            if !p.exists() {
+                return Vec::new();
+            }
+            match std::fs::read_dir(p) {
+                Ok(rd) => rd
+                    .flatten()
+                    .filter_map(|e| e.file_name().into_string().ok())
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
         }
-        let scripts_dir = std::env::var("PLUGINS_SCRIPTS_DIR").unwrap_or_else(|_| "plugins/scripts".into());
+        let scripts_dir =
+            std::env::var("PLUGINS_SCRIPTS_DIR").unwrap_or_else(|_| "plugins/scripts".into());
         let wasm_dir = std::env::var("PLUGINS_WASM_DIR").unwrap_or_else(|_| "plugins/wasm".into());
-        let index_path = std::env::var("PLUGINS_INDEX_JSON").unwrap_or_else(|_| "plugins/index.json".into());
+        let index_path =
+            std::env::var("PLUGINS_INDEX_JSON").unwrap_or_else(|_| "plugins/index.json".into());
         let scripts = list_dir(&scripts_dir);
         let wasm = list_dir(&wasm_dir);
-        let index = std::fs::read_to_string(&index_path).ok().and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
-        Ok(Json(serde_json::json!({"scripts": scripts, "wasm": wasm, "index": index})))
+        let index = std::fs::read_to_string(&index_path)
+            .ok()
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok());
+        Ok(Json(
+            serde_json::json!({"scripts": scripts, "wasm": wasm, "index": index}),
+        ))
     }
     async fn list_ui_tools() -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
         fn list_dir(path: &str) -> Vec<String> {
             let p = std::path::Path::new(path);
-            if !p.exists() { return Vec::new(); }
-            match std::fs::read_dir(p) { Ok(rd) => rd.flatten().filter_map(|e| e.file_name().into_string().ok()).collect(), Err(_) => Vec::new() }
+            if !p.exists() {
+                return Vec::new();
+            }
+            match std::fs::read_dir(p) {
+                Ok(rd) => rd
+                    .flatten()
+                    .filter_map(|e| e.file_name().into_string().ok())
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
         }
         let ui_dir = std::env::var("UI_TOOLS_DIR").unwrap_or_else(|_| "plugins/ui/tools".into());
         let alt_dir = "ui/tools";
         let mut tools = list_dir(&ui_dir);
-        if tools.is_empty() { tools = list_dir(alt_dir); }
+        if tools.is_empty() {
+            tools = list_dir(alt_dir);
+        }
         Ok(Json(serde_json::json!({"tools": tools})))
     }
     app = app
         .route("/api/neira/plugins", get(list_plugins))
         .route("/api/neira/ui/tools", get(list_ui_tools));
 
-    if std::env::var("DEV_ROUTES_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false) {
+    if std::env::var("DEV_ROUTES_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
         // register dev slow analysis node
         struct DevSlowNode;
         impl AnalysisNode for DevSlowNode {
-            fn id(&self) -> &str { "dev.slow" }
-            fn analysis_type(&self) -> &str { "dev" }
-            fn status(&self) -> NodeStatus { NodeStatus::Active }
-            fn links(&self) -> &[String] { &[] }
-            fn confidence_threshold(&self) -> f32 { 0.0 }
-            fn analyze(&self, input: &str, cancel_token: &tokio_util::sync::CancellationToken) -> AnalysisResult {
+            fn id(&self) -> &str {
+                "dev.slow"
+            }
+            fn analysis_type(&self) -> &str {
+                "dev"
+            }
+            fn status(&self) -> NodeStatus {
+                NodeStatus::Active
+            }
+            fn links(&self) -> &[String] {
+                &[]
+            }
+            fn confidence_threshold(&self) -> f32 {
+                0.0
+            }
+            fn analyze(
+                &self,
+                input: &str,
+                cancel_token: &tokio_util::sync::CancellationToken,
+            ) -> AnalysisResult {
                 let ms: u64 = input.trim().parse().ok().unwrap_or(5_000);
                 let start = std::time::Instant::now();
                 while start.elapsed().as_millis() < ms as u128 {
                     if cancel_token.is_cancelled() {
                         let mut r = AnalysisResult::new(self.id(), "cancelled", vec![]);
-                        r.status = NodeStatus::Error; return r;
+                        r.status = NodeStatus::Error;
+                        return r;
                     }
                     std::thread::sleep(std::time::Duration::from_millis(50));
                 }
-                AnalysisResult::new(self.id(), format!("slept {} ms", ms), vec!["dev-slow".into()])
+                AnalysisResult::new(
+                    self.id(),
+                    format!("slept {} ms", ms),
+                    vec!["dev-slow".into()],
+                )
             }
-            fn explain(&self) -> String { "Dev slow analysis for watchdog tests".into() }
+            fn explain(&self) -> String {
+                "Dev slow analysis for watchdog tests".into()
+            }
         }
         registry.register_analysis_node(Arc::new(DevSlowNode));
 
-        async fn dev_long_stream(State(state): State<AppState>, headers: HeaderMap) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, axum::http::StatusCode> {
+        async fn dev_long_stream(
+            State(state): State<AppState>,
+            headers: HeaderMap,
+        ) -> Result<Sse<impl Stream<Item = Result<Event, Infallible>>>, axum::http::StatusCode>
+        {
             let auth = auth_from_headers(&headers).unwrap_or_default();
-            if !state.hub.check_scope(&auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
+            if !state
+                .hub
+                .check_scope(&auth, backend::interaction_hub::Scope::Admin)
+            {
+                return Err(axum::http::StatusCode::FORBIDDEN);
+            }
             let cancel = tokio_util::sync::CancellationToken::new();
             metrics::gauge!("sse_active").increment(1.0);
-            let delay = std::env::var("SSE_DEV_DELAY_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(50);
-            let count = std::env::var("SSE_DEV_TOKENS").ok().and_then(|v| v.parse::<usize>().ok()).unwrap_or(200);
+            let delay = std::env::var("SSE_DEV_DELAY_MS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(50);
+            let count = std::env::var("SSE_DEV_TOKENS")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(200);
             let stream = stream! {
                 for i in 0..count { if cancel.is_cancelled(){ break; } yield Ok(Event::default().event("message").data(format!("x{}", i))); tokio::time::sleep(std::time::Duration::from_millis(delay)).await; if i%10==0 { yield Ok(Event::default().event("progress").data(serde_json::json!({"tokens": i}).to_string())); } }
                 yield Ok(Event::default().event("done").data("true")); metrics::gauge!("sse_active").decrement(1.0);
             };
             Ok(Sse::new(stream))
         }
-        async fn dev_long_analysis(State(state): State<AppState>, axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String,String>>) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        async fn dev_long_analysis(
+            State(state): State<AppState>,
+            axum::extract::Query(q): axum::extract::Query<
+                std::collections::HashMap<String, String>,
+            >,
+        ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
             let auth = q.get("auth").cloned().unwrap_or_default();
-            if !state.hub.check_scope(&auth, backend::interaction_hub::Scope::Admin) { return Err(axum::http::StatusCode::FORBIDDEN); }
+            if !state
+                .hub
+                .check_scope(&auth, backend::interaction_hub::Scope::Admin)
+            {
+                return Err(axum::http::StatusCode::FORBIDDEN);
+            }
             let ms: u64 = q.get("ms").and_then(|v| v.parse().ok()).unwrap_or(5000);
             let token = tokio_util::sync::CancellationToken::new();
             let id = format!("dev.slow");
-            match state.hub.analyze(&id, &format!("{}", ms), &auth, &token).await {
-                Some(res) => Ok(Json(serde_json::to_value(&res).unwrap_or(serde_json::json!({})) )),
+            match state
+                .hub
+                .analyze(&id, &format!("{}", ms), &auth, &token)
+                .await
+            {
+                Some(res) => Ok(Json(
+                    serde_json::to_value(&res).unwrap_or(serde_json::json!({})),
+                )),
                 None => Err(axum::http::StatusCode::INTERNAL_SERVER_ERROR),
             }
         }
@@ -1940,10 +2582,16 @@ async fn main() {
     let app = app.with_state(state);
 
     // Index compaction job (keywords TTL cleanup)
-    let compact_every_ms = std::env::var("INDEX_COMPACT_INTERVAL_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(300_000);
+    let compact_every_ms = std::env::var("INDEX_COMPACT_INTERVAL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(300_000);
     if compact_every_ms > 0 {
         tokio::spawn(async move {
-            let ttl_days: i64 = std::env::var("INDEX_KW_TTL_DAYS").ok().and_then(|v| v.parse().ok()).unwrap_or(90);
+            let ttl_days: i64 = std::env::var("INDEX_KW_TTL_DAYS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(90);
             let ttl_ms = ttl_days.max(0) as i64 * 86_400_000;
             loop {
                 tokio::time::sleep(std::time::Duration::from_millis(compact_every_ms)).await;
@@ -1951,7 +2599,9 @@ async fn main() {
                 if let Ok(rd) = std::fs::read_dir(&base) {
                     for e in rd.flatten() {
                         let idx = e.path().join("index.json");
-                        if !idx.exists() { continue; }
+                        if !idx.exists() {
+                            continue;
+                        }
                         if let Ok(s) = std::fs::read_to_string(&idx) {
                             if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&s) {
                                 let now_ms = chrono::Utc::now().timestamp_millis();
@@ -1959,17 +2609,30 @@ async fn main() {
                                     let mut changed = false;
                                     for (_, entry) in map.iter_mut() {
                                         if let Some(obj) = entry.as_object_mut() {
-                                            if let Some(ts) = obj.get("kw_updated_ms").and_then(|x| x.as_i64()) {
-                                                if ttl_ms > 0 && now_ms.saturating_sub(ts) > ttl_ms {
-                                                    obj.insert("keywords".into(), serde_json::Value::Array(Vec::new()));
-                                                    obj.insert("kw_updated_ms".into(), serde_json::json!(now_ms));
+                                            if let Some(ts) =
+                                                obj.get("kw_updated_ms").and_then(|x| x.as_i64())
+                                            {
+                                                if ttl_ms > 0 && now_ms.saturating_sub(ts) > ttl_ms
+                                                {
+                                                    obj.insert(
+                                                        "keywords".into(),
+                                                        serde_json::Value::Array(Vec::new()),
+                                                    );
+                                                    obj.insert(
+                                                        "kw_updated_ms".into(),
+                                                        serde_json::json!(now_ms),
+                                                    );
                                                     changed = true;
                                                 }
                                             }
                                         }
                                     }
                                     if changed {
-                                        let _ = std::fs::write(&idx, serde_json::to_string_pretty(&v).unwrap_or_else(|_| s.clone()));
+                                        let _ = std::fs::write(
+                                            &idx,
+                                            serde_json::to_string_pretty(&v)
+                                                .unwrap_or_else(|_| s.clone()),
+                                        );
                                         metrics::counter!("index_compact_runs").increment(1);
                                     }
                                 }
@@ -2001,8 +2664,9 @@ async fn main() {
     }
     info!("Listening on http://{}", listener.local_addr().unwrap());
 
-    let server = axum::serve(listener, app)
-        .with_graceful_shutdown(async move { shutdown_token.cancelled().await; });
+    let server = axum::serve(listener, app).with_graceful_shutdown(async move {
+        shutdown_token.cancelled().await;
+    });
     if let Err(err) = server.await {
         error!("server error: {err}");
     }

--- a/backend/src/organ_builder.rs
+++ b/backend/src/organ_builder.rs
@@ -1,0 +1,126 @@
+/* neira:meta
+id: NEI-20251010-organ-builder
+intent: code
+summary: |-
+  Асинхронная сборка органов со стадиями Draft→Canary→Experimental→Stable,
+  сохранением шаблонов на диск и метрикой времени сборки.
+*/
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::Value;
+use tracing::info;
+
+/// Состояние сборки органа.
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OrganState {
+    Draft,
+    Canary,
+    Experimental,
+    Stable,
+    Failed,
+}
+
+/// Хранит шаблоны органов и их статусы.
+pub struct OrganBuilder {
+    templates: RwLock<HashMap<String, Value>>,
+    statuses: RwLock<HashMap<String, OrganState>>,
+    start_times: RwLock<HashMap<String, Instant>>,
+    counter: AtomicU64,
+    templates_dir: PathBuf,
+    enabled: bool,
+}
+
+impl OrganBuilder {
+    /// Создаёт новый орган-билдер. Включение контролируется переменной окружения
+    /// `ORGANS_BUILDER_ENABLED`.
+    pub fn new() -> Arc<Self> {
+        let enabled = std::env::var("ORGANS_BUILDER_ENABLED")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let dir = std::env::var("ORGANS_BUILDER_TEMPLATES_DIR")
+            .unwrap_or_else(|_| "organ_templates".into());
+        let templates_dir = PathBuf::from(dir);
+        if enabled {
+            let _ = std::fs::create_dir_all(&templates_dir);
+        }
+        Arc::new(Self {
+            templates: RwLock::new(HashMap::new()),
+            statuses: RwLock::new(HashMap::new()),
+            start_times: RwLock::new(HashMap::new()),
+            counter: AtomicU64::new(1),
+            templates_dir,
+            enabled,
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Сохраняет шаблон и возвращает идентификатор органа.
+    pub fn start_build(self: &Arc<Self>, tpl: Value) -> String {
+        let id = format!("organ-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        {
+            self.templates
+                .write()
+                .unwrap()
+                .insert(id.clone(), tpl.clone());
+            self.statuses
+                .write()
+                .unwrap()
+                .insert(id.clone(), OrganState::Draft);
+            self.start_times
+                .write()
+                .unwrap()
+                .insert(id.clone(), Instant::now());
+            let path = self.templates_dir.join(format!("{id}.json"));
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(path, tpl.to_string());
+        }
+        metrics::counter!("organ_build_attempts_total").increment(1);
+        info!(organ_id = %id, "organ build started");
+        let this = Arc::clone(self);
+        let build_id = id.clone();
+        tokio::spawn(async move {
+            let stages = [
+                (OrganState::Canary, 50u64),
+                (OrganState::Experimental, 50u64),
+                (OrganState::Stable, 50u64),
+            ];
+            for (state, delay) in stages {
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                this.update_status(&build_id, state);
+            }
+        });
+        id
+    }
+
+    /// Возвращает статус сборки.
+    pub fn status(&self, id: &str) -> Option<OrganState> {
+        metrics::counter!("organ_build_status_queries_total").increment(1);
+        self.statuses.read().unwrap().get(id).copied()
+    }
+
+    /// Ручное обновление статуса.
+    pub fn update_status(&self, id: &str, state: OrganState) -> Option<OrganState> {
+        let mut statuses = self.statuses.write().unwrap();
+        let prev = statuses.get_mut(id)?;
+        *prev = state;
+        if state == OrganState::Stable {
+            if let Some(start) = self.start_times.write().unwrap().remove(id) {
+                let ms = start.elapsed().as_millis() as f64;
+                metrics::histogram!("organ_build_duration_ms").record(ms);
+            }
+        }
+        Some(*prev)
+    }
+}

--- a/backend/src/policy/mod.rs
+++ b/backend/src/policy/mod.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Copy)]
 pub enum Capability {
     FactoryAdapter,
+    OrgansBuilder,
 }
 
 #[derive(Debug, Clone)]
@@ -23,14 +24,38 @@ pub struct PolicyError {
 }
 
 impl PolicyEngine {
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 
-    pub fn require_capability(&self, hub: &crate::interaction_hub::InteractionHub, cap: Capability) -> Result<(), PolicyError> {
+    pub fn require_capability(
+        &self,
+        hub: &crate::interaction_hub::InteractionHub,
+        cap: Capability,
+    ) -> Result<(), PolicyError> {
         match cap {
             Capability::FactoryAdapter => {
-                if hub.factory_is_adapter_enabled() { Ok(()) } else { Err(PolicyError{ code: "capability_disabled", reason: "factory_adapter is disabled".into(), capability: Some("factory_adapter") }) }
+                if hub.factory_is_adapter_enabled() {
+                    Ok(())
+                } else {
+                    Err(PolicyError {
+                        code: "capability_disabled",
+                        reason: "factory_adapter is disabled".into(),
+                        capability: Some("factory_adapter"),
+                    })
+                }
+            }
+            Capability::OrgansBuilder => {
+                if hub.organ_builder_enabled() {
+                    Ok(())
+                } else {
+                    Err(PolicyError {
+                        code: "capability_disabled",
+                        reason: "organs_builder is disabled".into(),
+                        capability: Some("organs_builder"),
+                    })
+                }
             }
         }
     }
 }
-

--- a/backend/tests/organ_builder_test.rs
+++ b/backend/tests/organ_builder_test.rs
@@ -1,0 +1,24 @@
+/* neira:meta
+id: NEI-20251010-organ-builder-test
+intent: test
+summary: Проверяет переходы стадий органа и ручное обновление статуса.
+*/
+use std::path::PathBuf;
+
+use backend::organ_builder::{OrganBuilder, OrganState};
+
+#[tokio::test]
+async fn organ_builder_progresses_and_updates() {
+    std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
+    let dir = PathBuf::from("backend/tests/tmp_organs");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.to_str().unwrap());
+    let builder = OrganBuilder::new();
+    let id = builder.start_build(serde_json::json!({"kind": "test"}));
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert_eq!(builder.status(&id), Some(OrganState::Stable));
+    builder.update_status(&id, OrganState::Failed);
+    assert_eq!(builder.status(&id), Some(OrganState::Failed));
+    assert!(dir.join(format!("{id}.json")).exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -3,6 +3,11 @@ id: NEI-20250923-factory-api-draft
 intent: docs
 summary: Черновой API Фабрикаторов (dry‑run/approve/rollback) и сборки органов.
 -->
+<!-- neira:meta
+id: NEI-20251010-organ-builder-status-route
+intent: docs
+summary: описан ручной апдейт статуса органа и метрика длительности сборки.
+-->
 
 # Factory API (Draft)
 
@@ -34,9 +39,16 @@ Adapter Contracts (обязательные хуки)
   - Gate: `organs_builder=experimental`
   - Body: { organ_template, dryrun?: true }
   - Resp: { organ_id, state: 'draft'|'canary'|'experimental'|'stable' }
+  - Logs `organ build started` и метрики `organ_build_attempts_total`, `organ_build_duration_ms`
 
 - GET `/organs/:id/status`
   - Resp: { id, state, nodes, metrics }
+  - Метрика: `organ_build_status_queries_total`
+
+- POST `/organs/:id/status`
+  - Body: { state: 'draft'|'canary'|'experimental'|'stable'|'failed' }
+  - Resp: { id, state }
+  - Позволяет вручную продвигать орган по стадиям
 
 ## Examples
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -9,6 +9,11 @@ id: NEI-20250922-analysis-queue-env-docs
 intent: docs
 summary: Добавлены переменные для адаптивных порогов очередей анализа.
 -->
+<!-- neira:meta
+id: NEI-20251010-organ-builder-env-docs
+intent: docs
+summary: описаны ORGANS_BUILDER_ENABLED и ORGANS_BUILDER_TEMPLATES_DIR.
+-->
 
 # ENV Reference (Истина)
 
@@ -44,7 +49,9 @@ summary: Добавлены переменные для адаптивных п�
 | INDEX_COMPACT_INTERVAL_MS   | int             | 300000                | compaction job          | Интервал фоновой чистки                                      |
 | SSE_WARN_AFTER_MS           | int             | 60000                 | SSE                     | Варнинг при долгом стриме                                    |
 | NERVOUS_SYSTEM_JSON_LOGS    | bool            | false                 | logging                 | JSON‑логи включить                                           |
-| MASK_PRESETS_DIR            | string          | config/mask_presets   | masking                 | Каталог пресетов масок                                       |
+| MASK_PRESETS_DIR            | string          | config/mask_presets   | masking                 | Каталог пресетов масок                                 |
+| ORGANS_BUILDER_ENABLED     | bool            | false                 | organ builder           | Включить модуль орган-билдера                          |
+| ORGANS_BUILDER_TEMPLATES_DIR | string        | organ_templates       | organ builder           | Каталог шаблонов органов                               |
 
 Лимиты `CONTEXT_MAX_LINES` и `CONTEXT_MAX_BYTES` при отсутствии в окружении
 оцениваются автоматически на основе свободного места диска и средней длины

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,3 +1,8 @@
+<!-- neira:meta
+id: NEI-20251010-organ-builder-metrics
+intent: docs
+summary: добавлена метрика organ_build_duration_ms и статусные запросы.
+-->
 # Реестр Метрик (Истина)
 
 | Имя | Тип | Единицы | Где инкрементируется | Назначение |
@@ -90,5 +95,8 @@
 | factory_rollbacks_total | counter | ops | Factory | Откаты узлов |
 | organ_build_attempts_total | counter | ops | OrganBuilder | Попытки сборки органов |
 | organ_build_failures_total | counter | ops | OrganBuilder | Ошибки сборки органов |
+| organ_build_status_queries_total | counter | ops | OrganBuilder | Запросы статуса органа |
+| organ_build_duration_ms | histogram | ms | OrganBuilder | Время от Draft до Stable |
+| organ_status_not_found_total | counter | ops | OrganBuilder | Запросы статуса к несуществующим органам |
 | training_iterations_total | counter | iters | Training | Итерации обучения новых узлов |
 | training_converged_total | counter | iters | Training | Конвергировали до стабильности |


### PR DESCRIPTION
## Summary
- add asynchronous organ builder with template persistence and duration metrics
- expose POST /organs/:id/status for manual state updates
- document organ builder env vars, metrics and capability examples

## Testing
- `cargo clippy -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44051610483239022057d051b2110