### PR TITLE
feat: log organ status update errors

### DIFF
--- a/backend/tests/organ_builder_test.rs
+++ b/backend/tests/organ_builder_test.rs
@@ -97,3 +97,71 @@ async fn organ_builder_resumes_counter_from_disk() {
     std::env::remove_var("ORGANS_BUILDER_ENABLED");
     std::env::remove_var("ORGANS_BUILDER_TEMPLATES_DIR");
 }
+
+/* neira:meta
+id: NEI-20250317-organ-builder-update-missing-test
+intent: test
+summary: records error metric when updating status for unknown organ.
+*/
+#[tokio::test]
+#[serial]
+async fn organ_builder_records_status_update_error() {
+    std::env::set_var("ORGANS_BUILDER_ENABLED", "true");
+
+    use metrics::{
+        Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit,
+    };
+    use std::sync::{Arc, Mutex};
+
+    struct CounterRecorder {
+        data: Arc<Mutex<Vec<(String, u64)>>>,
+    }
+
+    impl Recorder for CounterRecorder {
+        fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+        fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+        fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+
+        fn register_counter(&self, key: &Key, _meta: &Metadata<'_>) -> Counter {
+            let name = key.name().to_string();
+            let data = self.data.clone();
+            let ctr = TestCounter { name, data };
+            Counter::from_arc(Arc::new(ctr))
+        }
+
+        fn register_gauge(&self, _key: &Key, _: &Metadata<'_>) -> Gauge {
+            Gauge::noop()
+        }
+
+        fn register_histogram(&self, _key: &Key, _: &Metadata<'_>) -> Histogram {
+            Histogram::noop()
+        }
+    }
+
+    struct TestCounter {
+        name: String,
+        data: Arc<Mutex<Vec<(String, u64)>>>,
+    }
+
+    impl metrics::CounterFn for TestCounter {
+        fn increment(&self, value: u64) {
+            self.data.lock().unwrap().push((self.name.clone(), value));
+        }
+    }
+
+    let data = Arc::new(Mutex::new(Vec::new()));
+    let recorder = CounterRecorder { data: data.clone() };
+    metrics::set_global_recorder(recorder).expect("set recorder");
+
+    let builder = OrganBuilder::new();
+    assert!(builder
+        .update_status("missing", OrganState::Failed)
+        .is_none());
+
+    let records = data.lock().unwrap();
+    assert!(records
+        .iter()
+        .any(|(n, v)| n == "organ_build_status_errors_total" && *v == 1));
+
+    std::env::remove_var("ORGANS_BUILDER_ENABLED");
+}

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -96,6 +96,12 @@ summary: добавлена метрика organ_build_duration_ms и стату
 | organ_build_attempts_total | counter | ops | OrganBuilder | Попытки сборки органов |
 | organ_build_failures_total | counter | ops | OrganBuilder | Ошибки сборки органов |
 | organ_build_status_queries_total | counter | ops | OrganBuilder | Запросы статуса органа |
+<!-- neira:meta
+id: NEI-20250317-organ-status-error-metric
+intent: docs
+summary: document organ_build_status_errors_total metric.
+-->
+| organ_build_status_errors_total | counter | ops | OrganBuilder | Ошибки обновления статуса |
 | organ_build_duration_ms | histogram | ms | OrganBuilder | Время от Draft до Stable |
 | organ_status_not_found_total | counter | ops | OrganBuilder | Запросы статуса к несуществующим органам |
 | organ_build_restored_total | counter | ops | OrganBuilder | Восстановленные органы при запуске |


### PR DESCRIPTION
## Summary
- count missing organ status updates and expose metric
- log update failures and return 404/409
- document new organ_build_status_errors_total metric

## Testing
- `cargo test`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b535a9415c8323b110ebad75248e9e