### PR TITLE
docs: заменить scope backend на spinal_cord

### DIFF
--- a/spinal_cord/src/action/chat_cell.rs
+++ b/spinal_cord/src/action/chat_cell.rs
@@ -95,7 +95,7 @@ impl ChatCell for EchoChatCell {
 /* neira:meta
 id: NEI-20250829-setup-meta-chatcell
 intent: docs
-scope: backend/chat-cell
+scope: spinal_cord/chat-cell
 summary: |
   EchoChatCell: простая отражающая клетка. Входящее user‑сообщение сохраняется в SynapseHub,
   чтобы избежать дублей; здесь сохраняется ответ ассистента.

--- a/spinal_cord/src/action/metrics_collector_cell.rs
+++ b/spinal_cord/src/action/metrics_collector_cell.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20250829-175425-metrics-collector
 intent: docs
-scope: backend/action
+scope: spinal_cord/action
 summary: |
   Сборщик метрик с динамическим интервалом опроса.
 env:

--- a/spinal_cord/src/action/scripted_training_cell.rs
+++ b/spinal_cord/src/action/scripted_training_cell.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20250829-175425-scripted-training
 intent: docs
-scope: backend/action
+scope: spinal_cord/action
 summary: |
   Выполняет сценарии обучения; пути и режим задаются через переменные окружения.
 env:

--- a/spinal_cord/src/cell_template.rs
+++ b/spinal_cord/src/cell_template.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20250829-175425-cell-template
 intent: docs
-scope: backend/core
+scope: spinal_cord/core
 summary: |
   Загружает и валидирует шаблоны ячеек по JSON‑схеме.
 env:

--- a/spinal_cord/src/context/context_storage.rs
+++ b/spinal_cord/src/context/context_storage.rs
@@ -725,7 +725,7 @@ fn super_keywords(content: &str) -> Vec<String> {
 /* neira:meta
 id: NEI-20250829-setup-meta-storage
 intent: docs
-scope: backend/storage
+scope: spinal_cord/storage
 summary: |
   Файловое хранилище контекста (ndjson + дневная ротация + gzip), индекс index.json,
   TTL ключевых слов, адаптивные лимиты по диску (storage_metrics.json), маскирование

--- a/spinal_cord/src/idempotent_store.rs
+++ b/spinal_cord/src/idempotent_store.rs
@@ -84,7 +84,7 @@ fn now_secs() -> u64 {
 /* neira:meta
 id: NEI-20250829-setup-meta-idem
 intent: docs
-scope: backend/idempotency
+scope: spinal_cord/idempotency
 summary: |
   Персистентное хранилище идемпотентных ответов (JSONL + TTL). Используется SynapseHub
   для выдачи повторных ответов по request_id, переживает рестарт.

--- a/spinal_cord/src/security/init_config_cell.rs
+++ b/spinal_cord/src/security/init_config_cell.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20250829-175425-init-config
 intent: docs
-scope: backend/security
+scope: spinal_cord/security
 summary: |
   Инициализирует переменные конфигурации, устанавливая INTEGRITY_ROOT.
 env:

--- a/spinal_cord/src/security/integrity_checker_cell.rs
+++ b/spinal_cord/src/security/integrity_checker_cell.rs
@@ -1,7 +1,7 @@
 /* neira:meta
 id: NEI-20250829-175425-integrity-checker
 intent: docs
-scope: backend/security
+scope: spinal_cord/security
 summary: |
   Проверяет контрольные суммы файлов и отправляет подозрительные в карантин.
 env:

--- a/spinal_cord/src/synapse_hub.rs
+++ b/spinal_cord/src/synapse_hub.rs
@@ -1050,7 +1050,7 @@ static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 /* neira:meta
 id: NEI-20250829-setup-meta-hub
 intent: docs
-scope: backend/hub
+scope: spinal_cord/hub
 summary: |
   Политики чата: скоупы read/write/admin, idempotency (LRU+file TTL), rate-limit с ключом,
   safe-mode (write=admin), сохранение входящего user-сообщения с метаданными (source/thread_id).


### PR DESCRIPTION
## Summary
- заменить `scope: backend` на `scope: spinal_cord` в модулях spinal_cord

## Testing
- `cargo check`
- `cargo test` *(прервано: зависание)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a1ea7680832391c5ad3e4247c2f7