### PR TITLE
feat: watch node templates recursively

### DIFF
--- a/backend/src/node_registry.rs
+++ b/backend/src/node_registry.rs
@@ -158,8 +158,13 @@ impl NodeRegistry {
         )
         .map_err(|e| e.to_string())?;
 
+        /* neira:meta
+        id: NEI-20250310-node-registry-recursive
+        intent: fix
+        summary: Включено рекурсивное наблюдение за каталогом шаблонов узлов.
+        */
         watcher
-            .watch(&dir, RecursiveMode::NonRecursive)
+            .watch(&dir, RecursiveMode::Recursive)
             .map_err(|e| e.to_string())?;
 
         Ok(Self {

--- a/backend/tests/node_registry_reload.rs
+++ b/backend/tests/node_registry_reload.rs
@@ -56,3 +56,23 @@ fn register_template_persists_to_disk() {
     let registry2 = NodeRegistry::new(dir.path()).unwrap();
     assert!(registry2.get("n2").is_some());
 }
+
+#[test]
+fn loads_template_from_subdir() {
+    let dir = tempdir().unwrap();
+    let registry = NodeRegistry::new(dir.path()).unwrap();
+
+    let sub = dir.path().join("nested");
+    fs::create_dir(&sub).unwrap();
+    let path = sub.join("n3-0.1.0.json");
+    let tpl = json!({
+        "id": "n3",
+        "version": "0.1.0",
+        "analysis_type": "a",
+        "metadata": {"schema": "1.0.0"}
+    });
+    fs::write(&path, serde_json::to_string(&tpl).unwrap()).unwrap();
+
+    thread::sleep(Duration::from_secs(1));
+    assert_eq!(registry.get("n3").unwrap().analysis_type, "a");
+}

--- a/docs/guides/voice-v1-runbook.md
+++ b/docs/guides/voice-v1-runbook.md
@@ -4,6 +4,12 @@ intent: docs
 summary: Пошаговый запуск Voice v1 через Factory Adapter: dry-run → create → approve, автоподхват шаблонов, проверки.
 -->
 
+<!-- neira:meta
+id: NEI-20250310-node-templates-subdir-runbook
+intent: docs
+summary: Уточнено, что каталог шаблонов поддерживает подкаталоги.
+-->
+
 # Voice v1 — Runbook (Adapter-only)
 
 Goal
@@ -20,9 +26,9 @@ Prerequisites
 
 - Backend собран и запущен с включённым адаптером фабрики:
   - PowerShell: `$env:FACTORY_ADAPTER_ENABLED='1'`
-  - (опц.) каталог шаблонов: `$env:NODE_TEMPLATES_DIR='templates'`
-- Токен (минимум write) для API: `$env:FACTORY_TOKEN='secret'` (см. backend init)
-- Базовый URL: `$env:FACTORY_BASE_URL='http://localhost:3000'` (порт можно сменить через `NEIRA_BIND_ADDR`)
+  - (опц.) каталог шаблонов: `$env:NODE_TEMPLATES_DIR='templates'` (подкаталоги поддерживаются)
+  - Токен (минимум write) для API: `$env:FACTORY_TOKEN='secret'` (см. backend init)
+  - Базовый URL: `$env:FACTORY_BASE_URL='http://localhost:3000'` (порт можно сменить через `NEIRA_BIND_ADDR`)
 - Пример смены порта: `$env:NEIRA_BIND_ADDR='0.0.0.0:4000'`
 - Проверьте свободность порта: `lsof -i :3000` (иначе задайте другой через `NEIRA_BIND_ADDR`)
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -53,6 +53,12 @@ intent: docs
 summary: Описаны IDLE_EMA_ALPHA и IDLE_DRYRUN_QUEUE_DEPTH.
 -->
 
+<!-- neira:meta
+id: NEI-20250310-node-templates-recursive-docs
+intent: docs
+summary: Уточнено, что NODE_TEMPLATES_DIR поддерживает подкаталоги.
+-->
+
 | Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                                                                 |
 | ---------------------------- | --------------- | --------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
 | CONTEXT_DIR                  | string          | context               | backend context storage | База для истории чатов                                                                                  |
@@ -64,7 +70,7 @@ summary: Описаны IDLE_EMA_ALPHA и IDLE_DRYRUN_QUEUE_DEPTH.
 | MASK_PII                     | bool            | true                  | storage masking         | Маскирование PII по умолчанию                                                                           |
 | MASK_REGEX                   | string list (;) | —                     | storage masking         | Кастомные regex для маскирования                                                                        |
 | MASK_ROLES                   | string list (,) | user                  | storage masking         | Роли для маскирования                                                                                   |
-| NODE_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов узлов                                                                                  |
+| NODE_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов узлов (подкаталоги поддерживаются)                                                      |
 | CHAT_RATE_LIMIT_PER_MIN      | int             | 120                   | hub rate limit          | Лимит запросов в минуту                                                                                 |
 | CHAT_RATE_KEY                | enum            | auth                  | hub rate limit          | Ключ лимита: auth/chat/session                                                                          |
 | IO_WATCHER_THRESHOLD_MS      | int             | 100                   | nervous probes          | Порог латентности для проб                                                                              |


### PR DESCRIPTION
## Summary
- watch node templates directory recursively
- test loading templates from subdirectories
- document subdirectory support for NODE_TEMPLATES_DIR

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b60a39dd148323a17573f726a40f95