### PR TITLE
feat(backend): restore organ statuses on startup

### DIFF
--- a/backend/ENV.md
+++ b/backend/ENV.md
@@ -63,8 +63,8 @@ SSE and logging
 
 Masking presets
 - MASK_PRESETS_DIR: directory with regex preset files named <preset>.txt (default: config/mask_presets)
-- ORGANS_BUILDER_ENABLED: enable organ builder module (default: false)
-- ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates (default: organ_templates)
+- ORGANS_BUILDER_ENABLED: enable organ builder module; restores statuses from templates_dir on startup (default: false)
+- ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates; existing *.json are loaded as stable (default: organ_templates)
 - ORGANS_BUILDER_TTL_SECS: seconds to keep organ templates after stabilization (default: 3600)
 
 ## Автоматическое определение `INTEGRITY_ROOT`

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -55,8 +55,8 @@ summary: добавлена переменная ORGANS_BUILDER_TTL_SECS для 
 | SSE_WARN_AFTER_MS           | int             | 60000                 | SSE                     | Варнинг при долгом стриме                |
 | NERVOUS_SYSTEM_JSON_LOGS    | bool            | false                 | logging                 | JSON‑логи включить                       |
 | MASK_PRESETS_DIR            | string          | config/mask_presets   | masking                 | Каталог пресетов масок                   |
-| ORGANS_BUILDER_ENABLED     | bool            | false                 | organ builder           | Включить модуль орган-билдера            |
-| ORGANS_BUILDER_TEMPLATES_DIR | string        | organ_templates       | organ builder           | Каталог шаблонов органов                 |
+| ORGANS_BUILDER_ENABLED     | bool            | false                 | organ builder           | Включить модуль; при запуске восстанавливает статусы из каталога |
+| ORGANS_BUILDER_TEMPLATES_DIR | string        | organ_templates       | organ builder           | Каталог шаблонов органов (все *.json загружаются как stable) |
 | ORGANS_BUILDER_TTL_SECS    | int             | 3600                  | organ builder           | Время хранения шаблонов после стабилизации (сек) |
 
 Лимиты `CONTEXT_MAX_LINES` и `CONTEXT_MAX_BYTES` при отсутствии в окружении

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -98,5 +98,6 @@ summary: добавлена метрика organ_build_duration_ms и стату
 | organ_build_status_queries_total | counter | ops | OrganBuilder | Запросы статуса органа |
 | organ_build_duration_ms | histogram | ms | OrganBuilder | Время от Draft до Stable |
 | organ_status_not_found_total | counter | ops | OrganBuilder | Запросы статуса к несуществующим органам |
+| organ_build_restored_total | counter | ops | OrganBuilder | Восстановленные органы при запуске |
 | training_iterations_total | counter | iters | Training | Итерации обучения новых узлов |
 | training_converged_total | counter | iters | Training | Конвергировали до стабильности |


### PR DESCRIPTION
## Summary
- load organ templates from disk and restore statuses when OrganBuilder starts
- log and report metric for restored organs
- document startup restoration and new metric

## Testing
- `cargo test --test organ_builder_test`

------
https://chatgpt.com/codex/tasks/task_e_68b5187b03c48323ba52731c785a1f69