### PR TITLE
Мозг направляет задачи в планировщик и публикует события

### DIFF
--- a/spinal_cord/src/brain.rs
+++ b/spinal_cord/src/brain.rs
@@ -3,34 +3,57 @@ id: NEI-20260614-brain-loop
 intent: code
 summary: Обрабатывает сообщения DataFlowController, распределяя события и задачи.
 */
+/* neira:meta
+id: NEI-20240709-brain-scheduler-eventbus
+intent: refactor
+summary: Задачи проходят через TaskScheduler, события публикуются в EventBus.
+*/
+use std::any::Any;
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::cell_registry::CellRegistry;
 use crate::circulatory_system::FlowMessage;
-use crate::event_bus::EventBus;
-use crate::task_scheduler::TaskScheduler;
+use crate::event_bus::{Event, EventBus};
+use crate::task_scheduler::{Priority, Queue, TaskScheduler};
 
 /// Главный цикл мозга: потребляет сообщения из общего канала и реагирует на них
 pub async fn brain_loop(
     mut df_rx: UnboundedReceiver<FlowMessage>,
     registry: Arc<CellRegistry>,
-    _scheduler: Arc<RwLock<TaskScheduler>>,
-    _event_bus: Arc<EventBus>,
+    scheduler: Arc<RwLock<TaskScheduler>>,
+    event_bus: Arc<EventBus>,
 ) {
     while let Some(msg) = df_rx.recv().await {
         match msg {
             FlowMessage::Event(ev) => {
                 info!(event = %ev, "получено событие");
+                #[allow(dead_code)]
+                struct BusEvent(String);
+                impl Event for BusEvent {
+                    fn name(&self) -> &'static str {
+                        "FlowEvent"
+                    }
+                    fn as_any(&self) -> &dyn Any {
+                        self
+                    }
+                }
+                let event = BusEvent(ev);
+                event_bus.publish(&event);
             }
             FlowMessage::Task { id, payload } => {
                 info!(task_id = %id, "получена задача");
-                if let Some(cell) = registry.get_analysis_cell(&id) {
-                    let cancel = CancellationToken::new();
-                    let _ = cell.analyze(&payload, &cancel);
+                if registry.get_analysis_cell(&id).is_some() {
+                    scheduler.write().unwrap().enqueue(
+                        Queue::Standard,
+                        id.clone(),
+                        payload,
+                        Priority::Low,
+                        None,
+                        vec![id],
+                    );
                 } else {
                     warn!(task_id = %id, "клетка не найдена");
                 }

--- a/tests/brain_loop_test.rs
+++ b/tests/brain_loop_test.rs
@@ -7,7 +7,7 @@ use backend::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
 use backend::brain::brain_loop;
 use backend::cell_registry::CellRegistry;
 use backend::circulatory_system::{DataFlowController, FlowMessage};
-use backend::event_bus::EventBus;
+use backend::event_bus::{Event, EventBus, Subscriber};
 use backend::task_scheduler::TaskScheduler;
 use tokio_util::sync::CancellationToken;
 
@@ -41,7 +41,7 @@ impl AnalysisCell for DummyCell {
 }
 
 #[tokio::test]
-async fn brain_loop_processes_tasks() {
+async fn brain_loop_schedules_tasks() {
     let dir = tempfile::tempdir().unwrap();
     let registry = Arc::new(CellRegistry::new(dir.path()).unwrap());
     let counter = Arc::new(AtomicUsize::new(0));
@@ -53,12 +53,50 @@ async fn brain_loop_processes_tasks() {
     let scheduler = Arc::new(RwLock::new(TaskScheduler::default()));
     let event_bus = EventBus::new();
 
-    tokio::spawn(brain_loop(rx, registry.clone(), scheduler, event_bus));
+    tokio::spawn(brain_loop(
+        rx,
+        registry.clone(),
+        scheduler.clone(),
+        event_bus,
+    ));
 
     flow.send(FlowMessage::Task {
         id: "dummy".into(),
         payload: "".into(),
     });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+    let next = scheduler.write().unwrap().next();
+    assert_eq!(next, Some(("dummy".into(), "".into())));
+}
+
+struct DummySubscriber {
+    hits: Arc<AtomicUsize>,
+}
+
+impl Subscriber for DummySubscriber {
+    fn on_event(&self, _event: &dyn Event) {
+        self.hits.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn brain_loop_publishes_events() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(CellRegistry::new(dir.path()).unwrap());
+    let (flow, rx) = DataFlowController::new();
+    let scheduler = Arc::new(RwLock::new(TaskScheduler::default()));
+    let event_bus = EventBus::new();
+    let counter = Arc::new(AtomicUsize::new(0));
+    event_bus.subscribe(Arc::new(DummySubscriber {
+        hits: counter.clone(),
+    }));
+
+    tokio::spawn(brain_loop(rx, registry, scheduler, event_bus.clone()));
+
+    flow.send(FlowMessage::Event("ping".into()));
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 


### PR DESCRIPTION
## Что сделано
- задачи теперь ставятся в `TaskScheduler`, а не выполняются сразу
- события `FlowMessage::Event` публикуются через `EventBus`
- тесты проверяют работу планировщика и шины событий

## Как проверить
- `cargo test --test brain_loop_test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf8c9d508323ad4797914cbf0f9a