### PR TITLE
docs: replace Node with Cell in comments

### DIFF
--- a/backend/src/nervous_system/base_path_resolver.rs
+++ b/backend/src/nervous_system/base_path_resolver.rs
@@ -28,7 +28,7 @@ pub fn resolve_base_path() -> Option<PathBuf> {
     None
 }
 
-/// Node that resolves the base path once and stores it in the `MemoryCell`
+/// Cell that resolves the base path once and stores it in the `MemoryCell`
 /// under the `base_path` key.
 #[derive(Default)]
 pub struct BasePathResolverCell;

--- a/backend/src/security/init_config_cell.rs
+++ b/backend/src/security/init_config_cell.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use crate::action_cell::ActionCell;
 use crate::memory_cell::MemoryCell;
 
-/// Node responsible for initializing configuration variables.
+/// Cell responsible for initializing configuration variables.
 /// Ensures `INTEGRITY_ROOT` is set based on `MemoryCell` base path.
 pub struct InitConfigCell;
 

--- a/backend/src/security/quarantine_cell.rs
+++ b/backend/src/security/quarantine_cell.rs
@@ -1,5 +1,5 @@
 /* neira:meta
-id: NEI-20250829-175425-quarantine-node
+id: NEI-20250829-175425-quarantine-cell
 intent: docs
 summary: |
   Переводит подозрительные модули в карантин и активирует безопасный режим.
@@ -15,7 +15,7 @@ use crate::action_cell::ActionCell;
 use crate::memory_cell::MemoryCell;
 use crate::security::safe_mode_controller::SafeModeController;
 
-/// Node responsible for putting suspicious modules into quarantine.
+/// Cell responsible for putting suspicious modules into quarantine.
 /// Receives module identifiers over a channel and attempts to disable
 /// or restart them. Each quarantine action is logged and a developer
 /// notification is emitted.
@@ -26,14 +26,21 @@ pub struct QuarantineCell {
 }
 
 impl QuarantineCell {
-    /// Creates the node and returns a sender for quarantine messages
+    /// Creates the cell and returns a sender for quarantine messages
     /// along with a receiver for developer notifications.
     pub fn new(
         safe_mode: Arc<SafeModeController>,
-    ) -> (Arc<Self>, UnboundedSender<String>, UnboundedReceiver<DeveloperRequest>) {
+    ) -> (
+        Arc<Self>,
+        UnboundedSender<String>,
+        UnboundedReceiver<DeveloperRequest>,
+    ) {
         let (tx, mut rx) = unbounded_channel();
         let (notify_tx, notify_rx) = unbounded_channel();
-        let node = Arc::new(Self { notify: notify_tx, safe_mode });
+        let node = Arc::new(Self {
+            notify: notify_tx,
+            safe_mode,
+        });
         let node_clone = node.clone();
         tokio::spawn(async move {
             while let Some(module) = rx.recv().await {


### PR DESCRIPTION
## Summary
- replace "Node" with "Cell" terminology in quarantine, base path resolver and config init comments

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b68fa4769c83239c63dcb4298ae530