### PR TITLE
feat(nervous-system): add SSE loop detector

### DIFF
--- a/backend/src/nervous_system/loop_detector.rs
+++ b/backend/src/nervous_system/loop_detector.rs
@@ -1,0 +1,91 @@
+use std::collections::{HashMap, VecDeque};
+
+/* neira:meta
+id: NEI-20260214-loop-detector
+intent: code
+summary: |-
+  Sliding window detector for repetitive SSE sequences; publishes loop_detected_total.
+*/
+
+/// Check incoming tokens for loops or low entropy.
+///
+/// Returns Some(ratio) if a loop is detected and increments `loop_detected_total`.
+#[allow(clippy::float_cmp)]
+pub fn check_sequence(
+    win: &mut VecDeque<String>,
+    token: &str,
+    window: usize,
+    threshold: f32,
+    entropy_min: f32,
+) -> Option<f32> {
+    if window == 0 {
+        return None;
+    }
+    win.push_back(token.to_string());
+    if win.len() > window {
+        let _ = win.pop_front();
+    }
+    if win.len() < window / 2 {
+        return None;
+    }
+    let mut freq: HashMap<&str, usize> = HashMap::new();
+    for t in win.iter() {
+        *freq.entry(t.as_str()).or_insert(0) += 1;
+    }
+    let max_rep = freq.values().copied().max().unwrap_or(0) as f32;
+    let ratio = max_rep / (win.len() as f32);
+    let mut ent: f32 = 0.0;
+    if entropy_min > 0.0 {
+        let concat = win.iter().map(|s| s.as_str()).collect::<Vec<&str>>().join(" ");
+        let mut cf: HashMap<char, usize> = HashMap::new();
+        for ch in concat.chars() {
+            *cf.entry(ch).or_insert(0) += 1;
+        }
+        let total = concat.chars().count() as f32;
+        if total > 0.0 {
+            for v in cf.values() {
+                let p = (*v as f32) / total;
+                ent += -(p * p.log2());
+            }
+        }
+    }
+    if ratio >= threshold || (entropy_min > 0.0 && ent < entropy_min) {
+        metrics::counter!("loop_detected_total").increment(1);
+        Some(ratio)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_simple_loop() {
+        let mut win = VecDeque::new();
+        let tokens = ["a", "b", "a", "b", "a", "b", "a", "b"]; // 50% repetition
+        let mut detected = false;
+        for t in tokens {
+            if check_sequence(&mut win, t, 6, 0.6, 0.0).is_some() {
+                detected = true;
+                break;
+            }
+        }
+        assert!(detected);
+    }
+
+    #[test]
+    fn ignores_unique_sequence() {
+        let mut win = VecDeque::new();
+        let tokens = ["a", "b", "c", "d", "e", "f"]; // no repetition
+        let mut detected = false;
+        for t in tokens {
+            if check_sequence(&mut win, t, 6, 0.6, 0.0).is_some() {
+                detected = true;
+                break;
+            }
+        }
+        assert!(!detected);
+    }
+}

--- a/backend/src/nervous_system/mod.rs
+++ b/backend/src/nervous_system/mod.rs
@@ -18,3 +18,4 @@ pub mod base_path_resolver;
 pub mod host_metrics;
 pub mod io_watcher;
 pub mod watchdog;
+pub mod loop_detector;

--- a/docs/design/nervous_system.md
+++ b/docs/design/nervous_system.md
@@ -10,6 +10,12 @@ intent: docs
 summary: Добавлен раздел про WATCHDOG* переменные.
 -->
 
+<!-- neira:meta
+id: NEI-20260214-loop-detector-docs
+intent: docs
+summary: Описан детектор повторов SSE и переменные LOOP_*.
+-->
+
 # Нервная система (Nervous System)
 
 Цели
@@ -29,6 +35,7 @@ summary: Добавлен раздел про WATCHDOG* переменные.
   - IO Watcher: latency ввода/вывода, `io_*` histogram, событийные `system.io.*` записи.
   - Heartbeat/Живость: `sse_active` gauge, пульс через admin UI.
 - Watchdogs: soft/hard таймауты выполнения анализа/потоков, счётчики и рекомендации по ENV.
+- Loop Detector: анализирует поток SSE на повторы и низкую энтропию, публикует `loop_detected_total`.
 - Интроспекция: `/api/neira/introspection/status` блоки `watchdogs`, `queues/backpressure`, `anti_idle`, `capabilities`.
 
 Интеграции (хуки)

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -42,7 +42,11 @@ intent: docs
 summary: Добавлен раздел с переменными WATCHDOG*.
 -->
 
-# ENV Reference (Истина)
+<!-- neira:meta
+id: NEI-20260214-loop-detector-env-docs
+intent: docs
+summary: Добавлена переменная LOOP_ENTROPY_MIN для детектора повторов.
+-->
 
 | Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                                                                 |
 | ---------------------------- | --------------- | --------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
@@ -137,7 +141,10 @@ summary: Добавлен раздел с переменными WATCHDOG*.
 | LOOP_DETECT_ENABLED            | bool   | true               | watchdog    | Включить детектор циклов/повторов                                                           |
 | LOOP_WINDOW_TOKENS             | int    | 256                | watchdog    | Окно анализа повторов                                                                       |
 | LOOP_REPEAT_THRESHOLD          | float  | 0.6                | watchdog    | Порог повторяемости (0..1)                                                                  |
+| LOOP_ENTROPY_MIN               | float  | 0.0                | watchdog    | Минимальная энтропия окна (0 — отключено)
+                                                   |
 | CONTROL_ALLOW_PAUSE            | bool   | true               | control     | Разрешить pause/resume (admin)                                                              |
+                                                   |
 | CONTROL_ALLOW_KILL             | bool   | true               | control     | Разрешить аварийную остановку (admin)                                                       |
 | CONTROL_SNAPSHOT_DIR           | string | ./snapshots        | control     | Каталог для snapshot‑срезов                                                                 |
 | TRACE_ENABLED                  | bool   | false              | control     | Включить генерацию трасс по request_id                                                      |


### PR DESCRIPTION
## Summary
- add sliding-window loop detector for SSE streams
- route loop detection logic through new nervous_system module
- document loop detector and LOOP_ENTROPY_MIN env var

## Testing
- `cargo fmt`
- `cargo clippy -p backend -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b5d9b2ddd483238fe6b81ee5990c88