### PR TITLE
feat(frontend): add organs metrics panel

### DIFF
--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -23,6 +23,11 @@ id: NEI-20250207-factory-sample-templates-doc
 intent: docs
 summary: добавлен раздел Sample Templates с примерами органных шаблонов.
 -->
+<!-- neira:meta
+id: NEI-20250219-organs-panel-doc
+intent: docs
+summary: добавлен раздел о запуске панели органов.
+-->
 
 # Factory API (Draft)
 
@@ -107,6 +112,11 @@ ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200
 
 - [examples/organs/organ.echo.v1.json](../../examples/organs/organ.echo.v1.json) — минимальный эхо‑орган.
 - [examples/organs/organ.reverse.v1.json](../../examples/organs/organ.reverse.v1.json) — орган, разворачивающий текст.
+
+## Organs Panel
+
+1. `npm run frontend:dev`
+2. Открыть `http://localhost:5173/src/organs.html`.
 
 Notes
 

--- a/frontend/src/diagram.js
+++ b/frontend/src/diagram.js
@@ -1,0 +1,49 @@
+/* neira:meta
+id: NEI-20250219-metrics-diagram-component
+intent: example
+summary: |
+  Компонент диаграммы метрик: fetch /metrics и рисует простую гистограмму.
+*/
+
+/* global fetch, setInterval */
+export async function renderMetrics(canvas) {
+  async function load() {
+    try {
+      const res = await fetch('/metrics');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      const data = parseMetrics(text).slice(0, 5);
+      drawChart(data);
+    } catch (err) {
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillText(`Ошибка: ${err.message}`, 10, 20);
+    }
+  }
+
+  function parseMetrics(text) {
+    return text
+      .split('\n')
+      .filter(line => line && !line.startsWith('#'))
+      .map(line => {
+        const [name, value] = line.split(/\s+/);
+        return { name, value: Number(value) };
+      });
+  }
+
+  function drawChart(metrics) {
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const width = canvas.width / metrics.length;
+    metrics.forEach((m, i) => {
+      const h = Math.min(canvas.height, m.value);
+      ctx.fillStyle = '#4caf50';
+      ctx.fillRect(i * width + 2, canvas.height - h, width - 4, h);
+      ctx.fillStyle = '#000';
+      ctx.fillText(m.name, i * width + 4, canvas.height - h - 4);
+    });
+  }
+
+  await load();
+  setInterval(load, 5000);
+}

--- a/frontend/src/organs.html
+++ b/frontend/src/organs.html
@@ -1,0 +1,21 @@
+<!-- neira:meta
+id: NEI-20250219-organs-page
+intent: docs
+summary: |
+  Страница просмотра органов с диаграммой метрик.
+-->
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Органы</title>
+  </head>
+  <body>
+    <canvas id="chart" width="400" height="200"></canvas>
+    <script type="module">
+      import { renderMetrics } from './diagram.js';
+      const canvas = document.getElementById('chart');
+      renderMetrics(canvas);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add simple metrics diagram component and organs page
- document how to launch organs panel

## Testing
- `npm test`
- `npm test --prefix frontend`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b55afe48cc8323a8b5ae276697e460