### PR TITLE
feat: add immune system observer

### DIFF
--- a/backend/src/factory/mod.rs
+++ b/backend/src/factory/mod.rs
@@ -9,6 +9,11 @@ id: NEI-20250316-stemcell-rename
 intent: refactor
 summary: Введены StemCellFactory и StemCellRecord.
 */
+/* neira:meta
+id: NEI-20250215-factory-watch
+intent: refactor
+summary: Добавлены вызовы nervous_system::watch и immune_system::observe при создании записи.
+*/
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -96,6 +101,8 @@ impl StemCellFactory {
             "backend": backend,
             "template_id": tpl.id
         }));
+        crate::nervous_system::watch(&rec);
+        crate::immune_system::observe(&rec);
         rec
     }
 

--- a/backend/src/immune_system/mod.rs
+++ b/backend/src/immune_system/mod.rs
@@ -1,0 +1,11 @@
+/* neira:meta
+id: NEI-20250215-immune-module
+intent: code
+summary: Создан модуль immune_system с функцией observe.
+*/
+
+use crate::factory::StemCellRecord;
+
+pub fn observe(_record: &StemCellRecord) {
+    metrics::counter!("immune_observations_total").increment(1);
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,8 @@
+/* neira:meta
+id: NEI-20250215-immune-export
+intent: code
+summary: Экспортирован модуль immune_system.
+*/
 pub mod action;
 pub mod action_cell;
 pub mod analysis_cell;
@@ -7,11 +12,12 @@ pub mod config;
 pub mod context;
 pub mod hearing;
 pub mod idempotent_store;
-pub mod synapse_hub;
+pub mod immune_system;
 pub mod memory_cell;
 pub mod nervous_system;
 pub mod queue_config;
 pub mod security;
+pub mod synapse_hub;
 pub mod task_scheduler;
 pub mod trigger_detector;
 // duplicates removed

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -20,6 +20,11 @@ id: NEI-20250316-stemcell-rename
 intent: refactor
 summary: Перечисление StemCellState (раньше назывался FabricationState).
 */
+/* neira:meta
+id: NEI-20250215-immune-import-main
+intent: refactor
+summary: Добавлен импорт immune_system.
+*/
 use async_stream::stream;
 use axum::{
     extract::{
@@ -33,6 +38,8 @@ use axum::{
 };
 use backend::context::context_storage::set_runtime_mask_config;
 use backend::hearing;
+#[allow(unused_imports)]
+use backend::immune_system;
 use backend::nervous_system::anti_idle;
 use backend::nervous_system::backpressure_probe::BackpressureProbe;
 use backend::nervous_system::heartbeat;

--- a/backend/src/nervous_system/mod.rs
+++ b/backend/src/nervous_system/mod.rs
@@ -1,3 +1,9 @@
+/* neira:meta
+id: NEI-20250215-ns-watch
+intent: code
+summary: Добавлен заглушечный watch для мониторинга записей фабрики.
+*/
+use crate::factory::StemCellRecord;
 use async_trait::async_trait;
 
 /// Common interface for system-level probes that expose diagnostics and
@@ -12,6 +18,10 @@ pub trait SystemProbe: Send + Sync {
     /// nothing, allowing probes that operate only via `start` to leave it
     /// empty.
     fn collect(&mut self) {}
+}
+
+pub fn watch(_record: &StemCellRecord) {
+    metrics::counter!("nervous_watches_total").increment(1);
 }
 
 pub mod anti_idle;

--- a/backend/src/synapse_hub.rs
+++ b/backend/src/synapse_hub.rs
@@ -15,6 +15,11 @@ id: NEI-20250316-stemcell-rename
 intent: refactor
 summary: Обновлены ссылки на StemCellFactory и связанные типы.
 */
+/* neira:meta
+id: NEI-20250215-immune-import-hub
+intent: refactor
+summary: Добавлен импорт immune_system.
+*/
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -25,6 +30,8 @@ use crate::context::context_storage::{ChatMessage, ContextStorage, Role};
 use crate::factory::{FabricatorCell, SelectorCell, StemCellFactory};
 use crate::hearing;
 use crate::idempotent_store::IdempotentStore;
+#[allow(unused_imports)]
+use crate::immune_system;
 use crate::nervous_system::{
     host_metrics::HostMetrics, io_watcher::IoWatcher, watchdog::Watchdog, SystemProbe,
 };


### PR DESCRIPTION
## Summary
- watch new stem-cell records through nervous and immune systems
- export immune system module and wire imports

## Testing
- `cargo clippy -p backend --no-deps`
- `cargo test --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68b6e386059c8323ba105dbace4e2fd5