### PR TITLE
feat: add organ build cancellation endpoint

### DIFF
--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -13,6 +13,7 @@ use crate::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord}
 use crate::config::Config;
 use crate::context::context_storage::{ChatMessage, ContextStorage, Role};
 use crate::factory::{FabricatorNode, FactoryService, SelectorNode};
+use crate::hearing;
 use crate::idempotent_store::IdempotentStore;
 use crate::organ_builder::{OrganBuilder, OrganState};
 use crate::security::integrity_checker_node::IntegrityCheckerNode;
@@ -25,7 +26,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::task::{spawn_blocking, JoinHandle};
 use tokio::time::{interval, sleep};
 use tokio_util::sync::CancellationToken;
-use crate::hearing;
 
 use crate::analysis_node::{AnalysisResult, NodeStatus};
 use crate::memory_node::MemoryNode;
@@ -313,25 +313,32 @@ impl InteractionHub {
         self.factory.counts()
     }
 
-// Organ builder accessors
-pub fn organ_builder_enabled(&self) -> bool {
-    self.organ_builder.is_enabled()
-}
-/* neira:meta
-id: NEI-20251010-organ-builder-update
-intent: code
-summary: добавлены методы обновления и получения статусов органа.
-*/
-pub fn organ_build(&self, tpl: serde_json::Value) -> String {
-    self.organ_builder.start_build(tpl)
-}
-pub fn organ_status(&self, id: &str) -> Option<OrganState> {
-    self.organ_builder.status(id)
-}
-pub fn organ_update_status(&self, id: &str, st: OrganState) -> Option<OrganState> {
-    self.organ_builder.update_status(id, st)
-}
-
+    // Organ builder accessors
+    pub fn organ_builder_enabled(&self) -> bool {
+        self.organ_builder.is_enabled()
+    }
+    /* neira:meta
+    id: NEI-20251010-organ-builder-update
+    intent: code
+    summary: добавлены методы обновления и получения статусов органа.
+    */
+    pub fn organ_build(&self, tpl: serde_json::Value) -> String {
+        self.organ_builder.start_build(tpl)
+    }
+    pub fn organ_status(&self, id: &str) -> Option<OrganState> {
+        self.organ_builder.status(id)
+    }
+    pub fn organ_update_status(&self, id: &str, st: OrganState) -> Option<OrganState> {
+        self.organ_builder.update_status(id, st)
+    }
+    /* neira:meta
+    id: NEI-20251115-organ-cancel-build-method
+    intent: code
+    summary: добавлен метод отмены сборки органа.
+    */
+    pub fn organ_cancel_build(&self, id: &str) -> bool {
+        self.organ_builder.cancel_build(id)
+    }
 
     pub fn is_trace_enabled(&self) -> bool {
         self.trace_enabled.load(Ordering::Relaxed)

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -13,6 +13,11 @@ id: NEI-20251101-organ-builder-stage-delays-doc
 intent: docs
 summary: добавлен пример настройки ORGANS_BUILDER_STAGE_DELAYS_MS.
 -->
+<!-- neira:meta
+id: NEI-20251115-organ-cancel-build-doc
+intent: docs
+summary: описан DELETE /organs/:id/build для отмены сборки.
+-->
 
 # Factory API (Draft)
 
@@ -56,6 +61,9 @@ Adapter Contracts (обязательные хуки)
   - Body: { state: 'draft'|'canary'|'experimental'|'stable'|'failed' }
   - Resp: { id, state }
   - Позволяет вручную продвигать орган по стадиям
+
+- DELETE `/organs/:id/build`
+  - Останавливает сборку органа и переводит его в `failed`
 
 ## Examples
 

--- a/docs/design/factory-system.md
+++ b/docs/design/factory-system.md
@@ -4,6 +4,11 @@ intent: design
 summary: |
   Каркас системы Фабрикаторов: FabricatorNode/SelectorNode, жизненный цикл узлов (Draft→Canary→Experimental→Stable), интеграции с Nervous/Immune, HITL‑обучение и органы.
 -->
+<!-- neira:meta
+id: NEI-20251115-organ-cancel-build-design
+intent: design
+summary: упомянут DELETE /organs/:id/build в API эскизе.
+-->
 
 # Factory System (Фабрикаторы)
 
@@ -38,6 +43,7 @@ API (эскиз)
 - POST `/factory/nodes/:id/approve|disable|rollback`
 - POST `/organs/build` (dryrun=true|false) → {organ_id, state}
 - GET `/organs/:id/status`
+- DELETE `/organs/:id/build`
 
 Metrics (минимальный набор)
 - factory_nodes_created_total, factory_nodes_active, factory_exec_errors_total

--- a/docs/guides/factory-shim.md
+++ b/docs/guides/factory-shim.md
@@ -3,6 +3,11 @@ id: NEI-20250831-factory-shim-guide
 intent: docs
 summary: Внешний оркестратор (Shim) для фабрики: CLI, LLM-агент, безопасные команды dry-run/create/approve без прямой связи с ядром Нейры.
 -->
+<!-- neira:meta
+id: NEI-20251115-organ-cancel-build-guide
+intent: docs
+summary: добавлена ссылка на DELETE /organs/:id/build как зарезервированный маршрут.
+-->
 
 # Factory Shim (External Orchestrator)
 
@@ -20,7 +25,7 @@ Endpoints (реализовано сейчас)
 
 Черновик (в доках, но ещё не реализовано в backend)
 
-- POST `/organs/build`, GET `/organs/:id/status` — зарезервированы для Organ Builder v0.
+- POST `/organs/build`, GET `/organs/:id/status`, DELETE `/organs/:id/build` — зарезервированы для Organ Builder v0.
 
 Safety & Policies
 


### PR DESCRIPTION
## Summary
- save JoinHandle for organ builds and expose `cancel_build`
- add REST endpoint `DELETE /organs/:id/build`
- document organ build cancellation

## Testing
- `cargo clippy --all -- -D warnings`
- `cargo test`
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b52c90ae5083238769b02c9043bb1b