### PR TITLE
fix: локальная передача задач без повторной отправки

### DIFF
--- a/tests/brain_loop_test.rs
+++ b/tests/brain_loop_test.rs
@@ -3,12 +3,18 @@ use std::sync::{
     Arc, RwLock,
 };
 
+/* neira:meta
+id: NEI-20240725-brain-loop-test
+intent: test
+summary: Проверяет локальную обработку задач и пустоту канала DataFlowController.
+*/
 use backend::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
 use backend::brain::brain_loop;
 use backend::cell_registry::CellRegistry;
 use backend::circulatory_system::{DataFlowController, FlowMessage};
 use backend::event_bus::{Event, EventBus, Subscriber};
 use backend::task_scheduler::TaskScheduler;
+use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::sync::CancellationToken;
 
 struct DummyCell {
@@ -53,8 +59,18 @@ async fn brain_loop_schedules_tasks() {
     let scheduler = Arc::new(RwLock::new(TaskScheduler::default()));
     let event_bus = EventBus::new();
 
+    let (tx_forward, rx_forward) = unbounded_channel();
+    let (monitor_tx, mut monitor_rx) = unbounded_channel();
+    tokio::spawn(async move {
+        let mut rx = rx;
+        while let Some(msg) = rx.recv().await {
+            let _ = monitor_tx.send(msg.clone());
+            let _ = tx_forward.send(msg);
+        }
+    });
+
     tokio::spawn(brain_loop(
-        rx,
+        rx_forward,
         registry.clone(),
         scheduler.clone(),
         event_bus,
@@ -66,10 +82,12 @@ async fn brain_loop_schedules_tasks() {
     });
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    monitor_rx.try_recv().unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-    assert_eq!(counter.load(Ordering::SeqCst), 0);
-    let next = scheduler.write().unwrap().next();
-    assert_eq!(next, Some(("dummy".into(), "".into())));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+    assert!(scheduler.write().unwrap().next().is_none());
+    assert!(monitor_rx.try_recv().is_err());
 }
 
 struct DummySubscriber {


### PR DESCRIPTION
## Summary
- задачи ставятся в локальную очередь без повторной отправки в DataFlowController
- brain_loop сразу передаёт задачу в клетку анализа
- тест убеждается, что канал DataFlowController остаётся пустым после обработки

## Testing
- `cargo test`
- `cargo test --test brain_loop_test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d492d34c832399bc47da34ab5315