### PR TITLE
Типизация сообщений кровотока

### DIFF
--- a/docs/system/brain.md
+++ b/docs/system/brain.md
@@ -5,6 +5,11 @@ id: NEI-20240918-brain-doc
 intent: docs
 summary: Описана структура мозга и взаимодействие с DataFlow, EventBus и TaskScheduler.
 -->
+<!-- neira:meta
+id: NEI-20240514-brain-doc-example
+intent: docs
+summary: Добавлен пример отправки FlowEvent и TaskPayload через DataFlowController.
+-->
 
 ## Обзор
 Модуль `brain` объединяет ключевые органы Нейры и управляет их работой. Он
@@ -28,3 +33,20 @@ summary: Описана структура мозга и взаимодейст�
 
 Такой цикл позволяет мозгу распределять работу между клетками и удерживать
 общую координацию системы без тесной связности между модулями.
+
+## Пример
+
+```rust
+use backend::circulatory_system::{DataFlowController, FlowEvent, FlowMessage, TaskPayload};
+
+let (flow, mut rx) = DataFlowController::new();
+flow.send(FlowMessage::Event(FlowEvent { name: "ping".into() }));
+flow.send(FlowMessage::Task {
+    id: "dummy".into(),
+    payload: TaskPayload::Text("data".into()),
+});
+
+if let Some(message) = rx.blocking_recv() {
+    println!("{message:?}");
+}
+```

--- a/spinal_cord/src/circulatory_system.rs
+++ b/spinal_cord/src/circulatory_system.rs
@@ -3,16 +3,32 @@ id: NEI-20250226-dataflow-controller
 intent: code
 summary: Простая шина передачи данных между органами через mpsc.
 */
+/* neira:meta
+id: NEI-20240514-flowmessage-serde
+intent: refactor
+summary: FlowMessage использует типизированные события и payload задач, сериализуемые через serde.
+*/
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowEvent {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TaskPayload {
+    Text(String),
+}
+
 /// Сообщения, циркулирующие между органами
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FlowMessage {
     /// Событие из глобальной шины
-    Event(String),
+    Event(FlowEvent),
     /// Задача для конкретного органа
-    Task { id: String, payload: String },
+    Task { id: String, payload: TaskPayload },
 }
 
 /// Контроллер потоков данных между органами

--- a/spinal_cord/src/event_bus.rs
+++ b/spinal_cord/src/event_bus.rs
@@ -20,7 +20,12 @@ intent: refactor
 summary: |-
   Метод Event::name возвращает &str, позволяя событиям иметь динамические имена.
 */
-use crate::circulatory_system::{DataFlowController, FlowMessage};
+/* neira:meta
+id: NEI-20240514-event-bus-flowevent
+intent: refactor
+summary: publish отправляет типизированное FlowEvent вместо строки.
+*/
+use crate::circulatory_system::{DataFlowController, FlowEvent, FlowMessage};
 use std::any::Any;
 use std::sync::{Arc, RwLock};
 
@@ -65,7 +70,9 @@ impl EventBus {
     pub fn publish(&self, event: &dyn Event) {
         self.publish_local(event);
         if let Some(flow) = &*self.flow.read().unwrap() {
-            flow.send(FlowMessage::Event(event.name().to_string()));
+            flow.send(FlowMessage::Event(FlowEvent {
+                name: event.name().to_string(),
+            }));
         }
     }
 }

--- a/spinal_cord/src/task_scheduler.rs
+++ b/spinal_cord/src/task_scheduler.rs
@@ -14,13 +14,18 @@ id: NEI-20270310-local-enqueue
 intent: feature
 summary: Добавлен локальный enqueue без отправки в DataFlowController.
 */
+/* neira:meta
+id: NEI-20240514-task-scheduler-payload
+intent: refactor
+summary: enqueue отправляет TaskPayload вместо строки.
+*/
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::time::Instant;
 
 use crate::analysis_cell::QualityMetrics;
-use crate::circulatory_system::{DataFlowController, FlowMessage};
+use crate::circulatory_system::{DataFlowController, FlowMessage, TaskPayload};
 use crate::memory_cell::UsageStats;
 use std::sync::Arc;
 
@@ -145,7 +150,7 @@ impl TaskScheduler {
         if let Some(flow) = &self.flow {
             flow.send(FlowMessage::Task {
                 id: id_send,
-                payload: input_send,
+                payload: TaskPayload::Text(input_send),
             });
         }
     }

--- a/spinal_cord/tests/brain_flow_test.rs
+++ b/spinal_cord/tests/brain_flow_test.rs
@@ -3,13 +3,18 @@ id: NEI-20241002-brain-flow-test
 intent: test
 summary: Проверяет, что Brain обрабатывает FlowMessage::Task и FlowMessage::Event.
 */
+/* neira:meta
+id: NEI-20240514-brain-flow-test-typed
+intent: test
+summary: Использует FlowEvent и TaskPayload.
+*/
 use std::sync::{Arc, RwLock};
 
 use backend::action::metrics_collector_cell::MetricsCollectorCell;
 use backend::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
 use backend::brain::Brain;
 use backend::cell_registry::CellRegistry;
-use backend::circulatory_system::{DataFlowController, FlowMessage};
+use backend::circulatory_system::{DataFlowController, FlowEvent, FlowMessage, TaskPayload};
 use backend::event_bus::{Event, EventBus, Subscriber};
 use backend::task_scheduler::TaskScheduler;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -76,7 +81,7 @@ async fn brain_flow_test_receives_messages() {
 
     flow.send(FlowMessage::Task {
         id: "dummy".into(),
-        payload: "payload".into(),
+        payload: TaskPayload::Text("payload".into()),
     });
     let payload = timeout(Duration::from_secs(1), task_rx.recv())
         .await
@@ -84,7 +89,7 @@ async fn brain_flow_test_receives_messages() {
         .expect("task payload");
     assert_eq!(payload, "payload");
 
-    flow.send(FlowMessage::Event("test".into()));
+    flow.send(FlowMessage::Event(FlowEvent { name: "test".into() }));
     let ev = timeout(Duration::from_secs(1), event_rx.recv())
         .await
         .expect("event processed")

--- a/spinal_cord/tests/brain_subscriber_test.rs
+++ b/spinal_cord/tests/brain_subscriber_test.rs
@@ -3,11 +3,16 @@ id: NEI-20240930-brain-subscriber-test
 intent: test
 summary: Проверяет, что BrainSubscriber пересылает события в DataFlowController.
 */
+/* neira:meta
+id: NEI-20240514-brain-subscriber-test-flowevent
+intent: test
+summary: Проверяет имя в типизированном FlowEvent.
+*/
 use std::any::Any;
 use std::sync::Arc;
 
 use backend::brain::BrainSubscriber;
-use backend::circulatory_system::{DataFlowController, FlowMessage};
+use backend::circulatory_system::{DataFlowController, FlowEvent, FlowMessage};
 use backend::event_bus::{Event, EventBus};
 
 struct DummyEvent;
@@ -30,5 +35,5 @@ async fn brain_subscriber_forwards_events() {
     bus.publish_local(&DummyEvent);
 
     let msg = rx.try_recv().expect("message forwarded");
-    assert!(matches!(msg, FlowMessage::Event(name) if name == "DummyEvent"));
+    assert!(matches!(msg, FlowMessage::Event(ev) if ev.name == "DummyEvent"));
 }


### PR DESCRIPTION
## Изменения
- заменены строковые события и полезная нагрузка задач на структуры `FlowEvent` и `TaskPayload`
- обновлены EventBus, TaskScheduler и Brain под новые типы
- добавлен пример использования в документацию

## Тесты
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b80fb133a08323b06e7c0aa97cf560