### PR TITLE
feat: добавить кэш JSON Schema для DigestivePipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,15 @@ pre-commit install
 
 JSON‑схемы расположены в каталоге [schemas](schemas). При несовместимых изменениях повышайте версию: `1.0.0` → `1.1.0`.
 
+<!-- neira:meta
+id: NEI-20261015-digestive-cache-doc
+intent: docs
+summary: Описан кэш JSON Schema DigestivePipeline и способ сброса.
+-->
+### Кэш DigestivePipeline
+
+DigestivePipeline хранит загруженные JSON Schema в глобальном кэше в памяти процесса. Схема считывается с диска только один раз. Чтобы сбросить кэш, перезапустите приложение или вызовите `DigestivePipeline::reset_cache()`.
+
 ## Тесты
 
 Запуск тестов:

--- a/tests/digestive_pipeline_cache_test.rs
+++ b/tests/digestive_pipeline_cache_test.rs
@@ -1,0 +1,36 @@
+/* neira:meta
+id: NEI-20261015-digestive-cache-test
+intent: test
+summary: Проверяет, что DigestivePipeline читает JSON Schema с диска один раз.
+*/
+use backend::digestive_pipeline::DigestivePipeline;
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn caches_schema_after_first_read() {
+    DigestivePipeline::reset_cache();
+
+    let dir = tempdir().unwrap();
+    let schema_path = dir.path().join("schema.json");
+    fs::write(&schema_path, "{\"type\":\"object\"}").unwrap();
+
+    let cfg_path = dir.path().join("digestive.toml");
+    fs::write(
+        &cfg_path,
+        format!("schema_path = \"{}\"", schema_path.display()),
+    )
+    .unwrap();
+
+    std::env::set_var("DIGESTIVE_CONFIG", cfg_path.to_str().unwrap());
+    DigestivePipeline::init().unwrap();
+    DigestivePipeline::ingest("{\"foo\":\"bar\"}").unwrap();
+
+    fs::write(&schema_path, "not json").unwrap();
+    DigestivePipeline::ingest("{\"foo\":\"baz\"}").unwrap();
+
+    std::env::remove_var("DIGESTIVE_CONFIG");
+    DigestivePipeline::reset_cache();
+}


### PR DESCRIPTION
## Summary
- добавить глобальный in-memory кэш JSON Schema
- сбрасывать кэш через `DigestivePipeline::reset_cache`
- описать расположение и очистку кэша

## Testing
- `cargo clippy -p backend --no-deps`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b8524150208323a9f37abd68ee38ab