### PR TITLE
refactor: заменить match с одним вариантом на if let

### DIFF
--- a/backend/src/action/scripted_training_cell.rs
+++ b/backend/src/action/scripted_training_cell.rs
@@ -166,12 +166,9 @@ impl ScriptedTrainingCell {
                         .strip_prefix("FILE:")
                         .or_else(|| key.strip_prefix("VAR_FILE:"))
                     {
-                        match std::fs::read_to_string(path) {
-                            Ok(mut s) => {
-                                s.truncate(s.trim_end().len());
-                                out.push_str(s.trim());
-                            }
-                            Err(_) => {}
+                        if let Ok(mut s) = std::fs::read_to_string(path) {
+                            s.truncate(s.trim_end().len());
+                            out.push_str(s.trim());
                         }
                     } else {
                         out.push_str(env.get(key).map(|s| s.as_str()).unwrap_or(""));


### PR DESCRIPTION
## Summary
- заменили match с одним вариантом на if let в scripted_training_cell

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b7386a62308323ad1ed2bdca8e8f9a