### PR TITLE
feat(factory): track auto response failures

### DIFF
--- a/backend/src/factory/mod.rs
+++ b/backend/src/factory/mod.rs
@@ -176,28 +176,37 @@ impl StemCellFactory {
     intent: code
     summary: Добавлены auto_heal и auto_rollback для реакций immune_system.
     */
+    /* neira:meta
+    id: NEI-20250310-factory-auto-failure-metrics
+    intent: code
+    summary: Добавлены счётчики неудачных auto_heal и auto_rollback.
+    */
     pub fn auto_heal(&self, id: &str) -> Option<StemCellState> {
         let res = self.disable(id);
-        if res.is_some() {
+        if let Some(_) = res {
             metrics::counter!("factory_auto_heals_total").increment(1);
             let _ = Self::audit_log(&serde_json::json!({
                 "ts": Utc::now().to_rfc3339(),
                 "event": "factory.auto_heal",
                 "id": id
             }));
+        } else {
+            metrics::counter!("factory_auto_heal_failures_total").increment(1);
         }
         res
     }
 
     pub fn auto_rollback(&self, id: &str) -> Option<StemCellState> {
         let res = self.rollback(id);
-        if res.is_some() {
+        if let Some(_) = res {
             metrics::counter!("factory_auto_rollbacks_total").increment(1);
             let _ = Self::audit_log(&serde_json::json!({
                 "ts": Utc::now().to_rfc3339(),
                 "event": "factory.auto_rollback",
                 "id": id
             }));
+        } else {
+            metrics::counter!("factory_auto_rollback_failures_total").increment(1);
         }
         res
     }

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -93,6 +93,11 @@ id: NEI-20250215-factory-auto-metrics
 intent: docs
 summary: документированы метрики auto_heal и auto_rollback.
 -->
+<!-- neira:meta
+id: NEI-20250310-factory-auto-failure-metrics-docs
+intent: docs
+summary: добавлены счётчики неудачных auto_heal и auto_rollback.
+-->
 | metric | type | unit | scope | description |
 |---|---|---|---|---|
 | factory_cells_created_total | counter | cells | Factory | Создано клеток (всего) |
@@ -103,6 +108,8 @@ summary: документированы метрики auto_heal и auto_rollbac
 | factory_rollbacks_total | counter | ops | Factory | Откаты клеток |
 | factory_auto_heals_total | counter | ops | Factory | Авто‑отключения по тревоге |
 | factory_auto_rollbacks_total | counter | ops | Factory | Авто‑откат по тревоге |
+| factory_auto_heal_failures_total | counter | ops | Factory | Неудачные авто‑отключения |
+| factory_auto_rollback_failures_total | counter | ops | Factory | Неудачные авто‑откаты |
 | organ_build_attempts_total | counter | ops | OrganBuilder | Попытки сборки органов |
 | organ_build_failures_total | counter | ops | OrganBuilder | Ошибки сборки органов |
 | organ_build_status_queries_total | counter | ops | OrganBuilder | Запросы статуса органа |


### PR DESCRIPTION
## Summary
- count failed auto-heal and auto-rollback attempts
- document auto response failure counters

## Testing
- `cargo fmt -p backend` *(fails: command not found)*
- `cargo clippy -p backend -- -D warnings` *(fails: command not found)*
- `cargo test -p backend` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7036dea108323a4ade3e3561b0c2c