### PR TITLE
fix: переименовать описание реестра клеток

### DIFF
--- a/backend/src/cell_registry.rs
+++ b/backend/src/cell_registry.rs
@@ -111,7 +111,7 @@ fn scan_dir(
     }
 }
 
-/// Реестр узлов: хранит метаданные и следит за изменениями файлов.
+/// Реестр клеток: хранит метаданные и следит за изменениями файлов.
 pub struct CellRegistry {
     root: PathBuf,
     cells: Arc<RwLock<HashMap<String, CellTemplate>>>,


### PR DESCRIPTION
## Summary
- поправлено описание структуры `CellRegistry`

## Testing
- `cargo fmt -- backend/src/cell_registry.rs`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6bf4743f48323b2e56511cffb9a80