### PR TITLE
feat: подключить BrainSubscriber к EventBus

### DIFF
--- a/spinal_cord/src/synapse_hub.rs
+++ b/spinal_cord/src/synapse_hub.rs
@@ -86,7 +86,7 @@ use tokio::time::{interval, sleep};
 use tokio_util::sync::CancellationToken;
 
 use crate::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
-use crate::brain::Brain;
+use crate::brain::{Brain, BrainSubscriber};
 use crate::cell_registry::CellRegistry;
 use crate::memory_cell::MemoryCell;
 use crate::queue_config::QueueConfig;
@@ -213,6 +213,12 @@ impl SynapseHub {
         let (data_flow, df_rx) = DataFlowController::new();
         let event_bus = EventBus::new();
         event_bus.attach_flow_controller(data_flow.clone());
+        /* neira:meta
+        id: NEI-20240930-brain-subscriber-hook
+        intent: feat
+        summary: Подписывает BrainSubscriber на события EventBus.
+        */
+        event_bus.subscribe(Arc::new(BrainSubscriber::new(data_flow.clone())));
         event_bus.subscribe(Arc::new(NervousSystemSubscriber));
         event_bus.subscribe(Arc::new(ImmuneSystemSubscriber));
 

--- a/spinal_cord/tests/brain_subscriber_test.rs
+++ b/spinal_cord/tests/brain_subscriber_test.rs
@@ -1,0 +1,34 @@
+/* neira:meta
+id: NEI-20240930-brain-subscriber-test
+intent: test
+summary: Проверяет, что BrainSubscriber пересылает события в DataFlowController.
+*/
+use std::any::Any;
+use std::sync::Arc;
+
+use backend::brain::BrainSubscriber;
+use backend::circulatory_system::{DataFlowController, FlowMessage};
+use backend::event_bus::{Event, EventBus};
+
+struct DummyEvent;
+
+impl Event for DummyEvent {
+    fn name(&self) -> &'static str {
+        "DummyEvent"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[tokio::test]
+async fn brain_subscriber_forwards_events() {
+    let (flow, mut rx) = DataFlowController::new();
+    let bus = EventBus::new();
+    bus.subscribe(Arc::new(BrainSubscriber::new(flow.clone())));
+
+    bus.publish_local(&DummyEvent);
+
+    let msg = rx.try_recv().expect("message forwarded");
+    assert!(matches!(msg, FlowMessage::Event(name) if name == "DummyEvent"));
+}


### PR DESCRIPTION
## Summary
- Реализован BrainSubscriber, пересылающий события в DataFlowController
- SynapseHub подписывает BrainSubscriber на EventBus
- Добавлен тест для BrainSubscriber

## Testing
- `cargo clippy --tests`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b80049f6e48323998034a411d15808