### PR TITLE
feat: add organ builder CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Documentation Index
 - [Низкоуровневая цепочка инструментов](docs/system/low-level-toolchain.md)
 - [Система самообновления](docs/system/self-updating-system.md)
 - [Пример использования](docs/guides/usage-example.md)
+- [Орган билдер CLI](docs/guides/usage-example.md#organ-builder-cli)
 - [CLI‑утилита валидации шаблонов](docs/legacy/usage-example.md)
 - [Практическое руководство](docs/guides/practical-guide.md)
 - [Глоссарий](docs/meta/glossary.md)

--- a/backend/src/bin/organ_builder.rs
+++ b/backend/src/bin/organ_builder.rs
@@ -1,0 +1,87 @@
+use std::env;
+use std::fs;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    if let Err(err) = run().await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    let cmd = args.next().ok_or_else(usage)?;
+    match cmd.as_str() {
+        "build" => {
+            let path = args.next().ok_or_else(usage)?;
+            let base = args.next().unwrap_or_else(default_base);
+            let content =
+                fs::read_to_string(&path).map_err(|e| format!("failed to read {path}: {e}"))?;
+            let template: serde_json::Value =
+                serde_json::from_str(&content).map_err(|e| format!("invalid JSON: {e}"))?;
+            let body = serde_json::json!({"organ_template": template});
+            let client = reqwest::Client::new();
+            let resp = client
+                .post(format!("{base}/organs/build"))
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+            let text = resp
+                .text()
+                .await
+                .map_err(|e| format!("response read failed: {e}"))?;
+            println!("{text}");
+        }
+        "status" => {
+            let id = args.next().ok_or_else(usage)?;
+            let base = args.next().unwrap_or_else(default_base);
+            let client = reqwest::Client::new();
+            let resp = client
+                .get(format!("{base}/organs/{id}/status"))
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+            if resp.status().is_success() {
+                let text = resp
+                    .text()
+                    .await
+                    .map_err(|e| format!("response read failed: {e}"))?;
+                println!("{text}");
+            } else {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_else(|_| String::new());
+                return Err(format!("status {status}: {text}"));
+            }
+        }
+        "cancel" => {
+            let id = args.next().ok_or_else(usage)?;
+            let base = args.next().unwrap_or_else(default_base);
+            let client = reqwest::Client::new();
+            let resp = client
+                .delete(format!("{base}/organs/{id}/build"))
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+            if resp.status().is_success() {
+                println!("cancelled");
+            } else {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_else(|_| String::new());
+                return Err(format!("status {status}: {text}"));
+            }
+        }
+        other => return Err(format!("unknown command: {other}")),
+    }
+    Ok(())
+}
+
+fn usage() -> String {
+    "usage: cargo run --bin organ_builder -- <command> <arg> [base_url]".to_string()
+}
+
+fn default_base() -> String {
+    env::var("NEIRA_API_BASE").unwrap_or_else(|_| "http://127.0.0.1:3000".into())
+}

--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -50,3 +50,18 @@ npm run dev
 - `POST /api/neira/interact` — общий вход для пользовательских запросов.
 - `POST /api/neira/analysis` — выполнение конкретного `AnalysisNode`.
 - `POST /api/neira/action` — запуск `ActionNode`.
+
+## Organ Builder CLI
+
+```bash
+# запуск сборки органа из шаблона
+cargo run -p backend --bin organ_builder -- build organ.json
+# проверка статуса
+cargo run -p backend --bin organ_builder -- status organ-1
+# отмена сборки
+cargo run -p backend --bin organ_builder -- cancel organ-1
+```
+
+По умолчанию используется адрес `http://127.0.0.1:3000`. Иной URL можно
+передать последним аргументом или через переменную окружения
+`NEIRA_API_BASE`.


### PR DESCRIPTION
## Summary
- add `organ_builder` command-line utility with build, status and cancel commands
- document organ builder CLI in README and usage guide

## Testing
- `cargo clippy --bin organ_builder`
- `cargo test --bin organ_builder`


------
https://chatgpt.com/codex/tasks/task_e_68b53d242ae883238dc13eb665d5ef6d