### PR TITLE
fix: sort node doc paths for stable output

### DIFF
--- a/scripts/generate-node-docs.mjs
+++ b/scripts/generate-node-docs.mjs
@@ -4,8 +4,8 @@ intent: docs
 summary: |
   Generate markdown listing organs with their node identifiers.
 */
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
+import { promises as fs } from "node:fs";
+import path from "node:path";
 
 async function collectJsonFiles(dir) {
   const dirents = await fs.readdir(dir, { withFileTypes: true });
@@ -13,37 +13,40 @@ async function collectJsonFiles(dir) {
     dirents.map((dirent) => {
       const res = path.resolve(dir, dirent.name);
       if (dirent.isDirectory()) return collectJsonFiles(res);
-      if (dirent.isFile() && dirent.name.startsWith('organ.') && dirent.name.endsWith('.json'))
+      if (
+        dirent.isFile() &&
+        dirent.name.startsWith("organ.") &&
+        dirent.name.endsWith(".json")
+      )
         return [res];
       return [];
-    })
+    }),
   );
   return files.flat();
 }
 
 async function main() {
-  const files = await collectJsonFiles('examples');
+  const files = (await collectJsonFiles("examples")).sort();
   const lines = [
-    '<!-- neira:meta',
-    'id: NEI-20250101-000005-node-ids-doc',
-    'intent: docs',
-    'summary: |',
-    '  Node identifiers generated from organ specs.',
-    '-->',
-    '',
-    '# Node IDs',
-    ''
+    "<!-- neira:meta",
+    "id: NEI-20250101-000005-node-ids-doc",
+    "intent: docs",
+    "summary: |",
+    "  Node identifiers generated from organ specs.",
+    "-->",
+    "",
+    "# Node IDs",
+    "",
   ];
   for (const file of files) {
-    const data = JSON.parse(await fs.readFile(file, 'utf8'));
-    lines.push(`## ${data.id}`, '');
+    const data = JSON.parse(await fs.readFile(file, "utf8"));
+    lines.push(`## ${data.id}`, "");
     for (const node of data.nodes ?? []) {
       lines.push(`- ${node}`);
     }
-    lines.push('');
+    lines.push("");
   }
-  await fs.writeFile('docs/node-ids.md', lines.join('\n'));
+  await fs.writeFile("docs/node-ids.md", lines.join("\n"));
 }
 
 main();
-


### PR DESCRIPTION
## Summary
- sort collected JSON file paths before generating node docs for stable ordering
- regenerate Node ID docs (no changes)

## Testing
- `npx prettier scripts/generate-node-docs.mjs docs/node-ids.md -w`
- `npx eslint scripts/generate-node-docs.mjs`
- `node scripts/generate-node-docs.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54ca0314483238b01dea8dda7f18a