### PR TITLE
Add test for organ builder failure persistence

### DIFF
--- a/backend/tests/organ_builder_test.rs
+++ b/backend/tests/organ_builder_test.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20251010-organ-builder-test
 intent: test
-summary: Проверяет переходы стадий органа и ручное обновление статуса.
+summary: Проверяет переходы стадий органа, ручное обновление и удержание статуса `Failed`.
 */
 use std::path::PathBuf;
 
@@ -20,5 +20,20 @@ async fn organ_builder_progresses_and_updates() {
     builder.update_status(&id, OrganState::Failed);
     assert_eq!(builder.status(&id), Some(OrganState::Failed));
     assert!(dir.join(format!("{id}.json")).exists());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn organ_builder_failure_persists() {
+    std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
+    let dir = PathBuf::from("backend/tests/tmp_organs");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.to_str().unwrap());
+    let builder = OrganBuilder::new();
+    let id = builder.start_build(serde_json::json!({"kind": "test"}));
+    tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+    builder.update_status(&id, OrganState::Failed);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert_eq!(builder.status(&id), Some(OrganState::Failed));
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary
- ensure manual `Failed` status persists even after background progression

## Testing
- `cargo clippy --tests`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b489d831d48323a2b5bb507ed454ef