### PR TITLE
Добавить analyze_parsed в brain_flow_test

### DIFF
--- a/spinal_cord/tests/brain_flow_test.rs
+++ b/spinal_cord/tests/brain_flow_test.rs
@@ -15,6 +15,7 @@ use backend::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
 use backend::brain::Brain;
 use backend::cell_registry::CellRegistry;
 use backend::circulatory_system::{DataFlowController, FlowEvent, FlowMessage, TaskPayload};
+use backend::digestive_pipeline::ParsedInput;
 use backend::event_bus::{Event, EventBus, Subscriber};
 use backend::task_scheduler::TaskScheduler;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -25,6 +26,11 @@ struct TestCell {
     tx: UnboundedSender<String>,
 }
 
+/* neira:meta
+id: NEI-20260531-brain-flow-parsed
+intent: test
+summary: TestCell обновлён для analyze_parsed.
+*/
 impl AnalysisCell for TestCell {
     fn id(&self) -> &str {
         "dummy"
@@ -40,6 +46,12 @@ impl AnalysisCell for TestCell {
     }
     fn confidence_threshold(&self) -> f32 {
         0.0
+    }
+    fn analyze_parsed(&self, input: &ParsedInput, _: &CancellationToken) -> AnalysisResult {
+        if let ParsedInput::Text(text) = input {
+            let _ = self.tx.send(text.clone());
+        }
+        AnalysisResult::new(self.id(), "ok", vec![])
     }
     fn analyze(&self, input: &str, _cancel: &CancellationToken) -> AnalysisResult {
         let _ = self.tx.send(input.to_string());


### PR DESCRIPTION
## Summary
- поддержка ParsedInput в brain_flow_test

## Testing
- `/root/.cargo/bin/cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8286e53d48323878ca83d1c1a6297