### PR TITLE
feat: allow configuring organ builder stage delays

### DIFF
--- a/backend/ENV.md
+++ b/backend/ENV.md
@@ -17,7 +17,12 @@ summary: описаны переменные ORGANS_BUILDER_ENABLED, ORGANS_BUIL
 <!-- neira:meta
 id: NEI-20251101-organ-builder-stage-delays-env
 intent: docs
-summary: добавлена переменная ORGANS_BUILDER_STAGE_DELAYS_MS.
+summary: добавлена переменная ORGANS_BUILDER_STAGE_DELAYS.
+-->
+<!-- neira:meta
+id: NEI-20250620-organ-builder-stage-delays-env-rename
+intent: docs
+summary: переменная переименована в ORGANS_BUILDER_STAGE_DELAYS.
 -->
 
 Backend environment variables
@@ -76,7 +81,7 @@ Masking presets
 - ORGANS_BUILDER_ENABLED: enable organ builder module; restores statuses from templates_dir on startup (default: false)
 - ORGANS_BUILDER_TEMPLATES_DIR: directory to store organ templates; existing \*.json are loaded as stable (default: organ_templates)
 - ORGANS_BUILDER_TTL_SECS: seconds to keep organ templates after stabilization (default: 3600)
-- ORGANS_BUILDER_STAGE_DELAYS_MS: comma-separated delays in ms for Draft→Canary→Experimental→Stable transitions (default: 50,50,50)
+- ORGANS_BUILDER_STAGE_DELAYS: comma-separated delays in ms for Draft→Canary→Experimental→Stable transitions (default: 50,50,50)
 
 ## Автоматическое определение `INTEGRITY_ROOT`
 
@@ -117,4 +122,4 @@ NERVOUS_SYSTEM_JSON_LOGS=false
 MASK_PRESETS_DIR=./config/mask_presets
 ORGANS_BUILDER_ENABLED=false
 ORGANS_BUILDER_TEMPLATES_DIR=./organ_templates
-ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200
+ORGANS_BUILDER_STAGE_DELAYS=50,100,200

--- a/backend/src/organ_builder.rs
+++ b/backend/src/organ_builder.rs
@@ -10,7 +10,12 @@ summary: |-
 /* neira:meta
 id: NEI-20251101-organ-builder-stage-delays
 intent: code
-summary: Задержки переходов между стадиями читаются из ORGANS_BUILDER_STAGE_DELAYS_MS.
+summary: Задержки переходов между стадиями читаются из ORGANS_BUILDER_STAGE_DELAYS.
+*/
+/* neira:meta
+id: NEI-20250620-organ-builder-stage-delays-env
+intent: code
+summary: переименована переменная на ORGANS_BUILDER_STAGE_DELAYS.
 */
 /* neira:meta
 id: NEI-20251115-organ-cancel-build
@@ -78,7 +83,7 @@ impl OrganBuilder {
             .and_then(|v| v.parse().ok())
             .unwrap_or(3600);
         let stages_env =
-            std::env::var("ORGANS_BUILDER_STAGE_DELAYS_MS").unwrap_or_else(|_| "50,50,50".into());
+            std::env::var("ORGANS_BUILDER_STAGE_DELAYS").unwrap_or_else(|_| "50,50,50".into());
         let stages = parse_stage_delays(&stages_env);
         if enabled {
             let _ = std::fs::create_dir_all(&templates_dir);
@@ -353,7 +358,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_build_stops_task() {
         std::env::set_var("ORGANS_BUILDER_ENABLED", "1");
-        std::env::set_var("ORGANS_BUILDER_STAGE_DELAYS_MS", "1000,1000,1000");
+        std::env::set_var("ORGANS_BUILDER_STAGE_DELAYS", "1000,1000,1000");
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("ORGANS_BUILDER_TEMPLATES_DIR", dir.path());
         let builder = OrganBuilder::new();

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -11,7 +11,12 @@ summary: описан ручной апдейт статуса органа и �
 <!-- neira:meta
 id: NEI-20251101-organ-builder-stage-delays-doc
 intent: docs
-summary: добавлен пример настройки ORGANS_BUILDER_STAGE_DELAYS_MS.
+summary: добавлен пример настройки ORGANS_BUILDER_STAGE_DELAYS.
+-->
+<!-- neira:meta
+id: NEI-20250620-organ-builder-stage-delays-doc-rename
+intent: docs
+summary: пример обновлён под ORGANS_BUILDER_STAGE_DELAYS.
 -->
 <!-- neira:meta
 id: NEI-20251115-organ-cancel-build-doc
@@ -61,7 +66,7 @@ Adapter Contracts (обязательные хуки)
   - Body: { organ_template, dryrun?: true }
   - Resp: { organ_id, state: 'draft'|'canary'|'experimental'|'stable' }
   - Logs `organ build started` и метрики `organ_build_attempts_total`, `organ_build_duration_ms`
-  - Задержки стадий берутся из `ORGANS_BUILDER_STAGE_DELAYS_MS` (пример: `50,100,200` → canary/experimental/stable)
+  - Задержки стадий берутся из `ORGANS_BUILDER_STAGE_DELAYS` (пример: `50,100,200` → canary/experimental/stable)
 
 - GET `/organs/:id/status`
   - Resp: { id, state, nodes, metrics }
@@ -105,7 +110,7 @@ Response:
 Stage delay config:
 
 ```
-ORGANS_BUILDER_STAGE_DELAYS_MS=50,100,200
+ORGANS_BUILDER_STAGE_DELAYS=50,100,200
 ```
 
 ## Sample Templates

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -24,6 +24,11 @@ id: NEI-20251220-organ-builder-ttl-docs-update
 intent: docs
 summary: уточнено, что фоновой таймер удаляет шаблоны и статусы старше TTL.
 -->
+<!-- neira:meta
+id: NEI-20250620-organ-builder-stage-delays-docs
+intent: docs
+summary: добавлена переменная ORGANS_BUILDER_STAGE_DELAYS.
+-->
 
 <!-- neira:meta
 id: NEI-20251116-vite-api-url-env-doc
@@ -69,6 +74,7 @@ summary: Добавлена переменная VITE_API_URL для фронт�
 | ORGANS_BUILDER_ENABLED       | bool            | false                 | organ builder           | Включить модуль; при запуске восстанавливает статусы из каталога                   |
 | ORGANS_BUILDER_TEMPLATES_DIR | string          | organ_templates       | organ builder           | Каталог шаблонов органов (все \*.json загружаются как stable)                      |
 | ORGANS_BUILDER_TTL_SECS      | int             | 3600                  | organ builder           | Время хранения шаблонов и статусов; фоновый таймер удаляет записи старше TTL (сек) |
+| ORGANS_BUILDER_STAGE_DELAYS  | string list (,) | 50,50,50              | organ builder           | Задержки стадий Draft→Canary→Experimental→Stable (мс)                              |
 | VITE_API_URL                 | string          | —                     | frontend requests       | Базовый URL API для фронтенда                                                      |
 
 Лимиты `CONTEXT_MAX_LINES` и `CONTEXT_MAX_BYTES` при отсутствии в окружении


### PR DESCRIPTION
## Summary
- read organ builder stage delays from `ORGANS_BUILDER_STAGE_DELAYS`
- parse comma-separated delays like `50,100,200`
- document new env var and update examples

## Testing
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b58836892483238dd79d5119b9798c