### PR TITLE
test: reuse shared metrics recorder

### DIFF
--- a/backend/tests/chat_node_metrics_test.rs
+++ b/backend/tests/chat_node_metrics_test.rs
@@ -1,51 +1,20 @@
+/* neira:meta
+id: NEI-20250317-chat-node-metrics-recorder
+intent: test
+summary: reuse shared recorder to avoid resetting global metrics.
+*/
 use backend::action::chat_node::{ChatNode, EchoChatNode};
 use backend::context::context_storage::FileContextStorage;
-use metrics::Recorder;
-use metrics::{Counter, Gauge, Histogram, Key, KeyName, SharedString, Unit};
-use std::sync::{Arc, Mutex};
 
-struct TestRecorder {
-    data: Arc<Mutex<Vec<(String, f64)>>>,
-}
-
-impl Recorder for TestRecorder {
-    fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
-    fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
-    fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
-
-    fn register_counter(&self, _key: &Key, _: &metrics::Metadata<'_>) -> Counter {
-        Counter::noop()
-    }
-    fn register_gauge(&self, _key: &Key, _: &metrics::Metadata<'_>) -> Gauge {
-        Gauge::noop()
-    }
-    fn register_histogram(&self, key: &Key, _: &metrics::Metadata<'_>) -> Histogram {
-        let name = key.name().to_string();
-        let data = self.data.clone();
-        let hist = TestHistogram { name, data };
-        Histogram::from_arc(Arc::new(hist))
-    }
-}
-
-struct TestHistogram {
-    name: String,
-    data: Arc<Mutex<Vec<(String, f64)>>>,
-}
-
-impl metrics::HistogramFn for TestHistogram {
-    fn record(&self, value: f64) {
-        self.data.lock().unwrap().push((self.name.clone(), value));
-    }
-}
+mod common;
+use common::init_recorder;
 
 #[tokio::test]
 async fn chat_node_records_duration_metric() {
     std::env::set_var("CONTEXT_FLUSH_MS", "0");
     let tmp = tempfile::tempdir().expect("tmpdir");
 
-    let data = Arc::new(Mutex::new(Vec::new()));
-    let recorder = TestRecorder { data: data.clone() };
-    metrics::set_global_recorder(recorder).expect("set recorder");
+    let data = init_recorder();
 
     let node = EchoChatNode::default();
     let storage = FileContextStorage::new(tmp.path().join("context"));
@@ -54,7 +23,9 @@ async fn chat_node_records_duration_metric() {
 
     let records = data.lock().unwrap();
     assert!(
-        records.iter().any(|(n, _)| n == "chat_node_request_duration_ms"),
+        records
+            .iter()
+            .any(|(n, _)| n == "chat_node_request_duration_ms"),
         "no histogram recorded"
     );
     assert!(

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -1,3 +1,8 @@
+/* neira:meta
+id: NEI-20250317-test-recorder-counters
+intent: test
+summary: shared recorder now captures counters in addition to histograms.
+*/
 use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -10,8 +15,11 @@ impl Recorder for TestRecorder {
     fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
     fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
 
-    fn register_counter(&self, _key: &Key, _metadata: &Metadata<'_>) -> Counter {
-        Counter::noop()
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
+        let name = key.name().to_string();
+        let data = self.data.clone();
+        let ctr = TestCounter { name, data };
+        Counter::from_arc(Arc::new(ctr))
     }
     fn register_gauge(&self, _key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         Gauge::noop()
@@ -35,15 +43,37 @@ impl metrics::HistogramFn for TestHistogram {
     }
 }
 
+struct TestCounter {
+    name: String,
+    data: Arc<Mutex<Vec<(String, f64)>>>,
+}
+
+impl metrics::CounterFn for TestCounter {
+    fn increment(&self, value: u64) {
+        self.data
+            .lock()
+            .unwrap()
+            .push((self.name.clone(), value as f64));
+    }
+    fn absolute(&self, value: u64) {
+        self.data
+            .lock()
+            .unwrap()
+            .push((self.name.clone(), value as f64));
+    }
+}
+
 static RECORDER: OnceLock<Arc<Mutex<Vec<(String, f64)>>>> = OnceLock::new();
 
 pub fn init_recorder() -> Arc<Mutex<Vec<(String, f64)>>> {
-    let data = RECORDER.get_or_init(|| {
-        let data = Arc::new(Mutex::new(Vec::new()));
-        let recorder = TestRecorder { data: data.clone() };
-        let _ = metrics::set_global_recorder(recorder);
-        data
-    }).clone();
+    let data = RECORDER
+        .get_or_init(|| {
+            let data = Arc::new(Mutex::new(Vec::new()));
+            let recorder = TestRecorder { data: data.clone() };
+            let _ = metrics::set_global_recorder(recorder);
+            data
+        })
+        .clone();
     data.lock().unwrap().clear();
     data
 }


### PR DESCRIPTION
## Summary
- extend shared test recorder to store counters
- reuse shared recorder in chat node metrics and organ builder tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b53934ccb883238930e486a56dd322