### PR TITLE
feat: добавить остановку системных проб

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,12 @@ Neira поддерживает пользовательские системны
 нужно реализовать трейt [`SystemProbe`](spinal_cord/src/nervous_system/mod.rs) и
 запустить его в фоне:
 
+<!-- neira:meta
+id: NEI-20240607-systemprobe-doc-stop
+intent: docs
+summary: Пример SystemProbe обновлён методом stop.
+-->
+
 ```rust
 use neira::nervous_system::SystemProbe;
 
@@ -553,6 +559,10 @@ impl SystemProbe for CustomProbe {
 
     fn collect(&mut self) {
         // сбор и публикация метрик
+    }
+
+    fn stop(&mut self) {
+        // завершение фонового цикла
     }
 }
 

--- a/spinal_cord/src/nervous_system/mod.rs
+++ b/spinal_cord/src/nervous_system/mod.rs
@@ -3,6 +3,11 @@ id: NEI-20250215-ns-watch
 intent: code
 summary: Добавлен заглушечный watch для мониторинга записей фабрики.
 */
+/* neira:meta
+id: NEI-20240607-systemprobe-stop
+intent: feature
+summary: Трейт SystemProbe расширен методом stop для завершения фоновых циклов.
+*/
 use crate::event_bus::{CellCreated, Event, OrganBuilt, Subscriber};
 use crate::factory::StemCellRecord;
 use async_trait::async_trait;
@@ -19,6 +24,9 @@ pub trait SystemProbe: Send + Sync {
     /// nothing, allowing probes that operate only via `start` to leave it
     /// empty.
     fn collect(&mut self) {}
+
+    /// Signal the probe to terminate its background loop and clean up.
+    fn stop(&mut self);
 }
 
 pub fn watch(_record: &StemCellRecord) {

--- a/spinal_cord/tests/io_watcher_test.rs
+++ b/spinal_cord/tests/io_watcher_test.rs
@@ -1,9 +1,15 @@
+/* neira:meta
+id: NEI-20240607-io-watcher-test-update
+intent: test
+summary: Обновлены вызовы IoWatcher::new с токеном остановки.
+*/
 use std::sync::Arc;
 use std::time::Duration;
 
 use backend::action::diagnostics_cell::DiagnosticsCell;
 use backend::action::metrics_collector_cell::MetricsCollectorCell;
 use backend::nervous_system::io_watcher::IoWatcher;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
 async fn io_watcher_triggers_diagnostics_on_delay() {
@@ -11,7 +17,7 @@ async fn io_watcher_triggers_diagnostics_on_delay() {
     let (_diag, mut dev_rx, _alert_rx) =
         DiagnosticsCell::new_with_fix(rx, 1, metrics.clone(), Arc::new(|| false));
 
-    let watcher = IoWatcher::new(metrics, 1);
+    let watcher = IoWatcher::new(metrics, 1, CancellationToken::new());
     watcher.record_keyboard_latency(Duration::from_millis(5));
 
     let req = tokio::time::timeout(Duration::from_millis(100), dev_rx.recv())
@@ -27,7 +33,7 @@ async fn io_watcher_ignores_small_latency() {
     let (_diag, mut dev_rx, _alert_rx) =
         DiagnosticsCell::new_with_fix(rx, 1, metrics.clone(), Arc::new(|| false));
 
-    let watcher = IoWatcher::new(metrics, 100);
+    let watcher = IoWatcher::new(metrics, 100, CancellationToken::new());
     watcher.record_keyboard_latency(Duration::from_millis(10));
 
     tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
## Summary
- расширен трейt SystemProbe методом `stop`
- датчики HostMetrics и IoWatcher умеют корректно останавливаться
- SynapseHub завершает все пробы при выключении

## Testing
- `cargo test`
- `cargo test` (root)
- `cargo clippy -- -D warnings` *(failed: existing lints)*

------
https://chatgpt.com/codex/tasks/task_e_68b753a5ea488323a15bdd0a3fee6a72