### PR TITLE
feat: валидация стволовых записей по JSON Schema

### DIFF
--- a/schemas/stem_cell_record.json
+++ b/schemas/stem_cell_record.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StemCellRecord",
+  "type": "object",
+  "required": ["id", "backend", "template_id", "state", "created_at"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "backend": { "type": "string", "minLength": 1 },
+    "template_id": { "type": "string", "minLength": 1 },
+    "state": {
+      "type": "string",
+      "enum": ["Draft", "Canary", "Experimental", "Stable", "Disabled", "RolledBack"]
+    },
+    "created_at": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/spinal_cord/tests/immune_preflight_check.rs
+++ b/spinal_cord/tests/immune_preflight_check.rs
@@ -1,0 +1,33 @@
+/* neira:meta
+id: NEI-20260514-preflight-tests
+intent: test
+summary: Проверяет валидацию StemCellRecord через preflight_check.
+*/
+
+use backend::factory::{StemCellRecord, StemCellState};
+use backend::immune_system::preflight_check;
+use chrono::Utc;
+
+#[test]
+fn preflight_check_valid_record() {
+    let record = StemCellRecord {
+        id: "b:tpl".to_string(),
+        backend: "b".to_string(),
+        template_id: "tpl".to_string(),
+        state: StemCellState::Draft,
+        created_at: Utc::now(),
+    };
+    assert!(preflight_check(&record).is_ok());
+}
+
+#[test]
+fn preflight_check_invalid_record() {
+    let record = StemCellRecord {
+        id: String::new(),
+        backend: String::new(),
+        template_id: String::new(),
+        state: StemCellState::Draft,
+        created_at: Utc::now(),
+    };
+    assert!(preflight_check(&record).is_err());
+}


### PR DESCRIPTION
## Описание
- проверка `StemCellRecord` по схеме `schemas/stem_cell_record.json`
- тесты успешной и неуспешной валидации

## Тестирование
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --manifest-path spinal_cord/Cargo.toml --test immune_preflight_check -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b755da5f08832386773e319c2560fe