### PR TITLE
feat: add hearing module for stimuli system

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -184,7 +184,7 @@ capabilities:
 
   nervous_metrics_core:
     state: stable
-    notes: /metrics, базовые счётчики/гистограммы, warn для длинных SSE
+    notes: /metrics, базовые счётчики/гистограммы, warn для длинных SSE; ядро Системы раздражителей
     signals: [docs/reference/metrics.md]
 
   probes_capability:
@@ -247,7 +247,10 @@ capabilities:
 
   organ_hearing:
     state: locked
-    notes: аудиозахват + STT с маскированием; высокий риск приватности
+    notes: |
+      Аудиозахват + STT с маскированием; часть Системы раздражителей.
+      Включается фразой «Разблокируй organ_hearing».
+    signals: [stimuli_events_total]
 
   organ_voice:
     state: experimental

--- a/backend/src/hearing.rs
+++ b/backend/src/hearing.rs
@@ -1,0 +1,28 @@
+/* neira:meta
+id: NEI-20240519-hearing-wrapper
+intent: code
+summary: |
+  Обёртка вокруг tracing, отправляющая сообщения
+  в Систему раздражителей.
+*/
+
+use tracing::{info as tracing_info, warn as tracing_warn};
+
+const STIMULI_COUNTER: &str = "stimuli_events_total";
+
+/// Запись информационного сообщения и отправка его в Систему раздражителей.
+pub fn info(message: &str) {
+    tracing_info!("{}", message);
+    send("info", message);
+}
+
+/// Запись предупреждения и отправка его в Систему раздражителей.
+pub fn warn(message: &str) {
+    tracing_warn!("{}", message);
+    send("warn", message);
+}
+
+fn send(level: &str, _message: &str) {
+    metrics::counter!(STIMULI_COUNTER, "level" => level).increment(1);
+}
+

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -13,6 +13,7 @@ pub mod security;
 pub mod system;
 pub mod task_scheduler;
 pub mod trigger_detector;
+pub mod hearing;
 // duplicates removed
 
 // Global hub reference (optional), used for lightweight signals like Anti-Idle activity marks

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -17,7 +17,8 @@ use std::convert::Infallible;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::net::TcpListener;
-use tracing::{error, info};
+use tracing::error;
+use backend::hearing;
 
 use backend::action::chat_node::EchoChatNode;
 use backend::action::diagnostics_node::DiagnosticsNode;
@@ -223,7 +224,10 @@ async fn organ_status(
         }
         None => {
             metrics::counter!("organ_status_not_found_total").increment(1);
-            tracing::warn!(organ_id = %id, reason = "not_found", "organ status missing");
+            hearing::warn(&format!(
+                "organ status missing; organ_id={} reason=not_found",
+                id
+            ));
             Err(axum::http::StatusCode::NOT_FOUND)
         }
     }
@@ -965,7 +969,13 @@ async fn chat_stream(
                     }
                     if ratio >= loop_thresh || (entropy_min > 0.0 && ent < entropy_min) {
                         metrics::counter!("loop_detected_total").increment(1);
-                        tracing::warn!(chat_id=%req.chat_id, session_id=%req.session_id.clone().unwrap_or_default(), window=loop_win, ratio=%ratio, "loop detected in SSE stream; terminating early");
+                        hearing::warn(&format!(
+                            "loop detected in SSE stream; terminating early; chat_id={} session_id={} window={} ratio={}",
+                            req.chat_id,
+                            req.session_id.clone().unwrap_or_default(),
+                            loop_win,
+                            ratio
+                        ));
                         break;
                     }
                 }
@@ -983,7 +993,14 @@ async fn chat_stream(
         yield Ok(Event::default().event("progress").data(prog.to_string()));
         yield Ok(Event::default().event("done").data("true"));
         metrics::gauge!("sse_active").decrement(1.0);
-        if (elapsed * 1000.0) as u64 > warn_after_ms { tracing::warn!(duration_ms=(elapsed*1000.0) as u64, chat_id=%req.chat_id, session_id=%req.session_id.clone().unwrap_or_default(), "sse stream slow"); }
+        if (elapsed * 1000.0) as u64 > warn_after_ms {
+            hearing::warn(&format!(
+                "sse stream slow; duration_ms={} chat_id={} session_id={}",
+                (elapsed * 1000.0) as u64,
+                req.chat_id,
+                req.session_id.clone().unwrap_or_default()
+            ));
+        }
         if let Some(rid) = req_id2.as_deref() {
             hub_for_trace.trace_event(Some(rid), "chat.stream.done", serde_json::json!({"chat_id": chat_id2}));
         }
@@ -1759,9 +1776,15 @@ async fn main() {
                 metrics::counter!("sse_cancellations_total").increment(n as u64);
             }
             metrics::counter!("pause_drain_events_total").increment(1);
-            tracing::info!(auth=%auth, reason=%reason, cancelled_streams=n, "control: pause with drain");
+            hearing::info(&format!(
+                "control: pause with drain; auth={} reason={} cancelled_streams={}",
+                auth, reason, n
+            ));
         }
-        tracing::info!(request_id=%request_id, auth=%auth, reason=%reason, "control: pause");
+        hearing::info(&format!(
+            "control: pause; request_id={} auth={} reason={}",
+            request_id, auth, reason
+        ));
         let now_ms = chrono::Utc::now().timestamp_millis();
         Ok(Json(
             serde_json::json!({"paused": true, "reason": reason, "paused_since_ts_ms": now_ms}),
@@ -1798,7 +1821,10 @@ async fn main() {
             .paused
             .store(false, std::sync::atomic::Ordering::Relaxed);
         metrics::gauge!("paused_state").set(0.0);
-        tracing::info!(request_id=%request_id, auth=%auth, "control: resume");
+        hearing::info(&format!(
+            "control: resume; request_id={} auth={}",
+            request_id, auth
+        ));
         Ok(Json(serde_json::json!({"paused": false})))
     }
     async fn control_status(
@@ -1859,7 +1885,10 @@ async fn main() {
             .get("request_id")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        tracing::warn!(request_id=%request_id, auth=%auth, grace_ms=grace_ms, "control: kill (graceful)");
+        hearing::warn(&format!(
+            "control: kill (graceful); request_id={} auth={} grace_ms={}",
+            request_id, auth, grace_ms
+        ));
         metrics::counter!("kill_switch_total").increment(1);
         // Инициируем graceful shutdown сервера
         state.shutdown.cancel();
@@ -1976,7 +2005,7 @@ async fn main() {
                 obj["trace_file"] = serde_json::json!(tf.to_string_lossy());
             }
         }
-        tracing::info!("control: snapshot created");
+        hearing::info("control: snapshot created");
         let _ = std::fs::create_dir_all(&dir);
         let _ = std::fs::write(
             &path,


### PR DESCRIPTION
## Summary
- add `hearing` module to wrap tracing and emit stimuli events
- route backend logs through the new module
- document hearing organ activation in CAPABILITIES

## Testing
- `cargo test -p backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b503b9a9dc832390cea16d8d85a44b