### PR TITLE
fix: сохраняем результаты повторно поставленных задач

### DIFF
--- a/spinal_cord/src/brain.rs
+++ b/spinal_cord/src/brain.rs
@@ -8,16 +8,30 @@ id: NEI-20240709-brain-scheduler-eventbus
 intent: refactor
 summary: Задачи проходят через TaskScheduler, события публикуются в EventBus.
 */
+/* neira:meta
+id: NEI-20240725-brain-local-dispatch
+intent: bugfix
+summary: Задачи ставятся локально и сразу отправляются в клетку анализа без повторной переотправки.
+*/
+/* neira:meta
+id: NEI-20240731-brain-requeue-pipeline
+intent: fix
+summary: Перезапущенные задачи извлекаются из очереди и сохраняют результаты в MemoryCell.
+*/
 use std::any::Any;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::action::metrics_collector_cell::{MetricsCollectorCell, MetricsRecord};
 use crate::cell_registry::CellRegistry;
 use crate::circulatory_system::FlowMessage;
 use crate::event_bus::{Event, EventBus};
-use crate::task_scheduler::{Priority, Queue, TaskScheduler};
+use crate::memory_cell::MemoryCell;
+use crate::task_scheduler::TaskScheduler;
 
 /// Главный цикл мозга: потребляет сообщения из общего канала и реагирует на них
 pub async fn brain_loop(
@@ -25,6 +39,8 @@ pub async fn brain_loop(
     registry: Arc<CellRegistry>,
     scheduler: Arc<RwLock<TaskScheduler>>,
     event_bus: Arc<EventBus>,
+    memory: Arc<MemoryCell>,
+    metrics: Arc<MetricsCollectorCell>,
 ) {
     while let Some(msg) = df_rx.recv().await {
         match msg {
@@ -43,19 +59,37 @@ pub async fn brain_loop(
                 let event = BusEvent(ev);
                 event_bus.publish(&event);
             }
-            FlowMessage::Task { id, payload } => {
+            FlowMessage::Task { id, payload: _ } => {
                 info!(task_id = %id, "получена задача");
-                if registry.get_analysis_cell(&id).is_some() {
-                    scheduler.write().unwrap().enqueue(
-                        Queue::Standard,
-                        id.clone(),
-                        payload,
-                        Priority::Low,
-                        None,
-                        vec![id],
-                    );
+                let next_task = { scheduler.write().unwrap().next() };
+                if let Some((task_id, input)) = next_task {
+                    if let Some(cell) = registry.get_analysis_cell(&task_id) {
+                        let token = CancellationToken::new();
+                        let start = Instant::now();
+                        let cell_cloned = cell.clone();
+                        let input_cloned = input.clone();
+                        let token_cloned = token.clone();
+                        let result = tokio::task::spawn_blocking(move || {
+                            cell_cloned.analyze(&input_cloned, &token_cloned)
+                        })
+                        .await
+                        .unwrap();
+                        memory.push_metrics(&result);
+                        metrics.record(MetricsRecord {
+                            id: result.id.clone(),
+                            metrics: result.quality_metrics.clone(),
+                        });
+                        let elapsed = start.elapsed().as_millis();
+                        memory.update_time(&task_id, elapsed);
+                        let mem = memory.clone();
+                        let rid = task_id.clone();
+                        mem.recalc_priority_async(rid);
+                        memory.save_checkpoint(&task_id, &result);
+                    } else {
+                        warn!(task_id = %task_id, "клетка не найдена");
+                    }
                 } else {
-                    warn!(task_id = %id, "клетка не найдена");
+                    warn!(task_id = %id, "планировщик пуст");
                 }
             }
         }

--- a/spinal_cord/src/synapse_hub.rs
+++ b/spinal_cord/src/synapse_hub.rs
@@ -51,6 +51,11 @@ intent: refactor
 summary: Анализ выполняется локально без уведомления brain_loop.
 */
 /* neira:meta
+id: NEI-20240731-brain-loop-deps
+intent: fix
+summary: brain_loop получает ссылки на MemoryCell и MetricsCollector.
+*/
+/* neira:meta
 id: NEI-20250224-blocking-analyze
 intent: fix
 summary: Анализ выполняется в отдельном блокирующем пуле tokio::task.
@@ -260,6 +265,8 @@ impl SynapseHub {
             hub.registry.clone(),
             scheduler.clone(),
             event_bus.clone(),
+            hub.memory.clone(),
+            hub.metrics.clone(),
         ));
 
         // Spawn host metrics polling loop


### PR DESCRIPTION
## Summary
- brain_loop извлекает задачу из планировщика и сохраняет результат анализа в MemoryCell и метрики
- synapse_hub передаёт brain_loop ссылки на MemoryCell и MetricsCollector
- тест предварительно ставит задачу в очередь и проверяет пустоту канала DataFlowController

## Testing
- `cargo test --quiet`
- `cargo test --test brain_loop_test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b7d492d34c832399bc47da34ab5315