### PR TITLE
feat(nervous_system): extract anti-idle controller

### DIFF
--- a/backend/src/context/context_storage.rs
+++ b/backend/src/context/context_storage.rs
@@ -1,3 +1,4 @@
+use crate::nervous_system::anti_idle;
 use chrono::{Datelike, Utc};
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -300,11 +301,7 @@ impl ContextStorage for FileContextStorage {
         message: &ChatMessage,
     ) -> Result<(), String> {
         // Anti-Idle: отметим активность при записи контекста
-        if let Some(lock) = crate::GLOBAL_HUB.get() {
-            if let Ok(guard) = lock.read() {
-                if let Some(hub) = guard.as_ref() { hub.mark_activity(); }
-            }
-        }
+        anti_idle::mark_activity();
         let chat = chat_id.to_string();
         let sess = session_id.to_string();
         let mut msg = message.clone();
@@ -336,11 +333,7 @@ impl ContextStorage for FileContextStorage {
 
     fn load_session(&self, chat_id: &str, session_id: &str) -> Result<Vec<ChatMessage>, String> {
         // Anti-Idle: отметим активность при чтении контекста
-        if let Some(lock) = crate::GLOBAL_HUB.get() {
-            if let Ok(guard) = lock.read() {
-                if let Some(hub) = guard.as_ref() { hub.mark_activity(); }
-            }
-        }
+        anti_idle::mark_activity();
         metrics::counter!("context_loads").increment(1);
         // Read all (possibly rotated) files
         let dir = self.root.join(chat_id);

--- a/backend/src/nervous_system/anti_idle.rs
+++ b/backend/src/nervous_system/anti_idle.rs
@@ -1,0 +1,163 @@
+/* neira:meta
+id: NEI-20260301-anti-idle-module
+intent: code
+summary: |-
+  Вынесен модуль Anti-Idle: хранит состояние, считает idle_* и
+  предоставляет REST-ручку `/api/neira/anti_idle/toggle`.
+*/
+use axum::extract::FromRef;
+use axum::{extract::State, routing::post, Json, Router};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::interaction_hub::{InteractionHub, Scope};
+
+#[derive(Clone, Copy)]
+pub struct IdleThresholds {
+    pub idle_secs: u64,
+    pub long_secs: u64,
+    pub deep_secs: u64,
+}
+
+static ENABLED: AtomicBool = AtomicBool::new(true);
+static LAST_ACTIVITY: AtomicU64 = AtomicU64::new(0);
+static THRESHOLDS: OnceLock<IdleThresholds> = OnceLock::new();
+static EMA_ALPHA: OnceLock<f64> = OnceLock::new();
+static DRYRUN_DEPTH: OnceLock<u64> = OnceLock::new();
+
+pub fn init() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    LAST_ACTIVITY.store(now, Ordering::Relaxed);
+    let enabled = std::env::var("ANTI_IDLE_ENABLED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(true);
+    ENABLED.store(enabled, Ordering::Relaxed);
+    let _ = thresholds();
+    let _ = ema_alpha();
+    let _ = dryrun_queue_depth();
+}
+
+pub fn mark_activity() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    LAST_ACTIVITY.store(now, Ordering::Relaxed);
+}
+
+pub fn seconds_since_last_activity() -> u64 {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let last = LAST_ACTIVITY.load(Ordering::Relaxed);
+    now.saturating_sub(last)
+}
+
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+pub fn set_enabled(v: bool) {
+    ENABLED.store(v, Ordering::Relaxed);
+}
+
+pub fn thresholds() -> &'static IdleThresholds {
+    THRESHOLDS.get_or_init(|| {
+        let idle_secs = std::env::var("IDLE_THRESHOLD_SECONDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+        let long_secs = std::env::var("LONG_IDLE_THRESHOLD_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(5)
+            * 60;
+        let deep_secs = std::env::var("DEEP_IDLE_THRESHOLD_MINUTES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30)
+            * 60;
+        IdleThresholds {
+            idle_secs,
+            long_secs,
+            deep_secs,
+        }
+    })
+}
+
+pub fn ema_alpha() -> f64 {
+    *EMA_ALPHA.get_or_init(|| {
+        std::env::var("IDLE_EMA_ALPHA")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.3)
+    })
+}
+
+pub fn dryrun_queue_depth() -> u64 {
+    *DRYRUN_DEPTH.get_or_init(|| {
+        std::env::var("IDLE_DRYRUN_QUEUE_DEPTH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0)
+    })
+}
+
+pub fn idle_state(active_streams: usize) -> (u32, u64) {
+    let since = seconds_since_last_activity();
+    let t = thresholds();
+    let state_idx = if active_streams > 0 || since < t.idle_secs {
+        0
+    } else if since < t.long_secs {
+        1
+    } else if since < t.deep_secs {
+        2
+    } else {
+        3
+    };
+    (state_idx, since)
+}
+
+#[derive(Deserialize)]
+struct ToggleRequest {
+    auth: String,
+    enabled: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct ToggleResponse {
+    enabled: bool,
+}
+
+async fn toggle<S>(
+    State(hub): State<Arc<InteractionHub>>,
+    Json(req): Json<ToggleRequest>,
+) -> Result<Json<ToggleResponse>, axum::http::StatusCode>
+where
+    Arc<InteractionHub>: FromRef<S>,
+{
+    if !hub.check_auth(&req.auth) {
+        return Err(axum::http::StatusCode::UNAUTHORIZED);
+    }
+    if !hub.check_scope(&req.auth, Scope::Admin) {
+        return Err(axum::http::StatusCode::FORBIDDEN);
+    }
+    let new_state = req.enabled.unwrap_or(!is_enabled());
+    set_enabled(new_state);
+    Ok(Json(ToggleResponse { enabled: new_state }))
+}
+
+pub fn router<S>() -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+    Arc<InteractionHub>: FromRef<S>,
+{
+    Router::new().route("/api/neira/anti_idle/toggle", post(toggle::<S>))
+}

--- a/backend/src/nervous_system/mod.rs
+++ b/backend/src/nervous_system/mod.rs
@@ -14,9 +14,10 @@ pub trait SystemProbe: Send + Sync {
     fn collect(&mut self) {}
 }
 
+pub mod anti_idle;
+pub mod backpressure_probe;
 pub mod base_path_resolver;
 pub mod host_metrics;
 pub mod io_watcher;
-pub mod watchdog;
 pub mod loop_detector;
-pub mod backpressure_probe;
+pub mod watchdog;

--- a/docs/design/nervous_system.md
+++ b/docs/design/nervous_system.md
@@ -15,6 +15,11 @@ id: NEI-20260214-loop-detector-docs
 intent: docs
 summary: Описан детектор повторов SSE и переменные LOOP_*.
 -->
+<!-- neira:meta
+id: NEI-20260301-anti-idle-docs
+intent: docs
+summary: Добавлены пороги простоя и ручка `/api/neira/anti_idle/toggle`.
+-->
 
 # Нервная система (Nervous System)
 
@@ -37,6 +42,13 @@ summary: Описан детектор повторов SSE и переменн�
 - Watchdogs: soft/hard таймауты выполнения анализа/потоков, счётчики и рекомендации по ENV.
 - Loop Detector: анализирует поток SSE на повторы и низкую энтропию, публикует `loop_detected_total`.
 - Интроспекция: `/api/neira/introspection/status` блоки `watchdogs`, `queues/backpressure`, `anti_idle`, `capabilities`.
+
+## Anti-Idle
+
+- Порог `idle_state` вычисляется по `IDLE_THRESHOLD_SECONDS`, `LONG_IDLE_THRESHOLD_MINUTES` и `DEEP_IDLE_THRESHOLD_MINUTES`.
+- Сглаживание `idle_state_smoothed` — параметр `IDLE_EMA_ALPHA`.
+- Глубина очереди микрозадач в простое задаётся `IDLE_DRYRUN_QUEUE_DEPTH`.
+- Включение/выключение подсистемы — POST `/api/neira/anti_idle/toggle` (требуется админ‑токен).
 
 Интеграции (хуки)
 - Узлы (Analysis/Action/Chat):

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -47,6 +47,11 @@ id: NEI-20260214-loop-detector-env-docs
 intent: docs
 summary: Добавлена переменная LOOP_ENTROPY_MIN для детектора повторов.
 -->
+<!-- neira:meta
+id: NEI-20260301-idle-env-docs
+intent: docs
+summary: Описаны IDLE_EMA_ALPHA и IDLE_DRYRUN_QUEUE_DEPTH.
+-->
 
 | Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                                                                 |
 | ---------------------------- | --------------- | --------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
@@ -97,6 +102,10 @@ summary: Добавлена переменная LOOP_ENTROPY_MIN для дет�
 | ------------------------------------- | ------ | -------------- | ---------------- | ----------------------------- |
 | IDLE_THRESHOLD_SECONDS                | int    | 30             | idle detection   | Порог простоя (сек)           |
 | DEEP_IDLE_THRESHOLD_MINUTES           | int    | 30             | idle detection   | Глубокий простой (мин)        |
+| IDLE_EMA_ALPHA                        | float  | 0.3            | idle detection   | Вес EMA сглаживания idle_state     |
+                 |
+| IDLE_DRYRUN_QUEUE_DEPTH               | int    | 0              | idle microtasks  | Размер очереди микрозадач в простое |
+                 |
 | IDLE_MICRO_TASK_MAX_DURATION          | string | 10min          | anti-idle limits | Максимум одной микрозадачи    |
 | IDLE_SESSION_MAX_DURATION             | string | 30min          | anti-idle limits | Максимум одной сессии         |
 | IDLE_DAILY_AUTONOMOUS_LIMIT           | string | 4hours         | anti-idle limits | Дневной лимит автономии       |
@@ -179,6 +188,10 @@ summary: Добавлена переменная LOOP_ENTROPY_MIN для дет�
 | IDLE_THRESHOLD_SECONDS                | int    | 30             | idle detection   | Порог простоя (сек)                                       |
 | LONG_IDLE_THRESHOLD_MINUTES           | int    | 5              | idle detection   | Длительный простой (мин)                                  |
 | DEEP_IDLE_THRESHOLD_MINUTES           | int    | 30             | idle detection   | Глубокий простой (мин)                                    |
+| IDLE_EMA_ALPHA                        | float  | 0.3            | idle detection   | Вес EMA сглаживания idle_state     |
+                 |
+| IDLE_DRYRUN_QUEUE_DEPTH               | int    | 0              | idle microtasks  | Размер очереди микрозадач в простое |
+                 |
 | IDLE_MICRO_TASK_MAX_DURATION          | string | 10min          | anti-idle limits | Максимум одной микрозадачи                                |
 | IDLE_SESSION_MAX_DURATION             | string | 30min          | anti-idle limits | Максимум одной сессии                                     |
 | IDLE_DAILY_AUTONOMOUS_LIMIT           | string | 4hours         | anti-idle limits | Дневной лимит автономии                                   |


### PR DESCRIPTION
## Summary
- move anti-idle state into dedicated module and expose toggle API
- proxy activity tracking through anti_idle module
- document idle thresholds and env variables

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e335dac08323a1e0fc8523fb931d