### PR TITLE
feat: clean expired organ templates

### DIFF
--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -19,6 +19,11 @@ id: NEI-20251015-organ-builder-ttl-docs
 intent: docs
 summary: добавлена переменная ORGANS_BUILDER_TTL_SECS для очистки шаблонов.
 -->
+<!-- neira:meta
+id: NEI-20251220-organ-builder-ttl-docs-update
+intent: docs
+summary: уточнено, что фоновой таймер удаляет шаблоны и статусы старше TTL.
+-->
 
 <!-- neira:meta
 id: NEI-20251116-vite-api-url-env-doc
@@ -28,43 +33,43 @@ summary: Добавлена переменная VITE_API_URL для фронт�
 
 # ENV Reference (Истина)
 
-| Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                          |
-| ---------------------------- | --------------- | --------------------- | ----------------------- | ---------------------------------------------------------------- |
-| CONTEXT_DIR                  | string          | context               | backend context storage | База для истории чатов                                           |
-| CONTEXT_MAX_LINES            | int             | adaptive              | storage trim            | Ограничение строк (автоподбор, можно переопределить)             |
-| CONTEXT_MAX_BYTES            | int             | adaptive              | storage trim            | Ограничение размера файла (автоподбор, можно переопределить)     |
-| CONTEXT_DAILY_ROTATION       | bool            | true                  | storage rotation        | Ротация по дням                                                  |
-| CONTEXT_ARCHIVE_GZ           | bool            | true                  | storage rotation        | Архивирование .gz прошлых дней                                   |
-| CONTEXT_FLUSH_MS             | int             | 0                     | storage buffering       | Буферизованная запись, 0=выкл                                    |
-| MASK_PII                     | bool            | true                  | storage masking         | Маскирование PII по умолчанию                                    |
-| MASK_REGEX                   | string list (;) | —                     | storage masking         | Кастомные regex для маскирования                                 |
-| MASK_ROLES                   | string list (,) | user                  | storage masking         | Роли для маскирования                                            |
-| NODE_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов узлов                                           |
-| CHAT_RATE_LIMIT_PER_MIN      | int             | 120                   | hub rate limit          | Лимит запросов в минуту                                          |
-| CHAT_RATE_KEY                | enum            | auth                  | hub rate limit          | Ключ лимита: auth/chat/session                                   |
-| IO_WATCHER_THRESHOLD_MS      | int             | 100                   | nervous probes          | Порог латентности для проб                                       |
-| ANALYSIS_QUEUE_FAST_MS       | int             | adaptive              | queue thresholds        | Граница Fast/Standard очереди                                    |
-| ANALYSIS_QUEUE_LONG_MS       | int             | adaptive              | queue thresholds        | Граница Standard/Long очереди                                    |
-| ANALYSIS_QUEUE_RECALC_MIN    | int             | 100                   | queue thresholds        | Новые запросы для пересчёта                                      |
-| NERVOUS_SYSTEM_ENABLED       | bool            | true                  | metrics/init            | Вклюить /metrics и «нервную» подсистему                          |
-| PROBES_HOST_METRICS_ENABLED  | bool            | true                  | nervous probes          | Включить сбор хост‑метрик                                        |
-| PROBES_IO_WATCHER_ENABLED    | bool            | false                 | nervous probes          | Включить наблюдатель ввода/вывода                                |
-| INTEGRITY_ROOT               | string          | cwd                   | immune/integrity        | Корень для конфигов интегрити                                    |
-| INTEGRITY_CONFIG_PATH        | string          | config/integrity.json | immune/integrity        | Путь к конфигу                                                   |
-| INTEGRITY_CHECK_INTERVAL_MS  | int             | 60000                 | immune/integrity        | Интервал проверки                                                |
-| IDEMPOTENT_PERSIST           | bool            | false                 | hub idempotency         | Персистентный idempotent‑кэш                                     |
-| IDEMPOTENT_STORE_DIR         | string          | context               | idem store              | Каталог файла кэша                                               |
-| IDEMPOTENT_TTL_SECS          | int             | 86400                 | idem store              | TTL ответов                                                      |
-| PERSIST_REQUIRE_SESSION_ID   | bool            | false                 | hub policies            | Запрет persist без session_id                                    |
-| INDEX_KW_TTL_DAYS            | int             | 90                    | index compaction        | TTL ключевых слов в index.json                                   |
-| INDEX_COMPACT_INTERVAL_MS    | int             | 300000                | compaction job          | Интервал фоновой чистки                                          |
-| SSE_WARN_AFTER_MS            | int             | 60000                 | SSE                     | Варнинг при долгом стриме                                        |
-| NERVOUS_SYSTEM_JSON_LOGS     | bool            | false                 | logging                 | JSON‑логи включить                                               |
-| MASK_PRESETS_DIR             | string          | config/mask_presets   | masking                 | Каталог пресетов масок                                           |
-| ORGANS_BUILDER_ENABLED       | bool            | false                 | organ builder           | Включить модуль; при запуске восстанавливает статусы из каталога |
-| ORGANS_BUILDER_TEMPLATES_DIR | string          | organ_templates       | organ builder           | Каталог шаблонов органов (все \*.json загружаются как stable)    |
-| ORGANS_BUILDER_TTL_SECS      | int             | 3600                  | organ builder           | Время хранения шаблонов после стабилизации (сек)                 |
-| VITE_API_URL                 | string          | —                     | frontend requests       | Базовый URL API для фронтенда                                    |
+| Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                                            |
+| ---------------------------- | --------------- | --------------------- | ----------------------- | ---------------------------------------------------------------------------------- |
+| CONTEXT_DIR                  | string          | context               | backend context storage | База для истории чатов                                                             |
+| CONTEXT_MAX_LINES            | int             | adaptive              | storage trim            | Ограничение строк (автоподбор, можно переопределить)                               |
+| CONTEXT_MAX_BYTES            | int             | adaptive              | storage trim            | Ограничение размера файла (автоподбор, можно переопределить)                       |
+| CONTEXT_DAILY_ROTATION       | bool            | true                  | storage rotation        | Ротация по дням                                                                    |
+| CONTEXT_ARCHIVE_GZ           | bool            | true                  | storage rotation        | Архивирование .gz прошлых дней                                                     |
+| CONTEXT_FLUSH_MS             | int             | 0                     | storage buffering       | Буферизованная запись, 0=выкл                                                      |
+| MASK_PII                     | bool            | true                  | storage masking         | Маскирование PII по умолчанию                                                      |
+| MASK_REGEX                   | string list (;) | —                     | storage masking         | Кастомные regex для маскирования                                                   |
+| MASK_ROLES                   | string list (,) | user                  | storage masking         | Роли для маскирования                                                              |
+| NODE_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов узлов                                                             |
+| CHAT_RATE_LIMIT_PER_MIN      | int             | 120                   | hub rate limit          | Лимит запросов в минуту                                                            |
+| CHAT_RATE_KEY                | enum            | auth                  | hub rate limit          | Ключ лимита: auth/chat/session                                                     |
+| IO_WATCHER_THRESHOLD_MS      | int             | 100                   | nervous probes          | Порог латентности для проб                                                         |
+| ANALYSIS_QUEUE_FAST_MS       | int             | adaptive              | queue thresholds        | Граница Fast/Standard очереди                                                      |
+| ANALYSIS_QUEUE_LONG_MS       | int             | adaptive              | queue thresholds        | Граница Standard/Long очереди                                                      |
+| ANALYSIS_QUEUE_RECALC_MIN    | int             | 100                   | queue thresholds        | Новые запросы для пересчёта                                                        |
+| NERVOUS_SYSTEM_ENABLED       | bool            | true                  | metrics/init            | Вклюить /metrics и «нервную» подсистему                                            |
+| PROBES_HOST_METRICS_ENABLED  | bool            | true                  | nervous probes          | Включить сбор хост‑метрик                                                          |
+| PROBES_IO_WATCHER_ENABLED    | bool            | false                 | nervous probes          | Включить наблюдатель ввода/вывода                                                  |
+| INTEGRITY_ROOT               | string          | cwd                   | immune/integrity        | Корень для конфигов интегрити                                                      |
+| INTEGRITY_CONFIG_PATH        | string          | config/integrity.json | immune/integrity        | Путь к конфигу                                                                     |
+| INTEGRITY_CHECK_INTERVAL_MS  | int             | 60000                 | immune/integrity        | Интервал проверки                                                                  |
+| IDEMPOTENT_PERSIST           | bool            | false                 | hub idempotency         | Персистентный idempotent‑кэш                                                       |
+| IDEMPOTENT_STORE_DIR         | string          | context               | idem store              | Каталог файла кэша                                                                 |
+| IDEMPOTENT_TTL_SECS          | int             | 86400                 | idem store              | TTL ответов                                                                        |
+| PERSIST_REQUIRE_SESSION_ID   | bool            | false                 | hub policies            | Запрет persist без session_id                                                      |
+| INDEX_KW_TTL_DAYS            | int             | 90                    | index compaction        | TTL ключевых слов в index.json                                                     |
+| INDEX_COMPACT_INTERVAL_MS    | int             | 300000                | compaction job          | Интервал фоновой чистки                                                            |
+| SSE_WARN_AFTER_MS            | int             | 60000                 | SSE                     | Варнинг при долгом стриме                                                          |
+| NERVOUS_SYSTEM_JSON_LOGS     | bool            | false                 | logging                 | JSON‑логи включить                                                                 |
+| MASK_PRESETS_DIR             | string          | config/mask_presets   | masking                 | Каталог пресетов масок                                                             |
+| ORGANS_BUILDER_ENABLED       | bool            | false                 | organ builder           | Включить модуль; при запуске восстанавливает статусы из каталога                   |
+| ORGANS_BUILDER_TEMPLATES_DIR | string          | organ_templates       | organ builder           | Каталог шаблонов органов (все \*.json загружаются как stable)                      |
+| ORGANS_BUILDER_TTL_SECS      | int             | 3600                  | organ builder           | Время хранения шаблонов и статусов; фоновый таймер удаляет записи старше TTL (сек) |
+| VITE_API_URL                 | string          | —                     | frontend requests       | Базовый URL API для фронтенда                                                      |
 
 Лимиты `CONTEXT_MAX_LINES` и `CONTEXT_MAX_BYTES` при отсутствии в окружении
 оцениваются автоматически на основе свободного места диска и средней длины


### PR DESCRIPTION
## Summary
- add background cleanup timer for OrganBuilder
- purge template/status entries when TTL elapses
- document ORGANS_BUILDER_TTL_SECS

## Testing
- `cargo clippy --all-targets -- -A clippy::assertions-on-constants`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5813011f88323aa6ad1b7683505f3