### PR TITLE
docs: переименование backend/services в spinal_cord/services

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,3 +1,9 @@
+<!-- neira:meta
+id: NEI-20250902-202115-rename-backend
+intent: docs
+summary: |
+  Уточнено название каталога: backend/services -> spinal_cord/services.
+-->
 // Architectural Decision Records (ADR Index)
 
 Format
@@ -17,5 +23,5 @@ Templates
 
 ADR-001 Rust as primary language — Accepted
 - Context: Safety (memory correctness), performance, strong tooling, suitability for long-running services with low overhead and predictable behavior. Owner prefers Rust for control and reliability.
-- Decision: Implement backend/services in Rust; prefer Rust-first libs; keep interfaces simple for future polyglot modules.
+- Decision: Implement spinal_cord/services in Rust; prefer Rust-first libs; keep interfaces simple for future polyglot modules.
 - Consequences: Higher initial complexity vs scripting, but better long-term stability; need strict coding guidelines and documentation to mitigate onboarding cost.


### PR DESCRIPTION
## Summary
- обновлён DECISIONS.md: теперь указано `spinal_cord/services`
- добавлен neira:meta блок для фиксации правки

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b751819c508323b364553e6d87a423