### PR TITLE
fix(organ_builder): handle build command errors

### DIFF
--- a/backend/src/bin/organ_builder.rs
+++ b/backend/src/bin/organ_builder.rs
@@ -29,11 +29,17 @@ async fn run() -> Result<(), String> {
                 .send()
                 .await
                 .map_err(|e| format!("request failed: {e}"))?;
-            let text = resp
-                .text()
-                .await
-                .map_err(|e| format!("response read failed: {e}"))?;
-            println!("{text}");
+            if resp.status().is_success() {
+                let text = resp
+                    .text()
+                    .await
+                    .map_err(|e| format!("response read failed: {e}"))?;
+                println!("{text}");
+            } else {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_else(|_| String::new());
+                return Err(format!("status {status}: {text}"));
+            }
         }
         "status" => {
             let id = args.next().ok_or_else(usage)?;


### PR DESCRIPTION
## Summary
- handle non-success responses in `organ_builder` build command
- preserve non-zero exit on errors

## Testing
- `cargo clippy --manifest-path backend/Cargo.toml -- -D warnings` *(fails: clippy reports numerous existing lint errors)*
- `cargo test --manifest-path backend/Cargo.toml -- --nocapture` *(hung: aborted after no progress)*

------
https://chatgpt.com/codex/tasks/task_e_68b5415ab0e88323aa7e5d9af8e6d1c6