### PR TITLE
feat(immune): add preflight check for stem cell records

### DIFF
--- a/backend/src/immune_system/mod.rs
+++ b/backend/src/immune_system/mod.rs
@@ -5,7 +5,25 @@ summary: Создан модуль immune_system с функцией observe.
 */
 
 use crate::factory::StemCellRecord;
+use jsonschema_valid::ValidationError;
 
 pub fn observe(_record: &StemCellRecord) {
     metrics::counter!("immune_observations_total").increment(1);
+}
+
+/* neira:meta
+id: NEI-20260514-preflight-check
+intent: code
+summary: Добавлена заглушка preflight_check для валидации записей.
+*/
+pub fn preflight_check(record: &StemCellRecord) -> Result<(), ValidationError> {
+    metrics::counter!("immune_preflight_checks_total").increment(1);
+    if record.id.is_empty() || record.backend.is_empty() || record.template_id.is_empty() {
+        return Err(ValidationError::new(
+            "record fields must not be empty",
+            None,
+            None,
+        ));
+    }
+    Ok(())
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -184,7 +184,15 @@ async fn factory_create(
     adapter
         .register(&state.hub.registry)
         .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
-    let rec = state.hub.factory_create(backend, &body.tpl);
+    /* neira:meta
+    id: NEI-20260514-factory-handler-result
+    intent: code
+    summary: Обработчик учитывает ошибки preflight_check.
+    */
+    let rec = state
+        .hub
+        .factory_create(backend, &body.tpl)
+        .map_err(|_| axum::http::StatusCode::BAD_REQUEST)?;
     Ok(Json(serde_json::json!({"id": rec.id, "state": "draft"})))
 }
 

--- a/backend/src/synapse_hub.rs
+++ b/backend/src/synapse_hub.rs
@@ -39,6 +39,7 @@ use crate::organ_builder::{OrganBuilder, OrganState};
 use crate::security::integrity_checker_cell::IntegrityCheckerCell;
 use crate::security::quarantine_cell::QuarantineCell;
 use crate::security::safe_mode_controller::SafeModeController;
+use jsonschema_valid::ValidationError;
 use lru::LruCache;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -267,11 +268,16 @@ impl SynapseHub {
     pub fn factory_dry_run(&self, tpl: &crate::cell_template::CellTemplate) -> serde_json::Value {
         self.factory.dry_run(tpl)
     }
+    /* neira:meta
+    id: NEI-20260514-factory-create-result
+    intent: code
+    summary: Возвращает Result с ошибкой валидации при создании записи.
+    */
     pub fn factory_create(
         &self,
         backend: &str,
         tpl: &crate::cell_template::CellTemplate,
-    ) -> crate::factory::StemCellRecord {
+    ) -> Result<crate::factory::StemCellRecord, ValidationError> {
         self.factory.create_record(backend, tpl)
     }
     pub fn factory_advance(&self, id: &str) -> Option<crate::factory::StemCellState> {


### PR DESCRIPTION
## Summary
- add immune_system::preflight_check validating stem cell records
- call preflight check from StemCellFactory before saving records
- propagate validation errors through SynapseHub and HTTP factory handler

## Testing
- `pre-commit run --files backend/src/immune_system/mod.rs backend/src/factory/mod.rs backend/src/synapse_hub.rs backend/src/main.rs`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ecb2dce88323815d37f2d4d44ca8