### PR TITLE
ci: обновить actions для вывода через GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ name: CI
 # intent: ci
 # summary: Обновлены пути на spinal_cord и sensory_organs.
 
+# neira:meta
+# id: NEI-20260610-ci-github-output
+# intent: ci
+# summary: Обновлены actions для вывода через $GITHUB_OUTPUT.
+
 on:
   push:
     branches: [ main ]
@@ -27,14 +32,11 @@ jobs:
     env:
       CELL_TEMPLATES_DIR: ./templates
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Validate Cargo files
         run: cargo metadata --locked
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- replace `actions-rs/toolchain` with `dtolnay/rust-toolchain@stable`
- bump `actions/checkout` to v5
- keep `actions/setup-node` at latest v4

## Testing
- `scripts/check-duplicates.sh`
- `npm run lint`
- `npm run check-examples`
- `npm run generate-cell-docs`
- `git diff --exit-code docs/cell-ids.md`
- `cargo test --manifest-path spinal_cord/Cargo.toml`
- `npm test`

Attempted `act -n` to run workflow but command was not found (missing Docker).

------
https://chatgpt.com/codex/tasks/task_e_68b7b2be9e948323b53242b636cbdb33