### PR TITLE
refactor: move system module into nervous_system

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,11 +515,11 @@ scp target/release/neira user@server:/opt/neira
 ## Подключение пользовательского плагина
 
 Neira поддерживает пользовательские системные плагины. Для интеграции
-нужно реализовать трейt [`SystemProbe`](backend/src/system/mod.rs) и
+нужно реализовать трейt [`SystemProbe`](backend/src/nervous_system/mod.rs) и
 запустить его в фоне:
 
 ```rust
-use neira::system::SystemProbe;
+use neira::nervous_system::SystemProbe;
 
 struct CustomProbe;
 

--- a/backend/src/interaction_hub.rs
+++ b/backend/src/interaction_hub.rs
@@ -15,11 +15,11 @@ use crate::context::context_storage::{ChatMessage, ContextStorage, Role};
 use crate::factory::{FabricatorNode, FactoryService, SelectorNode};
 use crate::hearing;
 use crate::idempotent_store::IdempotentStore;
+use crate::nervous_system::{host_metrics::HostMetrics, io_watcher::IoWatcher, SystemProbe};
 use crate::organ_builder::{OrganBuilder, OrganState};
 use crate::security::integrity_checker_node::IntegrityCheckerNode;
 use crate::security::quarantine_node::QuarantineNode;
 use crate::security::safe_mode_controller::SafeModeController;
-use crate::system::{host_metrics::HostMetrics, io_watcher::IoWatcher, SystemProbe};
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -143,7 +143,7 @@ impl InteractionHub {
         registry.register_action_node(metrics.clone());
         registry.register_action_node(diagnostics.clone());
         registry.register_action_node(Arc::new(
-            crate::system::base_path_resolver::BasePathResolverNode::new(),
+            crate::nervous_system::base_path_resolver::BasePathResolverNode::new(),
         ));
         let safe_mode = SafeModeController::new();
         let (quarantine, quarantine_tx, _dev_rx) = QuarantineNode::new(safe_mode.clone());

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,17 +3,17 @@ pub mod action_node;
 pub mod analysis_node;
 pub mod config;
 pub mod context;
+pub mod hearing;
 pub mod idempotent_store;
 pub mod interaction_hub;
 pub mod memory_node;
+pub mod nervous_system;
 pub mod node_registry;
 pub mod node_template;
 pub mod queue_config;
 pub mod security;
-pub mod system;
 pub mod task_scheduler;
 pub mod trigger_detector;
-pub mod hearing;
 // duplicates removed
 
 // Global hub reference (optional), used for lightweight signals like Anti-Idle activity marks

--- a/backend/src/nervous_system/base_path_resolver.rs
+++ b/backend/src/nervous_system/base_path_resolver.rs
@@ -5,7 +5,7 @@ summary: |
   Определяет базовый путь проекта и сохраняет его в памяти.
 */
 
-use std::path::{PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::action_node::ActionNode;

--- a/backend/src/nervous_system/host_metrics.rs
+++ b/backend/src/nervous_system/host_metrics.rs
@@ -8,12 +8,12 @@ summary: |
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::time::{sleep, Duration};
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
+use tokio::time::{sleep, Duration};
 
+use super::SystemProbe;
 use crate::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
 use crate::analysis_node::QualityMetrics;
-use super::SystemProbe;
 
 const CPU_HIGH_THRESHOLD: f64 = 80.0;
 const MEM_HIGH_THRESHOLD: f64 = 80.0;
@@ -34,7 +34,6 @@ impl HostMetrics {
         );
         Self { sys, collector }
     }
-
 }
 
 #[async_trait]

--- a/backend/src/nervous_system/io_watcher.rs
+++ b/backend/src/nervous_system/io_watcher.rs
@@ -11,9 +11,9 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use super::SystemProbe;
 use crate::action::metrics_collector_node::{MetricsCollectorNode, MetricsRecord};
 use crate::analysis_node::QualityMetrics;
-use super::SystemProbe;
 
 /// Watches keyboard input and display output latency and reports delays
 /// to the diagnostics system.

--- a/backend/src/nervous_system/mod.rs
+++ b/backend/src/nervous_system/mod.rs
@@ -14,6 +14,6 @@ pub trait SystemProbe: Send + Sync {
     fn collect(&mut self) {}
 }
 
+pub mod base_path_resolver;
 pub mod host_metrics;
 pub mod io_watcher;
-pub mod base_path_resolver;

--- a/backend/tests/io_watcher_test.rs
+++ b/backend/tests/io_watcher_test.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use backend::action::diagnostics_node::DiagnosticsNode;
 use backend::action::metrics_collector_node::MetricsCollectorNode;
-use backend::system::io_watcher::IoWatcher;
+use backend::nervous_system::io_watcher::IoWatcher;
 
 #[tokio::test]
 async fn io_watcher_triggers_diagnostics_on_delay() {


### PR DESCRIPTION
## Summary
- move `backend/src/system` to `backend/src/nervous_system`
- update imports and references to new `nervous_system` module
- adjust README for new path and example

## Testing
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b5cee0ede88323ac12f71c17bf5104