### PR TITLE
feat: allow metrics panel to target backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1503,7 +1504,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1953,6 +1954,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1527,7 +1528,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2017,6 +2018,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -40,6 +40,7 @@ metrics = "0.24"
 sysinfo = "0.30"
 sha2 = "0.10"
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
+tower-http = { version = "0.5", features = ["cors"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,6 +19,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tokio::net::TcpListener;
 use tracing::error;
+use tower_http::cors::CorsLayer;
 
 use backend::action::chat_node::EchoChatNode;
 use backend::action::diagnostics_node::DiagnosticsNode;
@@ -2685,7 +2686,15 @@ async fn main() {
     if let Some(handle) = metrics_handle {
         app = app.route("/metrics", get(move || async move { handle.render() }));
     }
-    let app = app.with_state(state);
+    /* neira:meta
+    id: NEI-20250220-enable-cors
+    intent: docs
+    summary: |
+      Добавлен permissive CORS слой для доступа панели органов.
+    */
+    let app = app
+        .layer(CorsLayer::permissive())
+        .with_state(state);
 
     // Index compaction job (keywords TTL cleanup)
     let compact_every_ms = std::env::var("INDEX_COMPACT_INTERVAL_MS")

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -23,6 +23,16 @@ id: NEI-20250207-factory-sample-templates-doc
 intent: docs
 summary: добавлен раздел Sample Templates с примерами органных шаблонов.
 -->
+<!-- neira:meta
+id: NEI-20250219-organs-panel-doc
+intent: docs
+summary: добавлен раздел о запуске панели органов.
+-->
+<!-- neira:meta
+id: NEI-20250220-organs-panel-api-url-doc
+intent: docs
+summary: добавлена переменная VITE_API_URL для подключения к бэкенду.
+-->
 
 # Factory API (Draft)
 
@@ -107,6 +117,12 @@ ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200
 
 - [examples/organs/organ.echo.v1.json](../../examples/organs/organ.echo.v1.json) — минимальный эхо‑орган.
 - [examples/organs/organ.reverse.v1.json](../../examples/organs/organ.reverse.v1.json) — орган, разворачивающий текст.
+
+## Organs Panel
+
+1. `VITE_API_URL=http://localhost:3000 npm run frontend:dev`
+2. Открыть `http://localhost:5173/src/organs.html`.
+3. Бэкенд должен быть запущен на `http://localhost:3000` (CORS включён).
 
 Notes
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -19,6 +19,11 @@ id: NEI-20251015-organ-builder-ttl-docs
 intent: docs
 summary: добавлена переменная ORGANS_BUILDER_TTL_SECS для очистки шаблонов.
 -->
+<!-- neira:meta
+id: NEI-20250220-vite-api-url-env-doc
+intent: docs
+summary: описан VITE_API_URL для подключения фронтенда к бэкенду.
+-->
 
 # ENV Reference (Истина)
 
@@ -148,3 +153,9 @@ summary: добавлена переменная ORGANS_BUILDER_TTL_SECS для 
 | IDLE_REQUIRE_APPROVAL_FOR_NEW_DOMAINS | bool   | true           | safety           | Одобрение новых доменов задач       |
 | IDLE_REPORT_FREQUENCY                 | enum   | on_user_return | reporting        | Частота отчётов                     |
 | IDLE_DETAILED_LOGS                    | bool   | true           | reporting        | Детальные логи                      |
+ 
+### Frontend
+
+| Переменная  | Тип    | Дефолт              | Раздел    | Описание                                      |
+| ----------- | ------ | ------------------- | --------- | --------------------------------------------- |
+| VITE_API_URL | string | http://localhost:3000 | frontend | Базовый URL бэкенда для панели органов (CORS включён) |

--- a/frontend/src/diagram.js
+++ b/frontend/src/diagram.js
@@ -1,0 +1,51 @@
+/* neira:meta
+id: NEI-20250219-metrics-diagram-component
+intent: example
+summary: |
+  Компонент диаграммы метрик: fetch `${API_URL}/metrics` и рисует простую гистограмму.
+*/
+
+const API_URL = (import.meta.env.VITE_API_URL ?? '').replace(/\/$/, '');
+
+/* global fetch, setInterval */
+export async function renderMetrics(canvas) {
+  async function load() {
+    try {
+      const res = await fetch(`${API_URL}/metrics`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const text = await res.text();
+      const data = parseMetrics(text).slice(0, 5);
+      drawChart(data);
+    } catch (err) {
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillText(`Ошибка: ${err.message}`, 10, 20);
+    }
+  }
+
+  function parseMetrics(text) {
+    return text
+      .split('\n')
+      .filter(line => line && !line.startsWith('#'))
+      .map(line => {
+        const [name, value] = line.split(/\s+/);
+        return { name, value: Number(value) };
+      });
+  }
+
+  function drawChart(metrics) {
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const width = canvas.width / metrics.length;
+    metrics.forEach((m, i) => {
+      const h = Math.min(canvas.height, m.value);
+      ctx.fillStyle = '#4caf50';
+      ctx.fillRect(i * width + 2, canvas.height - h, width - 4, h);
+      ctx.fillStyle = '#000';
+      ctx.fillText(m.name, i * width + 4, canvas.height - h - 4);
+    });
+  }
+
+  await load();
+  setInterval(load, 5000);
+}

--- a/frontend/src/organs.html
+++ b/frontend/src/organs.html
@@ -1,0 +1,21 @@
+<!-- neira:meta
+id: NEI-20250219-organs-page
+intent: docs
+summary: |
+  Страница просмотра органов с диаграммой метрик.
+-->
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Органы</title>
+  </head>
+  <body>
+    <canvas id="chart" width="400" height="200"></canvas>
+    <script type="module">
+      import { renderMetrics } from './diagram.js';
+      const canvas = document.getElementById('chart');
+      renderMetrics(canvas);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- fetch metrics from configurable `VITE_API_URL`
- enable permissive CORS in backend for metrics
- document `VITE_API_URL` and update organs panel instructions

## Testing
- `npm test`
- `npm test --prefix frontend`
- `npm run lint`
- `cargo clippy --manifest-path backend/Cargo.toml`
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b55afe48cc8323a8b5ae276697e460