### PR TITLE
chore: заменить serde-xml-rs на quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,16 +183,16 @@ dependencies = [
  "notify",
  "once_cell",
  "parking_lot",
+ "quick-xml",
  "regex",
  "reqwest",
  "semver",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "serde_yaml",
  "sha2",
  "sysinfo",
- "thiserror 2.0.16",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -1224,7 +1224,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 2.0.16",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -1298,8 +1298,8 @@ dependencies = [
  "jsonschema-valid",
  "metrics-exporter-prometheus",
  "once_cell",
+ "quick-xml",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -1600,6 +1600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,18 +1904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
-dependencies = [
- "log",
- "serde",
- "thiserror 1.0.69",
- "xml-rs",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,30 +2109,10 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.16"
 source = "git+https://github.com/dtolnay/thiserror?tag=2.0.16#40b58536cc4570d7e94575d1c90ebb07edf9aba0"
 dependencies = [
- "thiserror-impl 2.0.16",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2336,7 +2314,7 @@ version = "0.2.3"
 source = "git+https://github.com/tokio-rs/tracing?rev=f71cebe41e4c12735b1d19ca804428d4ff7d905d#f71cebe41e4c12735b1d19ca804428d4ff7d905d"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.16",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -2418,7 +2396,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror 2.0.16",
+ "thiserror",
  "utf-8",
 ]
 
@@ -2900,12 +2878,6 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@
 # id: NEI-20260601-yaml-xml-deps
 # intent: chore
 # summary: Добавлены зависимости serde_yaml и serde-xml-rs для поддержки YAML и XML.
+# neira:meta
+# id: NEI-20260710-quick-xml-switch
+# intent: chore
+# summary: Заменена зависимость serde-xml-rs на quick-xml с поддержкой сериализации.
 
 [package]
 name = "neira"
@@ -25,7 +29,7 @@ jsonschema-valid = "0.5.2"
 jsonschema = "0.33"
 once_cell = "1"
 serde_yaml = "0.9"
-serde-xml-rs = "0.6"
+quick-xml = { version = "0.31", features = ["serialize"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/spinal_cord/Cargo.toml
+++ b/spinal_cord/Cargo.toml
@@ -30,11 +30,15 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] } # di
 tracing-appender = { git = "https://github.com/tokio-rs/tracing", rev = "f71cebe41e4c12735b1d19ca804428d4ff7d905d", package = "tracing-appender" }
 
 serde_yaml = "0.9"
- # neira:meta
- # id: NEI-20260601-digestive-xml-dep
- # intent: chore
- # summary: Добавлена зависимость serde-xml-rs для разбора XML.
-serde-xml-rs = "0.6"
+# neira:meta
+# id: NEI-20260601-digestive-xml-dep
+# intent: chore
+# summary: Добавлена зависимость serde-xml-rs для разбора XML.
+# neira:meta
+# id: NEI-20260710-quick-xml-dep
+# intent: chore
+# summary: Заменена зависимость serde-xml-rs на quick-xml для разбора XML.
+quick-xml = { version = "0.31", features = ["serialize"] }
 notify = { version = "8.2", default-features = false }
 semver = "1"
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }

--- a/spinal_cord/src/digestive_pipeline.rs
+++ b/spinal_cord/src/digestive_pipeline.rs
@@ -10,11 +10,16 @@ intent: feature
 summary: |
   DigestivePipeline распознаёт YAML и XML, конвертируя их в ParsedInput::Json.
 */
+/* neira:meta
+id: NEI-20260710-quick-xml
+intent: chore
+summary: Использован quick-xml вместо serde_xml_rs для разбора XML.
+*/
 use crate::cell_template::load_schema_from;
 use jsonschema_valid::Config;
 use once_cell::sync::Lazy;
+use quick_xml::de::from_str as from_xml;
 use serde_json::Value;
-use serde_xml_rs::from_str as from_xml;
 use serde_yaml;
 use std::{env, path::PathBuf};
 use thiserror::Error;


### PR DESCRIPTION
## Summary
- убрать зависимость serde-xml-rs в пользу quick-xml с поддержкой сериализации
- DigestivePipeline теперь разбирает XML через quick-xml

## Testing
- `scripts/check-duplicates.sh`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8399bc534832396f31818fd7af813