### PR TITLE
feat: list action node templates

### DIFF
--- a/backend/src/node_registry.rs
+++ b/backend/src/node_registry.rs
@@ -253,6 +253,16 @@ impl NodeRegistry {
         self.action_templates.read().unwrap().get(id).cloned()
     }
 
+    /// Возвращает все зарегистрированные шаблоны узлов действия.
+    pub fn list_action_templates(&self) -> Vec<ActionNodeTemplate> {
+        self.action_templates
+            .read()
+            .unwrap()
+            .values()
+            .cloned()
+            .collect()
+    }
+
     /// Регистрация реализации `AnalysisNode`.
     pub fn register_analysis_node(&self, node: Arc<dyn AnalysisNode + Send + Sync>) {
         self.analysis_nodes

--- a/tests/action_node_template_test.rs
+++ b/tests/action_node_template_test.rs
@@ -1,5 +1,11 @@
+/* neira:meta
+id: NEI-20250323-151200-action-template-list
+intent: test
+summary: Проверяет регистрацию и перечисление шаблонов узлов действия.
+*/
 use backend::node_registry::NodeRegistry;
 use backend::node_template::ActionNodeTemplate;
+use std::collections::HashSet;
 
 #[test]
 fn registry_registers_action_templates() {
@@ -19,4 +25,40 @@ fn registry_registers_action_templates() {
     };
     registry.register_action_template(tpl).unwrap();
     assert!(registry.get_action_template("action.example.v1").is_some());
+}
+
+#[test]
+fn registry_lists_action_templates() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = NodeRegistry::new(dir.path()).unwrap();
+    let tpl1 = ActionNodeTemplate {
+        id: "action.example.v1".to_string(),
+        version: "0.1.0".to_string(),
+        action_type: "example".to_string(),
+        links: vec![],
+        confidence_threshold: None,
+        draft_content: None,
+        metadata: backend::node_template::Metadata {
+            schema: "v1".to_string(),
+            extra: Default::default(),
+        },
+    };
+    let tpl2 = ActionNodeTemplate {
+        id: "action.another.v1".to_string(),
+        version: "0.1.0".to_string(),
+        action_type: "another".to_string(),
+        links: vec![],
+        confidence_threshold: None,
+        draft_content: None,
+        metadata: backend::node_template::Metadata {
+            schema: "v1".to_string(),
+            extra: Default::default(),
+        },
+    };
+    registry.register_action_template(tpl1).unwrap();
+    registry.register_action_template(tpl2).unwrap();
+    let listed = registry.list_action_templates();
+    let ids: HashSet<_> = listed.into_iter().map(|t| t.id).collect();
+    assert!(ids.contains("action.example.v1"));
+    assert!(ids.contains("action.another.v1"));
 }


### PR DESCRIPTION
## Summary
- list registered action templates in NodeRegistry
- cover action template listing with tests

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b6560dd7fc8323bc28ae197d03c717