### PR TITLE
feat: add action node template support

### DIFF
--- a/backend/src/node_registry.rs
+++ b/backend/src/node_registry.rs
@@ -19,7 +19,9 @@ use crate::action::scripted_training_node::ScriptedTrainingNode;
 use crate::action_node::ActionNode;
 use crate::analysis_node::AnalysisNode;
 use crate::memory_node::MemoryNode;
-use crate::node_template::{validate_template, NodeTemplate};
+use crate::node_template::{
+    validate_action_template, validate_template, ActionNodeTemplate, NodeTemplate,
+};
 
 /* neira:meta
 id: NEI-20241010-154500-load-template
@@ -43,11 +45,34 @@ fn load_template(path: &Path) -> Result<NodeTemplate, String> {
     serde_json::from_value(value).map_err(|e| format!("deserialize NodeTemplate: {e}"))
 }
 
+/* neira:meta
+id: NEI-20250214-153500-load-action-template
+intent: feature
+summary: |
+  Загружает `ActionNodeTemplate` из файла JSON или YAML.
+*/
+fn load_action_template(path: &Path) -> Result<ActionNodeTemplate, String> {
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let value: Value = if let Some("yaml") | Some("yml") = path.extension().and_then(|s| s.to_str())
+    {
+        let yaml: serde_yaml::Value =
+            serde_yaml::from_str(&content).map_err(|e| format!("invalid YAML: {e}"))?;
+        serde_json::to_value(yaml).map_err(|e| format!("YAML to JSON: {e}"))?
+    } else {
+        serde_json::from_str(&content).map_err(|e| format!("invalid JSON: {e}"))?
+    };
+    validate_action_template(&value).map_err(|errs| errs.join(", "))?;
+    serde_json::from_value(value).map_err(|e| format!("deserialize ActionNodeTemplate: {e}"))
+}
+
 /// Реестр узлов: хранит метаданные и следит за изменениями файлов.
 pub struct NodeRegistry {
     root: PathBuf,
     nodes: Arc<RwLock<HashMap<String, NodeTemplate>>>,
     paths: Arc<RwLock<HashMap<PathBuf, String>>>,
+    action_templates: Arc<RwLock<HashMap<String, ActionNodeTemplate>>>,
+    action_paths: Arc<RwLock<HashMap<PathBuf, String>>>,
     analysis_nodes: Arc<RwLock<HashMap<String, Arc<dyn AnalysisNode + Send + Sync>>>>,
     action_nodes: Arc<RwLock<Vec<Arc<dyn ActionNode>>>>,
     chat_nodes: Arc<RwLock<HashMap<String, Arc<dyn ChatNode + Send + Sync>>>>,
@@ -60,6 +85,8 @@ impl NodeRegistry {
         let dir = dir.as_ref().to_path_buf();
         let nodes = Arc::new(RwLock::new(HashMap::new()));
         let paths = Arc::new(RwLock::new(HashMap::new()));
+        let action_templates = Arc::new(RwLock::new(HashMap::new()));
+        let action_paths = Arc::new(RwLock::new(HashMap::new()));
         let analysis_nodes = Arc::new(RwLock::new(HashMap::new()));
         let action_nodes = Arc::new(RwLock::new(Vec::new()));
         let chat_nodes = Arc::new(RwLock::new(HashMap::new()));
@@ -68,18 +95,28 @@ impl NodeRegistry {
         for entry in fs::read_dir(&dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))? {
             let path = entry.map_err(|e| e.to_string())?.path();
             if path.is_file() {
-                match load_template(&path) {
-                    Ok(tpl) => {
-                        paths.write().unwrap().insert(path.clone(), tpl.id.clone());
-                        nodes.write().unwrap().insert(tpl.id.clone(), tpl);
-                    }
-                    Err(e) => error!("{}", e),
+                if let Ok(tpl) = load_template(&path) {
+                    paths.write().unwrap().insert(path.clone(), tpl.id.clone());
+                    nodes.write().unwrap().insert(tpl.id.clone(), tpl);
+                } else if let Ok(tpl) = load_action_template(&path) {
+                    action_paths
+                        .write()
+                        .unwrap()
+                        .insert(path.clone(), tpl.id.clone());
+                    action_templates
+                        .write()
+                        .unwrap()
+                        .insert(tpl.id.clone(), tpl);
+                } else {
+                    error!("failed to load template {}", path.display());
                 }
             }
         }
 
         let nodes_w = nodes.clone();
         let paths_w = paths.clone();
+        let action_tpls_w = action_templates.clone();
+        let action_paths_w = action_paths.clone();
         let mut watcher: RecommendedWatcher = RecommendedWatcher::new(
             move |res: Result<notify::Event, notify::Error>| match res {
                 Ok(event) => {
@@ -92,19 +129,32 @@ impl NodeRegistry {
                                 if let Some(id) = paths_w.write().unwrap().remove(&path) {
                                     nodes_w.write().unwrap().remove(&id);
                                     info!("Removed node {}", id);
+                                } else if let Some(id) =
+                                    action_paths_w.write().unwrap().remove(&path)
+                                {
+                                    action_tpls_w.write().unwrap().remove(&id);
+                                    info!("Removed action node {}", id);
                                 }
                             }
-                            _ => match load_template(&path) {
-                                Ok(tpl) => {
+                            _ => {
+                                if let Ok(tpl) = load_template(&path) {
                                     paths_w
                                         .write()
                                         .unwrap()
                                         .insert(path.clone(), tpl.id.clone());
                                     nodes_w.write().unwrap().insert(tpl.id.clone(), tpl);
                                     info!("Loaded node template {}", path.display());
+                                } else if let Ok(tpl) = load_action_template(&path) {
+                                    action_paths_w
+                                        .write()
+                                        .unwrap()
+                                        .insert(path.clone(), tpl.id.clone());
+                                    action_tpls_w.write().unwrap().insert(tpl.id.clone(), tpl);
+                                    info!("Loaded action node template {}", path.display());
+                                } else {
+                                    error!("failed to load template {}", path.display());
                                 }
-                                Err(e) => error!("{e}"),
-                            },
+                            }
                         }
                     }
                 }
@@ -122,6 +172,8 @@ impl NodeRegistry {
             root: dir,
             nodes,
             paths,
+            action_templates,
+            action_paths,
             analysis_nodes,
             action_nodes,
             chat_nodes,
@@ -141,12 +193,23 @@ impl NodeRegistry {
 
     /// Регистрация или обновление узла из файла.
     pub fn register(&self, path: &Path) -> Result<(), String> {
-        let tpl = load_template(path)?;
-        self.paths
-            .write()
-            .unwrap()
-            .insert(path.to_path_buf(), tpl.id.clone());
-        self.nodes.write().unwrap().insert(tpl.id.clone(), tpl);
+        if let Ok(tpl) = load_template(path) {
+            self.paths
+                .write()
+                .unwrap()
+                .insert(path.to_path_buf(), tpl.id.clone());
+            self.nodes.write().unwrap().insert(tpl.id.clone(), tpl);
+        } else {
+            let tpl = load_action_template(path)?;
+            self.action_paths
+                .write()
+                .unwrap()
+                .insert(path.to_path_buf(), tpl.id.clone());
+            self.action_templates
+                .write()
+                .unwrap()
+                .insert(tpl.id.clone(), tpl);
+        }
         Ok(())
     }
 
@@ -166,9 +229,29 @@ impl NodeRegistry {
         self.register(&path)
     }
 
+    /* neira:meta
+    id: NEI-20250214-154000-register-action-template
+    intent: feature
+    summary: Регистрирует шаблон узла действия и сохраняет его на диск.
+    */
+    pub fn register_action_template(&self, tpl: ActionNodeTemplate) -> Result<(), String> {
+        let value = tpl.to_json();
+        validate_action_template(&value).map_err(|errs| errs.join(", "))?;
+        let file = format!("{}-{}.json", tpl.id, tpl.version);
+        let path = self.root.join(file);
+        let content = serde_json::to_string(&tpl).map_err(|e| e.to_string())?;
+        fs::write(&path, content).map_err(|e| e.to_string())?;
+        self.register(&path)
+    }
+
     /// Получение метаданных узла по идентификатору.
     pub fn get(&self, id: &str) -> Option<NodeTemplate> {
         self.nodes.read().unwrap().get(id).cloned()
+    }
+
+    /// Получение шаблона узла действия по идентификатору.
+    pub fn get_action_template(&self, id: &str) -> Option<ActionNodeTemplate> {
+        self.action_templates.read().unwrap().get(id).cloned()
     }
 
     /// Регистрация реализации `AnalysisNode`.

--- a/docs/guides/voice-v1-runbook.md
+++ b/docs/guides/voice-v1-runbook.md
@@ -10,8 +10,9 @@ Goal
 
 - Зарегистрировать 3 шаблона узлов (NodeTemplate) для конвейера Voice v1:
   - `analysis.text_normalize.v1`
-  - `analysis.text_to_phonemes.v1`
-  - `analysis.speak_adapter.v1`
+- `analysis.text_to_phonemes.v1`
+- `analysis.speak_adapter.v1`
+- `action.speak_adapter.v1` (ActionNodeTemplate)
 - Прогнать dry-run, создать записи (draft), при необходимости продвинуть до canary.
 - Убедиться в автоподхвате шаблонов при перезапуске (NodeRegistry watcher).
 
@@ -34,14 +35,17 @@ Steps (PowerShell)
 node scripts/factory-shim/index.mjs dryrun-node --spec examples/factory/voice-v1/analysis.text_normalize.v1.json
 node scripts/factory-shim/index.mjs dryrun-node --spec examples/factory/voice-v1/analysis.text_to_phonemes.v1.json
 node scripts/factory-shim/index.mjs dryrun-node --spec examples/factory/voice-v1/analysis.speak_adapter.v1.json
+node scripts/factory-shim/index.mjs dryrun-node --spec examples/factory/voice-v1/action.speak_adapter.v1.json
 2. Создать записи (draft) и сохранить в `templates/`
 node scripts/factory-shim/index.mjs create-node --spec examples/factory/voice-v1/analysis.text_normalize.v1.json
 node scripts/factory-shim/index.mjs create-node --spec examples/factory/voice-v1/analysis.text_to_phonemes.v1.json
 node scripts/factory-shim/index.mjs create-node --spec examples/factory/voice-v1/analysis.speak_adapter.v1.json
+node scripts/factory-shim/index.mjs create-node --spec examples/factory/voice-v1/action.speak_adapter.v1.json
 3. (Опционально) Аппрув до canary
 node scripts/factory-shim/index.mjs approve-node --id adapter:analysis.text_normalize.v1 --yes
 node scripts/factory-shim/index.mjs approve-node --id adapter:analysis.text_to_phonemes.v1 --yes
 node scripts/factory-shim/index.mjs approve-node --id adapter:analysis.speak_adapter.v1 --yes
+node scripts/factory-shim/index.mjs approve-node --id adapter:action.speak_adapter.v1 --yes
 4. Проверка автоподхвата
 - Убедитесь, что в каталоге `templates/` появились файлы `analysis.*.json`.
 - Перезапустите backend — NodeRegistry загрузит шаблоны из каталога (есть файловый watcher).

--- a/docs/nodes/action-nodes.md
+++ b/docs/nodes/action-nodes.md
@@ -1,5 +1,11 @@
 # Узлы действий
 
+<!-- neira:meta
+id: NEI-20250214-155000-action-node-schema-doc
+intent: docs
+summary: Добавлено описание схемы шаблонов и пример для узлов действий.
+-->
+
 ## Навигация
 - [Обзор Нейры](README.md)
 - [Узлы действий](action-nodes.md)
@@ -58,6 +64,13 @@
    ```
 
 Дополнительные ActionNodes (работа с файлами, внешние API и т.п.) будут добавлены после MVP.
+
+### Шаблоны
+
+Шаблон узла действия описывается JSON‑файлом, соответствующим схеме
+[`schemas/v1/action-node-template.schema.json`](../../schemas/v1/action-node-template.schema.json).
+Пример реализации —
+[`examples/factory/voice-v1/action.speak_adapter.v1.json`](../../examples/factory/voice-v1/action.speak_adapter.v1.json).
 
 ### Пример HTTP/JSON/TOML вызова
 

--- a/docs/nodes/node-template.md
+++ b/docs/nodes/node-template.md
@@ -1,5 +1,11 @@
 # NodeTemplate
 
+<!-- neira:meta
+id: NEI-20250214-155200-node-template-action-note
+intent: docs
+summary: Добавлено упоминание ActionNodeTemplate и ссылки на схему.
+-->
+
 ## Навигация
 - [Обзор Нейры](README.md)
 - [Узлы действий](action-nodes.md)
@@ -25,6 +31,9 @@
 
 
 Шаблон для создания узлов анализа. Обязательными являются поля `id`, `analysis_type` и `metadata`.
+Для узлов действий используется отдельный шаблон `ActionNodeTemplate` с полем
+`action_type`; его схема находится по пути
+[`schemas/v1/action-node-template.schema.json`](../../schemas/v1/action-node-template.schema.json).
 
 ## Обязательные поля
 
@@ -165,4 +174,4 @@ cargo run --bin generate_node -- --schema v1
 
 ## Схемы
 
-JSON‑схемы расположены в каталоге [schemas](schemas). Схемы для NodeTemplate хранятся в `schemas/vX/node-template.schema.json`, где `X` — номер мажорной версии. При несовместимых изменениях повышайте версию: `1.0.0` → `2.0.0`.
+JSON‑схемы расположены в каталоге [schemas](schemas). Схемы для NodeTemplate хранятся в `schemas/vX/node-template.schema.json`, где `X` — номер мажорной версии. Для узлов действий используйте `schemas/vX/action-node-template.schema.json`. При несовместимых изменениях повышайте версию: `1.0.0` → `2.0.0`.

--- a/examples/factory/voice-v1/action.speak_adapter.v1.json
+++ b/examples/factory/voice-v1/action.speak_adapter.v1.json
@@ -1,0 +1,9 @@
+{
+  "id": "action.speak_adapter.v1",
+  "version": "0.1.0",
+  "action_type": "speak_adapter",
+  "links": [
+    "analysis.speak_adapter.v1"
+  ],
+  "metadata": { "schema": "v1" }
+}

--- a/schemas/v1/action-node-template.schema.json
+++ b/schemas/v1/action-node-template.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ActionNodeTemplate",
+  "type": "object",
+  "required": ["id", "version", "action_type", "metadata"],
+  "properties": {
+    "id": { "type": "string" },
+    "version": { "type": "string" },
+    "action_type": { "type": "string" },
+    "links": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "confidence_threshold": { "type": "number" },
+    "draft_content": { "type": "string" },
+    "metadata": {
+      "type": "object",
+      "required": ["schema"],
+      "properties": {
+        "schema": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/action_node_template_test.rs
+++ b/tests/action_node_template_test.rs
@@ -1,0 +1,22 @@
+use backend::node_registry::NodeRegistry;
+use backend::node_template::ActionNodeTemplate;
+
+#[test]
+fn registry_registers_action_templates() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = NodeRegistry::new(dir.path()).unwrap();
+    let tpl = ActionNodeTemplate {
+        id: "action.example.v1".to_string(),
+        version: "0.1.0".to_string(),
+        action_type: "example".to_string(),
+        links: vec![],
+        confidence_threshold: None,
+        draft_content: None,
+        metadata: backend::node_template::Metadata {
+            schema: "v1".to_string(),
+            extra: Default::default(),
+        },
+    };
+    registry.register_action_template(tpl).unwrap();
+    assert!(registry.get_action_template("action.example.v1").is_some());
+}

--- a/tests/action_node_template_validation_test.rs
+++ b/tests/action_node_template_validation_test.rs
@@ -1,0 +1,21 @@
+use backend::node_template::validate_action_template;
+use serde_json::json;
+
+#[test]
+fn valid_action_template_passes_validation() {
+    let value = json!({
+        "id": "action.example.v1",
+        "version": "0.1.0",
+        "action_type": "example",
+        "metadata": { "schema": "v1" }
+    });
+    validate_action_template(&value).expect("valid action template");
+}
+
+#[test]
+fn invalid_action_template_reports_errors() {
+    let value = json!({
+        "id": "broken"
+    });
+    assert!(validate_action_template(&value).is_err());
+}


### PR DESCRIPTION
## Summary
- add JSON schema for action node templates and sample speak adapter
- enable NodeRegistry to load and store action templates
- document action node templates and update voice v1 runbook

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b5f995b1408323841affaf8240b5b8