### PR TITLE
feat: учёт сообщений в кровотоке и публикация метрик

### DIFF
--- a/docs/system/brain.md
+++ b/docs/system/brain.md
@@ -12,12 +12,14 @@ summary: Добавлен пример отправки FlowEvent и TaskPayload
 -->
 
 ## Обзор
+
 Модуль `brain` объединяет ключевые органы Нейры и управляет их работой. Он
 получает сообщения из `DataFlow`, превращая их либо в события, либо в задачи для
 обработки. Сам `brain` не хранит состояние диалогов, а служит маршрутизатором
 между подсистемами.
 
 ## Структура
+
 - **DataFlow Receiver** — входной канал, через который приходят сообщения
   `FlowMessage`.
 - **CellRegistry** — реестр «нейронов», то есть специализированных клеток
@@ -26,6 +28,7 @@ summary: Добавлен пример отправки FlowEvent и TaskPayload
 - **TaskScheduler** — очередь задач с приоритетами.
 
 ## Взаимодействие
+
 1. `brain` принимает `FlowMessage` из `DataFlow`.
 2. Если это событие, оно публикуется в `EventBus` без обратной пересылки.
 3. Если это задача, она ставится в `TaskScheduler`; затем нужная клетка
@@ -37,7 +40,9 @@ summary: Добавлен пример отправки FlowEvent и TaskPayload
 ## Пример
 
 ```rust
-use backend::circulatory_system::{DataFlowController, FlowEvent, FlowMessage, TaskPayload};
+use backend::circulatory_system::{
+    DataFlowController, FlowEvent, FlowMessage, TaskPayload,
+};
 
 let (flow, mut rx) = DataFlowController::new();
 flow.send(FlowMessage::Event(FlowEvent { name: "ping".into() }));
@@ -46,7 +51,13 @@ flow.send(FlowMessage::Task {
     payload: TaskPayload::Text("data".into()),
 });
 
-if let Some(message) = rx.blocking_recv() {
+if let Ok(message) = rx.try_recv() {
     println!("{message:?}");
 }
+
+<!-- neira:meta
+id: NEI-20241003-brain-doc-flowreceiver
+intent: docs
+summary: Пример обновлён для FlowReceiver и try_recv.
+-->
 ```

--- a/spinal_cord/src/circulatory_system.rs
+++ b/spinal_cord/src/circulatory_system.rs
@@ -9,8 +9,11 @@ intent: refactor
 summary: FlowMessage использует типизированные события и payload задач, сериализуемые через serde.
 */
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{
+    error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlowEvent {
@@ -31,20 +34,84 @@ pub enum FlowMessage {
     Task { id: String, payload: TaskPayload },
 }
 
+/// Обёртка над `UnboundedReceiver`, учитывающая полученные сообщения.
+pub struct FlowReceiver {
+    rx: UnboundedReceiver<FlowMessage>,
+    received: Arc<AtomicU64>,
+}
+
+impl FlowReceiver {
+    pub fn new(rx: UnboundedReceiver<FlowMessage>, counter: Arc<AtomicU64>) -> Self {
+        Self {
+            rx,
+            received: counter,
+        }
+    }
+
+    /// Получение сообщения с инкрементом счётчика.
+    pub async fn recv(&mut self) -> Option<FlowMessage> {
+        let msg = self.rx.recv().await;
+        if msg.is_some() {
+            self.received.fetch_add(1, Ordering::Relaxed);
+        }
+        msg
+    }
+
+    /// Неблокирующее получение сообщения.
+    pub fn try_recv(&mut self) -> Result<FlowMessage, TryRecvError> {
+        match self.rx.try_recv() {
+            Ok(msg) => {
+                self.received.fetch_add(1, Ordering::Relaxed);
+                Ok(msg)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
 /// Контроллер потоков данных между органами
 pub struct DataFlowController {
     sender: UnboundedSender<FlowMessage>,
+    sent: Arc<AtomicU64>,
+    received: Arc<AtomicU64>,
 }
 
 impl DataFlowController {
     /// Создаёт контроллер и возвращает его вместе с приёмником событий
-    pub fn new() -> (Arc<Self>, UnboundedReceiver<FlowMessage>) {
+    pub fn new() -> (Arc<Self>, FlowReceiver) {
         let (tx, rx) = unbounded_channel();
-        (Arc::new(Self { sender: tx }), rx)
+        let sent = Arc::new(AtomicU64::new(0));
+        let received = Arc::new(AtomicU64::new(0));
+        (
+            Arc::new(Self {
+                sender: tx,
+                sent: sent.clone(),
+                received: received.clone(),
+            }),
+            FlowReceiver::new(rx, received),
+        )
     }
 
     /// Отправка сообщения в общий канал
     pub fn send(&self, msg: FlowMessage) {
-        let _ = self.sender.send(msg);
+        if self.sender.send(msg).is_ok() {
+            self.sent.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Количество отправленных сообщений.
+    pub fn sent_count(&self) -> u64 {
+        self.sent.load(Ordering::Relaxed)
+    }
+
+    /// Количество полученных сообщений.
+    pub fn received_count(&self) -> u64 {
+        self.received.load(Ordering::Relaxed)
     }
 }
+
+/* neira:meta
+id: NEI-20241003-flow-counters
+intent: feat
+summary: Учёт отправленных и полученных сообщений через AtomicU64 и обёртку FlowReceiver.
+*/

--- a/spinal_cord/tests/brain_flow_test.rs
+++ b/spinal_cord/tests/brain_flow_test.rs
@@ -76,7 +76,14 @@ async fn brain_flow_test_receives_messages() {
 
     let (metrics, _rx_metrics) = MetricsCollectorCell::channel();
 
-    let brain = Arc::new(Brain::new(rx, registry, scheduler, event_bus, metrics));
+    let brain = Arc::new(Brain::new(
+        rx,
+        flow.clone(),
+        registry,
+        scheduler,
+        event_bus,
+        metrics,
+    ));
     brain.clone().spawn();
 
     flow.send(FlowMessage::Task {
@@ -89,10 +96,18 @@ async fn brain_flow_test_receives_messages() {
         .expect("task payload");
     assert_eq!(payload, "payload");
 
-    flow.send(FlowMessage::Event(FlowEvent { name: "test".into() }));
+    flow.send(FlowMessage::Event(FlowEvent {
+        name: "test".into(),
+    }));
     let ev = timeout(Duration::from_secs(1), event_rx.recv())
         .await
         .expect("event processed")
         .expect("event name");
     assert_eq!(ev, "test");
 }
+
+/* neira:meta
+id: NEI-20241003-brain-flow-test-update
+intent: chore
+summary: Обновлён тест под новый FlowReceiver и публикацию метрик кровотока.
+*/

--- a/spinal_cord/tests/brain_subscriber_test.rs
+++ b/spinal_cord/tests/brain_subscriber_test.rs
@@ -37,3 +37,9 @@ async fn brain_subscriber_forwards_events() {
     let msg = rx.try_recv().expect("message forwarded");
     assert!(matches!(msg, FlowMessage::Event(ev) if ev.name == "DummyEvent"));
 }
+
+/* neira:meta
+id: NEI-20241003-brain-subscriber-test-update
+intent: chore
+summary: Тест адаптирован к FlowReceiver с учётом новых счётчиков.
+*/


### PR DESCRIPTION
## Summary
- добавить счетчики отправленных и полученных сообщений в `DataFlowController`
- публиковать метрики из `Brain` и `SynapseHub`
- обновить тесты и документацию под новый `FlowReceiver`

## Testing
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_68b814f090c0832392cb72a2aa17b81f