### PR TITLE
refactor: use CELL_TEMPLATES_DIR env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ name: CI
 # intent: ci
 # summary: Validate example organs and ensure node ID docs are up to date.
 
+# neira:meta
+# id: NEI-20250310-cell-templates-ci-env
+# intent: ci
+# summary: Установлена переменная CELL_TEMPLATES_DIR для тестов.
+
 on:
   push:
     branches: [ main ]
@@ -14,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CELL_TEMPLATES_DIR: ./templates
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1495,9 +1495,15 @@ async fn main() {
     } else {
         fmt_builder.init();
     }
-
-    let templates_dir =
-        std::env::var("NODE_TEMPLATES_DIR").unwrap_or_else(|_| "./templates".into());
+    /* neira:meta
+    id: NEI-20250310-cell-templates-env
+    intent: refactor
+    summary: |
+      Перешли на CELL_TEMPLATES_DIR, сохранив поддержку NODE_TEMPLATES_DIR для обратной совместимости.
+    */
+    let templates_dir = std::env::var("CELL_TEMPLATES_DIR")
+        .or_else(|_| std::env::var("NODE_TEMPLATES_DIR"))
+        .unwrap_or_else(|_| "./templates".into());
     let _ = std::fs::create_dir_all(&templates_dir);
     let registry = Arc::new(CellRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryCell::new());

--- a/docs/guides/voice-v1-runbook.md
+++ b/docs/guides/voice-v1-runbook.md
@@ -4,6 +4,12 @@ intent: docs
 summary: Пошаговый запуск Voice v1 через Factory Adapter, обновлена ссылка на схему cell-template.
 -->
 
+<!-- neira:meta
+id: NEI-20250310-cell-templates-env-doc
+intent: docs
+summary: Обновлена переменная окружения на CELL_TEMPLATES_DIR с поддержкой NODE_TEMPLATES_DIR.
+-->
+
 # Voice v1 — Runbook (Adapter-only)
 
 Goal
@@ -20,7 +26,7 @@ Prerequisites
 
 - Backend собран и запущен с включённым адаптером фабрики:
   - PowerShell: `$env:FACTORY_ADAPTER_ENABLED='1'`
-  - (опц.) каталог шаблонов: `$env:NODE_TEMPLATES_DIR='templates'` (подкаталоги поддерживаются)
+  - (опц.) каталог шаблонов: `$env:CELL_TEMPLATES_DIR='templates'` (подкаталоги поддерживаются; fallback `NODE_TEMPLATES_DIR`)
   - Токен (минимум write) для API: `$env:FACTORY_TOKEN='secret'` (см. backend init)
   - Базовый URL: `$env:FACTORY_BASE_URL='http://localhost:3000'` (порт можно сменить через `NEIRA_BIND_ADDR`)
 - Пример смены порта: `$env:NEIRA_BIND_ADDR='0.0.0.0:4000'`

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -56,7 +56,13 @@ summary: Описаны IDLE_EMA_ALPHA и IDLE_DRYRUN_QUEUE_DEPTH.
 <!-- neira:meta
 id: NEI-20250310-cell-templates-recursive-docs
 intent: docs
-summary: Уточнено, что NODE_TEMPLATES_DIR поддерживает подкаталоги.
+summary: Уточнено, что CELL_TEMPLATES_DIR поддерживает подкаталоги.
+-->
+
+<!-- neira:meta
+id: NEI-20250310-cell-templates-env-rename
+intent: docs
+summary: Переименована NODE_TEMPLATES_DIR в CELL_TEMPLATES_DIR с fallback на старое имя.
 -->
 
 | Ключ                         | Тип             | По умолчанию          | Где используется        | Влияние                                                                                                 |
@@ -70,7 +76,7 @@ summary: Уточнено, что NODE_TEMPLATES_DIR поддерживает п
 | MASK_PII                     | bool            | true                  | storage masking         | Маскирование PII по умолчанию                                                                           |
 | MASK_REGEX                   | string list (;) | —                     | storage masking         | Кастомные regex для маскирования                                                                        |
 | MASK_ROLES                   | string list (,) | user                  | storage masking         | Роли для маскирования                                                                                   |
-| NODE_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов клеток (подкаталоги поддерживаются)                                                      |
+| CELL_TEMPLATES_DIR           | string          | ./templates           | backend init            | Каталог шаблонов клеток (подкаталоги; fallback `NODE_TEMPLATES_DIR`)                                                      |
 | CHAT_RATE_LIMIT_PER_MIN      | int             | 120                   | hub rate limit          | Лимит запросов в минуту                                                                                 |
 | CHAT_RATE_KEY                | enum            | auth                  | hub rate limit          | Ключ лимита: auth/chat/session                                                                          |
 | IO_WATCHER_THRESHOLD_MS      | int             | 100                   | nervous probes          | Порог латентности для проб                                                                              |


### PR DESCRIPTION
## Summary
- prefer CELL_TEMPLATES_DIR over legacy NODE_TEMPLATES_DIR in backend with fallback
- document CELL_TEMPLATES_DIR and update runbook
- set CELL_TEMPLATES_DIR in CI

## Testing
- `npm test`
- `npm test --prefix frontend`
- `cargo test --manifest-path backend/Cargo.toml`
- `npm run lint`
- `cargo clippy --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b6b3d0dc948323a1787aeb7b4a3a57