### PR TITLE
test: serialize organ builder tests

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sha2",
  "sysinfo",
  "tempfile",
@@ -481,12 +482,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -494,6 +511,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -513,10 +547,15 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1546,6 +1585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1607,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -1655,6 +1709,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,6 +43,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"
 
 [patch.crates-io]
 kqueue-sys = { path = "../patches/kqueue-sys" }

--- a/backend/tests/organ_builder_test.rs
+++ b/backend/tests/organ_builder_test.rs
@@ -3,54 +3,57 @@ id: NEI-20251010-organ-builder-test
 intent: test
 summary: Проверяет переходы стадий органа, ручное обновление, удержание статуса `Failed` и очистку шаблонов по TTL.
 */
-use std::path::PathBuf;
-
 use backend::organ_builder::{OrganBuilder, OrganState};
+use serial_test::serial;
 
 #[tokio::test]
+#[serial]
 async fn organ_builder_progresses_and_updates() {
     std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
-    let dir = PathBuf::from("backend/tests/tmp_organs");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.to_str().unwrap());
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.path());
     let builder = OrganBuilder::new();
     let id = builder.start_build(serde_json::json!({"kind": "test"}));
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     assert_eq!(builder.status(&id), Some(OrganState::Stable));
     builder.update_status(&id, OrganState::Failed);
     assert_eq!(builder.status(&id), Some(OrganState::Failed));
-    assert!(dir.join(format!("{id}.json")).exists());
-    let _ = std::fs::remove_dir_all(&dir);
+    assert!(dir.path().join(format!("{id}.json")).exists());
+    std::env::remove_var("ORGANS_BUILDER_ENABLED");
+    std::env::remove_var("ORGANS_BUILDER_TEMPLATES_DIR");
 }
 
 #[tokio::test]
+#[serial]
 async fn organ_builder_failure_persists() {
     std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
-    let dir = PathBuf::from("backend/tests/tmp_organs");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.to_str().unwrap());
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.path());
     let builder = OrganBuilder::new();
     let id = builder.start_build(serde_json::json!({"kind": "test"}));
     tokio::time::sleep(std::time::Duration::from_millis(120)).await;
     builder.update_status(&id, OrganState::Failed);
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     assert_eq!(builder.status(&id), Some(OrganState::Failed));
-    let _ = std::fs::remove_dir_all(&dir);
+    std::env::remove_var("ORGANS_BUILDER_ENABLED");
+    std::env::remove_var("ORGANS_BUILDER_TEMPLATES_DIR");
 }
 
 #[tokio::test]
+#[serial]
 async fn organ_builder_removes_template_after_ttl() {
     std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
     std::env::set_var("ORGANS_BUILDER_TTL_SECS", "1");
-    let dir = PathBuf::from("backend/tests/tmp_organs");
-    let _ = std::fs::remove_dir_all(&dir);
-    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.to_str().unwrap());
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.path());
     let builder = OrganBuilder::new();
     let id = builder.start_build(serde_json::json!({"kind": "test"}));
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    assert!(dir.join(format!("{id}.json")).exists());
+    assert!(dir.path().join(format!("{id}.json")).exists());
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    assert!(!dir.join(format!("{id}.json")).exists());
+    assert!(!dir.path().join(format!("{id}.json")).exists());
     assert_eq!(builder.status(&id), Some(OrganState::Stable));
-    let _ = std::fs::remove_dir_all(&dir);
+    std::env::remove_var("ORGANS_BUILDER_ENABLED");
+    std::env::remove_var("ORGANS_BUILDER_TEMPLATES_DIR");
+    std::env::remove_var("ORGANS_BUILDER_TTL_SECS");
 }


### PR DESCRIPTION
## Summary
- add `serial_test` dev-dependency for backend
- switch organ builder integration tests to `tempfile` and serial execution

## Testing
- `cargo test --test organ_builder_test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68b5152a5d8c8323941a33767d15103d