### PR TITLE
docs: update example analysis type to ExampleCell

### DIFF
--- a/examples/cell_template.rs
+++ b/examples/cell_template.rs
@@ -1,3 +1,9 @@
+/* neira:meta
+id: NEI-20250602-150100-examplecell
+intent: docs
+summary: |
+  Переименован тип анализа в JSON-примере на ExampleCell.
+*/
 use backend::cell_template::{validate_template, CellTemplate};
 use serde_json::json;
 
@@ -5,7 +11,7 @@ fn main() {
     // Example template in JSON form
     let value = json!({
         "id": "example.template",
-        "analysis_type": "ExampleNode",
+        "analysis_type": "ExampleCell",
         "metadata": {
             "schema": "1.0.0",
             "author": "Example"

--- a/examples/cell_template.yaml
+++ b/examples/cell_template.yaml
@@ -1,5 +1,11 @@
+# neira:meta
+# id: NEI-20250602-150000-examplecell
+# intent: docs
+# summary: |
+#   Переименован тип анализа в примере в ExampleCell.
+
 id: example.template
-analysis_type: ExampleNode
+analysis_type: ExampleCell
 metadata:
   schema: "1.0.0"
   author: "Example"


### PR DESCRIPTION
## Summary
- rename `analysis_type` from ExampleNode to ExampleCell in example template files
- document example change with `neira:meta` blocks

## Testing
- `npm run check-examples`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a4799a588323b7ddbef3b1f1f54c