### PR TITLE
feat: учёт метрик brain_loop

### DIFF
--- a/spinal_cord/src/synapse_hub.rs
+++ b/spinal_cord/src/synapse_hub.rs
@@ -222,11 +222,17 @@ impl SynapseHub {
             .unwrap()
             .set_flow_controller(data_flow.clone());
 
+        /* neira:meta
+        id: NEI-20240821-brain-metrics-call
+        intent: refactor
+        summary: Передаёт MetricsCollectorCell в Brain для публикации метрик.
+        */
         let brain = Arc::new(Brain::new(
             df_rx,
             registry.clone(),
             scheduler.clone(),
             event_bus.clone(),
+            metrics.clone(),
         ));
 
         let hub = Self {


### PR DESCRIPTION
## Summary
- добавить MetricsCollectorCell и счётчики событий/задач в Brain
- передавать MetricsCollectorCell из SynapseHub
- покрыть метрики обработанных событий тестом

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f38d18508323b946d81eb2a610dc