### PR TITLE
docs: add nervous system link to navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Documentation Index
 - [Политика источников](docs/system/source-policy.md)
 - [Низкоуровневая цепочка инструментов](docs/system/low-level-toolchain.md)
 - [Система самообновления](docs/system/self-updating-system.md)
+- [Нервная система](docs/design/nervous_system.md)
 - [Пример использования](docs/guides/usage-example.md)
 - [Орган билдер CLI](docs/guides/usage-example.md#organ-builder-cli)
 - [CLI‑утилита валидации шаблонов](docs/legacy/usage-example.md)


### PR DESCRIPTION
## Summary
- link Nervous System design doc in README navigation

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f96901908323907364b9f706d3d5