### PR TITLE
fix(backend): use static lifetime for log level

### DIFF
--- a/backend/src/hearing.rs
+++ b/backend/src/hearing.rs
@@ -22,10 +22,6 @@ pub fn warn(message: &str) {
     send("warn", message);
 }
 
-
-fn send(level: &str, _message: &str) {
+fn send(level: &'static str, _message: &str) {
     metrics::counter!(STIMULI_COUNTER, "level" => level).increment(1);
 }
-
-
-


### PR DESCRIPTION
## Summary
- fix borrow-checker issue by requiring static string for log level

## Testing
- `cargo test --manifest-path backend/Cargo.toml`
- `cargo clippy --manifest-path backend/Cargo.toml --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68b50b6336d483238f0c7ee523d7a69c