### PR TITLE
feat: configurable organ builder stage delays

### DIFF
--- a/backend/ENV.md
+++ b/backend/ENV.md
@@ -14,10 +14,16 @@ id: NEI-20251010-organ-builder-env
 intent: docs
 summary: описаны переменные ORGANS_BUILDER_ENABLED, ORGANS_BUILDER_TEMPLATES_DIR и ORGANS_BUILDER_TTL_SECS.
 -->
+<!-- neira:meta
+id: NEI-20251101-organ-builder-stage-delays-env
+intent: docs
+summary: добавлена переменная ORGANS_BUILDER_STAGE_DELAYS_MS.
+-->
 
 Backend environment variables
 
 Note
+
 - Источником истины по переменным окружения является `docs/reference/env.md`.
 - Этот файл сохраняет обзор и пример `.env`, но при расхождениях доверяйте справочнику.
 
@@ -36,9 +42,9 @@ Note
 - NERVOUS_SYSTEM_ENABLED: enable Prometheus metrics and nervous system (default: true)
 - PROBES_HOST_METRICS_ENABLED: enable host metrics collection (default: true)
 - PROBES_IO_WATCHER_ENABLED: enable keyboard/display latency watcher (default: false, deprecated alias: IO_WATCHER_ENABLED)
- - ANALYSIS_QUEUE_FAST_MS: override boundary between fast and standard analysis queues in ms (default: adaptive)
- - ANALYSIS_QUEUE_LONG_MS: override boundary between standard and long analysis queues in ms (default: adaptive)
- - ANALYSIS_QUEUE_RECALC_MIN: number of new analysis requests before thresholds recompute (default: 100)
+- ANALYSIS_QUEUE_FAST_MS: override boundary between fast and standard analysis queues in ms (default: adaptive)
+- ANALYSIS_QUEUE_LONG_MS: override boundary between standard and long analysis queues in ms (default: adaptive)
+- ANALYSIS_QUEUE_RECALC_MIN: number of new analysis requests before thresholds recompute (default: 100)
 - INTEGRITY_ROOT: base dir for integrity config and files (default: current working directory; set explicitly if the service runs outside `backend/`)
 - INTEGRITY_CONFIG_PATH: path to integrity config file relative to INTEGRITY_ROOT or absolute (default: config/integrity.json)
 - INTEGRITY_CHECK_INTERVAL_MS: integrity check interval in ms (default: 60000)
@@ -48,24 +54,29 @@ estimates safe limits based on disk space and message size telemetry. Results
 are stored in `<CONTEXT_DIR>/storage_metrics.json` and updated over time.
 
 Idempotency and persist policy
+
 - IDEMPOTENT_PERSIST: enable persistent idempotency storage for request_id (default: false)
 - IDEMPOTENT_STORE_DIR: dir for idempotent store file (default: context)
 - IDEMPOTENT_TTL_SECS: TTL seconds for cached responses (default: 86400)
 - PERSIST_REQUIRE_SESSION_ID: if true, disallow persist=true without session_id (default: false)
 
 Index maintenance
+
 - INDEX_KW_TTL_DAYS: TTL days for keywords in index.json before compaction (default: 90)
 - INDEX_COMPACT_INTERVAL_MS: interval for background compaction job (default: 300000)
 
 SSE and logging
+
 - SSE_WARN_AFTER_MS: warn if a single SSE stream exceeds this duration (default: 60000)
 - NERVOUS_SYSTEM_JSON_LOGS: enable JSON logs for structured logging (default: false)
 
 Masking presets
+
 - MASK_PRESETS_DIR: directory with regex preset files named <preset>.txt (default: config/mask_presets)
 - ORGANS_BUILDER_ENABLED: enable organ builder module; restores statuses from templates_dir on startup (default: false)
-- ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates; existing *.json are loaded as stable (default: organ_templates)
+- ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates; existing \*.json are loaded as stable (default: organ_templates)
 - ORGANS_BUILDER_TTL_SECS: seconds to keep organ templates after stabilization (default: 3600)
+- ORGANS_BUILDER_STAGE_DELAYS_MS: comma-separated delays in ms for Draft→Canary→Experimental→Stable transitions (default: 50,50,50)
 
 ## Автоматическое определение `INTEGRITY_ROOT`
 
@@ -77,6 +88,7 @@ Masking presets
 структуре каталогов.
 
 How to use
+
 - Create a .env file in repo root or `backend/` and set variables.
 - The app loads env via dotenv at startup; env vars override .env.
 
@@ -105,3 +117,4 @@ NERVOUS_SYSTEM_JSON_LOGS=false
 MASK_PRESETS_DIR=./config/mask_presets
 ORGANS_BUILDER_ENABLED=false
 ORGANS_BUILDER_TEMPLATES_DIR=./organ_templates
+ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -8,6 +8,11 @@ id: NEI-20251010-organ-builder-status-route
 intent: docs
 summary: описан ручной апдейт статуса органа и метрика длительности сборки.
 -->
+<!-- neira:meta
+id: NEI-20251101-organ-builder-stage-delays-doc
+intent: docs
+summary: добавлен пример настройки ORGANS_BUILDER_STAGE_DELAYS_MS.
+-->
 
 # Factory API (Draft)
 
@@ -30,6 +35,7 @@ All routes require admin token unless noted. Exec routes are gated via CAPABILIT
   - Resp: { id, state: 'disabled'|'rolled_back' }
 
 Adapter Contracts (обязательные хуки)
+
 - Registry: регистрация NodeTemplate в файловом каталоге (`/nodes` API) + индексация в реестре.
 - Hub/NS/IS: автопубликация метрик (`factory_*`), статусы в интроспекции, проверки safe‑mode/политик.
 - Состояния: Draft → Canary → Experimental → Stable → (Disabled/RolledBack) — коды выдаются в API.
@@ -40,6 +46,7 @@ Adapter Contracts (обязательные хуки)
   - Body: { organ_template, dryrun?: true }
   - Resp: { organ_id, state: 'draft'|'canary'|'experimental'|'stable' }
   - Logs `organ build started` и метрики `organ_build_attempts_total`, `organ_build_duration_ms`
+  - Задержки стадий берутся из `ORGANS_BUILDER_STAGE_DELAYS_MS` (пример: `50,100,200` → canary/experimental/stable)
 
 - GET `/organs/:id/status`
   - Resp: { id, state, nodes, metrics }
@@ -50,10 +57,10 @@ Adapter Contracts (обязательные хуки)
   - Resp: { id, state }
   - Позволяет вручную продвигать орган по стадиям
 
-
 ## Examples
 
 Request (dry‑run, adapter):
+
 ```
 POST /factory/nodes/dryrun
 {
@@ -69,11 +76,20 @@ POST /factory/nodes/dryrun
 ```
 
 Response:
+
 ```
 {
   "ok": true,
   "report": { "analysis_type": "summary", "links": [], "risks": [] }
 }
 ```
+
+Stage delay config:
+
+```
+ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200
+```
+
 Notes
+
 - Exec backends (script/wasm) остаются locked. Сначала adapter‑only.


### PR DESCRIPTION
## Summary
- make organ builder stage delays configurable via `ORGANS_BUILDER_STAGE_DELAYS_MS`
- document new variable in backend env and factory API docs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b52313058c8323af1a27d2425b8165