### PR TITLE
feat: track immune alerts by severity

### DIFF
--- a/backend/src/immune_system/mod.rs
+++ b/backend/src/immune_system/mod.rs
@@ -13,6 +13,15 @@ pub fn observe(_record: &StemCellRecord) {
 }
 
 /* neira:meta
+id: NEI-20250720-immune-alert-handler
+intent: code
+summary: Добавлен обработчик alert для регистрации алертов иммунной системы.
+*/
+pub fn alert(severity: &str) {
+    metrics::counter!("immune_alerts_total", "severity" => severity.to_string()).increment(1);
+}
+
+/* neira:meta
 id: NEI-20251227-immune-subscriber
 intent: code
 summary: Подписчик immune_system на события CellCreated и OrganBuilt.

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -40,6 +40,7 @@ summary: добавлена метрика organ_build_duration_ms и стату
 | approvals_pending | gauge | count | Anti-Idle | Запросы на одобрение в очереди |
 | autonomous_time_spent_seconds | counter | s | Anti-Idle | Секунды автономной работы |
 | microtask_queue_depth | gauge | count | Anti-Idle | Глубина очереди микрозадач |
+| immune_alerts_total{severity} | counter | alerts | Immune System | Алерты иммунной системы (лейбл severity) |
 
 ## Связь с дорожной картой (Embryo / Stage 0–1)
 
@@ -83,6 +84,17 @@ summary: добавлена метрика organ_build_duration_ms и стату
 
 См. также: docs/design/homeostasis.md
 - pause_reason_total{reason} (counter): количество пауз по причинам (использовать осторожно из-за кардинальности).
+
+---
+
+## Immune System
+
+<!-- neira:meta
+id: NEI-20250720-immune-alert-metric-docs
+intent: docs
+summary: документирован счётчик immune_alerts_total с лейблом severity.
+-->
+- immune_alerts_total{severity} (counter): алерты иммунной системы (лейбл severity).
 
 ---
 


### PR DESCRIPTION
## Summary
- add `alert` handler to immune system for severity-based alert counting
- document `immune_alerts_total{severity}` metric

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b71c73ab708323b23c4d41ffa47f0a