### PR TITLE
refactor: rename factory to stem cell

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,6 +15,11 @@ id: NEI-20241004-hub-progress-cleanup
 intent: refactor
 summary: Удалён неиспользуемый клон SynapseHub при отправке прогресса анализа.
 */
+/* neira:meta
+id: NEI-20250316-stemcell-rename
+intent: refactor
+summary: Обновлены перечисления FabricationState → StemCellState.
+*/
 use async_stream::stream;
 use axum::{
     extract::{
@@ -53,11 +58,11 @@ use backend::cell_registry::CellRegistry;
 use backend::cell_template::CellTemplate;
 use backend::config::Config;
 use backend::context::context_storage::FileContextStorage;
-use backend::factory::{AdapterBackend, CellTemplateAdapter, FabricationState};
-use backend::synapse_hub::SynapseHub;
+use backend::factory::{AdapterBackend, CellTemplateAdapter, StemCellState};
 use backend::memory_cell::MemoryCell;
 use backend::policy::{Capability, PolicyEngine};
 use backend::security::init_config_cell::InitConfigCell;
+use backend::synapse_hub::SynapseHub;
 mod http {
     pub mod training_routes;
 }
@@ -441,14 +446,14 @@ fn format_organ_state(st: backend::organ_builder::OrganState) -> &'static str {
     }
 }
 
-fn format_state(st: FabricationState) -> &'static str {
+fn format_state(st: StemCellState) -> &'static str {
     match st {
-        FabricationState::Draft => "draft",
-        FabricationState::Canary => "canary",
-        FabricationState::Experimental => "experimental",
-        FabricationState::Stable => "stable",
-        FabricationState::Disabled => "disabled",
-        FabricationState::RolledBack => "rolled_back",
+        StemCellState::Draft => "draft",
+        StemCellState::Canary => "canary",
+        StemCellState::Experimental => "experimental",
+        StemCellState::Stable => "stable",
+        StemCellState::Disabled => "disabled",
+        StemCellState::RolledBack => "rolled_back",
     }
 }
 

--- a/backend/src/synapse_hub.rs
+++ b/backend/src/synapse_hub.rs
@@ -10,6 +10,11 @@ id: NEI-20250214-watchdog-refactor
 intent: refactor
 summary: Логика watchdog вынесена в модуль nervous_system::watchdog.
 */
+/* neira:meta
+id: NEI-20250316-stemcell-rename
+intent: refactor
+summary: Обновлены ссылки на StemCellFactory и связанные типы.
+*/
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -17,7 +22,7 @@ use crate::action::diagnostics_cell::DiagnosticsCell;
 use crate::action::metrics_collector_cell::{MetricsCollectorCell, MetricsRecord};
 use crate::config::Config;
 use crate::context::context_storage::{ChatMessage, ContextStorage, Role};
-use crate::factory::{FabricatorCell, FactoryService, SelectorCell};
+use crate::factory::{FabricatorCell, SelectorCell, StemCellFactory};
 use crate::hearing;
 use crate::idempotent_store::IdempotentStore;
 use crate::nervous_system::{
@@ -81,7 +86,7 @@ pub struct SynapseHub {
     trace_enabled: AtomicBool,
     trace_max_events: usize,
     // Factory service (adapter-only for now)
-    factory: Arc<FactoryService>,
+    factory: Arc<StemCellFactory>,
     organ_builder: Arc<OrganBuilder>,
 }
 
@@ -184,7 +189,7 @@ impl SynapseHub {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(200),
-            factory: FactoryService::new(),
+            factory: StemCellFactory::new(),
             organ_builder: OrganBuilder::new(),
         };
 
@@ -259,16 +264,16 @@ impl SynapseHub {
         &self,
         backend: &str,
         tpl: &crate::cell_template::CellTemplate,
-    ) -> crate::factory::FactoryRecord {
+    ) -> crate::factory::StemCellRecord {
         self.factory.create_record(backend, tpl)
     }
-    pub fn factory_advance(&self, id: &str) -> Option<crate::factory::FabricationState> {
+    pub fn factory_advance(&self, id: &str) -> Option<crate::factory::StemCellState> {
         self.factory.advance(id)
     }
-    pub fn factory_disable(&self, id: &str) -> Option<crate::factory::FabricationState> {
+    pub fn factory_disable(&self, id: &str) -> Option<crate::factory::StemCellState> {
         self.factory.disable(id)
     }
-    pub fn factory_rollback(&self, id: &str) -> Option<crate::factory::FabricationState> {
+    pub fn factory_rollback(&self, id: &str) -> Option<crate::factory::StemCellState> {
         self.factory.rollback(id)
     }
     pub fn factory_counts(&self) -> (usize, usize) {

--- a/docs/design/factory-system.md
+++ b/docs/design/factory-system.md
@@ -9,12 +9,18 @@ id: NEI-20251115-organ-cancel-build-design
 intent: design
 summary: упомянут DELETE /organs/:id/build в API эскизе.
 -->
+<!-- neira:meta
+id: NEI-20250316-stemcell-rename
+intent: docs
+summary: Термины обновлены на StemCellFactory/StemCellRecord/StemCellState.
+-->
 
-# Factory System (Фабрикаторы)
+# Stem Cell Factory System (Фабрикаторы)
 
 Purpose
 - Создавать новые клетки (Analysis/Action/Memory) из дескрипторов с безопасными бэкендами исполнения и управлением рисками.
 - Обеспечить повторное использование готовых клеток, автоподключение к ключевым системам, и «человек в петле» для обучения/стабилизации.
+- Центральный сервис управления — **StemCellFactory**; записи о созданных клетках хранятся как **StemCellRecord** со статусами **StemCellState**.
 
 Components
 - FabricatorCell (Action): принимает FabricationRequest и создаёт клетки через бэкенды:

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,11 @@ intent: docs
 summary: |
   Автогенерированный список файлов документации.
 -->
+<!-- neira:meta
+id: NEI-20250316-stemcell-rename
+intent: docs
+summary: Обновлён заголовок для stem-cell-factory.
+-->
 
 # Документация — оглавление
 
@@ -13,7 +18,7 @@ summary: |
 - [immune_system](immune_system.md)
 - design/
   - [anti-idle-system](design/anti-idle-system.md)
-  - [factory-system](design/factory-system.md)
+  - [stem-cell-factory](design/factory-system.md)
   - [homeostasis](design/homeostasis.md)
   - [nervous_system](design/nervous_system.md)
   - [organ-systems](design/organ-systems.md)


### PR DESCRIPTION
## Summary
- rename FactoryService and FactoryRecord to StemCellFactory and StemCellRecord
- update hub and API references to StemCellState enum
- refresh factory docs with new stem cell terminology

## Testing
- `cargo -Znext-lockfile-bump test` *(fails: package `zerofrom v0.1.6` requires rustc 1.81 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cf4687248323ae75196d7621d4d5