### PR TITLE
fix(spinal_cord): явный импорт ParsedInput из backend

### DIFF
--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -1,4 +1,4 @@
-use crate::digestive_pipeline::ParsedInput;
+use backend::digestive_pipeline::ParsedInput;
 use std::sync::{Arc, Mutex};
 
 /* neira:meta
@@ -30,6 +30,11 @@ summary: Обновлены пути к statics после переименов�
 id: NEI-20250215-immune-import-main
 intent: refactor
 summary: Добавлен импорт immune_system.
+*/
+/* neira:meta
+id: NEI-20260528-import-backend-parsed-input
+intent: refactor
+summary: Явное обращение к ParsedInput через crate backend.
 */
 use async_stream::stream;
 use axum::{

--- a/spinal_cord/tests/analysis_cell_metrics_test.rs
+++ b/spinal_cord/tests/analysis_cell_metrics_test.rs
@@ -1,10 +1,18 @@
+/* neira:meta
+id: NEI-20260531-120000-test-analyze-parsed
+intent: fix
+summary: |
+  Реализован analyze_parsed в тестовой клетке для успешной компиляции тестов.
+*/
+
 use backend::action::diagnostics_cell::DiagnosticsCell;
 use backend::action::metrics_collector_cell::MetricsCollectorCell;
 use backend::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
-use backend::synapse_hub::SynapseHub;
-use backend::config::Config;
-use backend::memory_cell::MemoryCell;
 use backend::cell_registry::CellRegistry;
+use backend::config::Config;
+use backend::digestive_pipeline::ParsedInput;
+use backend::memory_cell::MemoryCell;
+use backend::synapse_hub::SynapseHub;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
@@ -29,8 +37,11 @@ impl AnalysisCell for TestAnalysisCell {
     fn confidence_threshold(&self) -> f32 {
         0.0
     }
-    fn analyze(&self, input: &str, _cancel: &CancellationToken) -> AnalysisResult {
-        AnalysisResult::new(self.id(), input, vec![])
+    fn analyze_parsed(&self, input: &ParsedInput, _cancel: &CancellationToken) -> AnalysisResult {
+        match input {
+            ParsedInput::Json(value) => AnalysisResult::new(self.id(), value.to_string(), vec![]),
+            ParsedInput::Text(text) => AnalysisResult::new(self.id(), text, vec![]),
+        }
     }
     fn explain(&self) -> String {
         "test".into()


### PR DESCRIPTION
## Summary
- заменить локальный импорт ParsedInput на импорт из библиотеки backend
- реализовать analyze_parsed в тестовой клетке, чтобы сборка тестов прошла успешно

## Testing
- `cargo fmt -- spinal_cord/tests/analysis_cell_metrics_test.rs`
- `cargo clippy -p backend -- -D warnings`
- `cargo test --manifest-path spinal_cord/Cargo.toml`
- `cargo test --manifest-path spinal_cord/Cargo.toml --test analysis_cell_metrics_test`


------
https://chatgpt.com/codex/tasks/task_e_68b82e231a808323b1e9604c9180e427