### PR TITLE
Переименовать meta id для sensory_organs

### DIFF
--- a/sensory_organs/src/index.js
+++ b/sensory_organs/src/index.js
@@ -1,10 +1,10 @@
 /* neira:meta
-id: NEI-20250829-180333-frontend-init
+id: NEI-20250829-180333-sensory_organs-init
 intent: docs
 summary: |
   Инициализирует PWA и возвращает приветствие.
 */
 
 export function init() {
-  return 'Hello PWA';
+  return "Hello PWA";
 }

--- a/sensory_organs/src/main.js
+++ b/sensory_organs/src/main.js
@@ -1,5 +1,5 @@
 /* neira:meta
-id: NEI-20250829-180333-frontend-main
+id: NEI-20250829-180333-sensory_organs-main
 intent: docs
 summary: |
   Пример простого PWA с формой и обработкой сообщений. Добавлена поддержка VITE_API_URL.


### PR DESCRIPTION
## Summary
- обновлены neira:meta id в sensory_organs/src/index.js и sensory_organs/src/main.js

## Testing
- `npm run lint`
- `npm test`
- `npm run sensory_organs:test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5c04c3c83239c888b837bae114a