### PR TITLE
fix(spinal_cord): явный импорт ParsedInput из backend

### DIFF
--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -1,4 +1,4 @@
-use crate::digestive_pipeline::ParsedInput;
+use backend::digestive_pipeline::ParsedInput;
 use std::sync::{Arc, Mutex};
 
 /* neira:meta
@@ -30,6 +30,11 @@ summary: Обновлены пути к statics после переименов�
 id: NEI-20250215-immune-import-main
 intent: refactor
 summary: Добавлен импорт immune_system.
+*/
+/* neira:meta
+id: NEI-20260528-import-backend-parsed-input
+intent: refactor
+summary: Явное обращение к ParsedInput через crate backend.
 */
 use async_stream::stream;
 use axum::{


### PR DESCRIPTION
## Summary
- заменить локальный импорт ParsedInput на импорт из библиотеки backend
- добавить neira:meta блок для изменения

## Testing
- `cargo fmt -- spinal_cord/src/main.rs`
- `cargo clippy -p backend -- -D warnings`
- `cargo test -p backend` *(ошибка: package `backend` cannot be tested because it requires dev-dependencies and is not a member of the workspace)*
- `cargo test --manifest-path spinal_cord/Cargo.toml` *(ошибка: not all trait items implemented: missing analyze_parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68b82e231a808323b1e9604c9180e427