### PR TITLE
feat: чтение схемы DigestivePipeline из конфигурации

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,11 @@ id: NEI-20260601-digestive-formats-doc
 intent: docs
 summary: Уточнены поддерживаемые форматы входа: JSON, YAML и XML.
 -->
+<!-- neira:meta
+id: NEI-20260725-digestive-config-doc
+intent: docs
+summary: Описан конфиг DigestivePipeline и переменная DIGESTIVE_CONFIG.
+-->
 
 # Neira Assistant Operating Guide — START HERE
 
@@ -68,6 +73,8 @@ Default Behaviors
 - Validate with cargo/test/lint where available.
 - Never delete data or secrets; never hard-code secrets.
 - DigestivePipeline принимает вход в форматах JSON, YAML и XML.
+- Путь к JSON Schema для DigestivePipeline задаётся в `spinal_cord/config/digestive.toml` (ключ `schema_path`),
+  можно переопределить переменной `DIGESTIVE_CONFIG`.
 
 Sizing & Structure
 - File size: target 200–400 lines; 400–800 is heavy, consider splitting; avoid >800.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -1938,6 +1939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,6 +2260,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2866,6 +2917,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/spinal_cord/Cargo.lock
+++ b/spinal_cord/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "notify",
  "once_cell",
  "parking_lot",
+ "quick-xml",
  "regex",
  "reqwest",
  "semver",
@@ -191,10 +192,12 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -225,9 +228,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "block-buffer"
@@ -1409,6 +1412,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1953,15 +1975,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2053,6 +2075,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2642,6 +2705,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/spinal_cord/Cargo.toml
+++ b/spinal_cord/Cargo.toml
@@ -39,6 +39,7 @@ serde_yaml = "0.9"
 # intent: chore
 # summary: Заменена зависимость serde-xml-rs на quick-xml для разбора XML.
 quick-xml = { version = "0.31", features = ["serialize"] }
+toml = "0.8"
 notify = { version = "8.2", default-features = false }
 semver = "1"
 metrics-exporter-prometheus = { version = "0.17", default-features = false, features = ["http-listener"] }

--- a/spinal_cord/config/digestive.toml
+++ b/spinal_cord/config/digestive.toml
@@ -1,0 +1,5 @@
+# neira:meta
+# id: NEI-20260725-digestive-config
+# intent: config
+# summary: Указан путь до JSON Schema для DigestivePipeline.
+schema_path = "../schemas/analysis-result.schema.json"

--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -1,4 +1,4 @@
-use backend::digestive_pipeline::ParsedInput;
+use backend::digestive_pipeline::{DigestivePipeline, ParsedInput};
 use std::sync::{Arc, Mutex};
 
 /* neira:meta
@@ -35,6 +35,11 @@ summary: Добавлен импорт immune_system.
 id: NEI-20260528-import-backend-parsed-input
 intent: refactor
 summary: Явное обращение к ParsedInput через crate backend.
+*/
+/* neira:meta
+id: NEI-20260725-digestive-init-main
+intent: chore
+summary: Конфигурация DigestivePipeline загружается при старте.
 */
 use async_stream::stream;
 use axum::{
@@ -1502,6 +1507,7 @@ async fn toggle_probe(
 #[tokio::main]
 async fn main() {
     let _ = dotenv();
+    DigestivePipeline::init().expect("digestive config");
     let cfg = Config::from_env();
     let logs_dir = "logs";
     let _ = std::fs::create_dir_all(logs_dir);

--- a/tests/digestive_pipeline_config_test.rs
+++ b/tests/digestive_pipeline_config_test.rs
@@ -1,0 +1,29 @@
+/* neira:meta
+id: NEI-20260725-digestive-config-test
+intent: test
+summary: Проверяет, что DigestivePipeline использует путь схемы из конфигурации.
+*/
+use backend::digestive_pipeline::{DigestivePipeline, PipelineError};
+use tempfile::tempdir;
+
+#[test]
+fn validates_with_overridden_schema() {
+    let dir = tempdir().expect("temp dir");
+    let schema = r#"{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["extra"]
+    }"#;
+    let schema_path = dir.path().join("schema.json");
+    std::fs::write(&schema_path, schema).expect("write schema");
+
+    let cfg_content = format!("schema_path = \"{}\"", schema_path.display());
+    let cfg_path = dir.path().join("digestive.toml");
+    std::fs::write(&cfg_path, cfg_content).expect("write config");
+    std::env::set_var("DIGESTIVE_CONFIG", &cfg_path);
+
+    DigestivePipeline::init().expect("init");
+    let raw = "{\"id\":1}";
+    let err = DigestivePipeline::ingest(raw).expect_err("should fail");
+    assert!(matches!(err, PipelineError::Validation(_)));
+}


### PR DESCRIPTION
## Summary
- вынес путь к JSON Schema DigestivePipeline в config/digestive.toml
- инициализируем DigestivePipeline при старте приложения
- тест смены схемы через конфиг

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b83f6133f4832386a51812fa23b8f1