### PR TITLE
feat: add organ rebuild endpoint

### DIFF
--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -340,6 +340,15 @@ impl InteractionHub {
         self.organ_builder.cancel_build(id)
     }
 
+    /* neira:meta
+    id: NEI-20251205-organ-rebuild-method
+    intent: code
+    summary: добавлен метод перезапуска сборки органа по шаблону.
+    */
+    pub fn organ_rebuild(&self, id: &str) -> bool {
+        self.organ_builder.rebuild(id)
+    }
+
     pub fn is_trace_enabled(&self) -> bool {
         self.trace_enabled.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
## Summary
- support rebuilding organs using saved templates
- expose POST /organs/:id/rebuild endpoint
- cover rebuild logic with tests

## Testing
- `cargo clippy --tests`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b54f2987e08323bf18118ecafcb156