### PR TITLE
feat: сохранять распарсенный ввод в память

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ id: NEI-20260725-digestive-config-doc
 intent: docs
 summary: Описан конфиг DigestivePipeline и переменная DIGESTIVE_CONFIG.
 -->
+<!-- neira:meta
+id: NEI-20261124-memory-storage-doc
+intent: docs
+summary: Указано сохранение распарсенного входа в MemoryCell.
+-->
 
 # Neira Assistant Operating Guide — START HERE
 
@@ -75,6 +80,7 @@ Default Behaviors
 - DigestivePipeline принимает вход в форматах JSON, YAML и XML.
 - Путь к JSON Schema для DigestivePipeline задаётся в `spinal_cord/config/digestive.toml` (ключ `schema_path`),
   можно переопределить переменной `DIGESTIVE_CONFIG`.
+- После успешного парсинга вход сохраняется в MemoryCell через `store_parsed_input`.
 
 Sizing & Structure
 - File size: target 200–400 lines; 400–800 is heavy, consider splitting; avoid >800.

--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -41,6 +41,11 @@ id: NEI-20260725-digestive-init-main
 intent: chore
 summary: Конфигурация DigestivePipeline загружается при старте.
 */
+/* neira:meta
+id: NEI-20261124-digestive-memory-hook
+intent: chore
+summary: DigestivePipeline получает ссылку на MemoryCell для сохранения входов.
+*/
 use async_stream::stream;
 use axum::{
     extract::{
@@ -1539,6 +1544,7 @@ async fn main() {
     let _ = std::fs::create_dir_all(&templates_dir);
     let registry = Arc::new(CellRegistry::new(&templates_dir).expect("registry"));
     let memory = Arc::new(MemoryCell::new());
+    DigestivePipeline::set_memory(memory.clone());
     registry.register_init_cell(Arc::new(InitConfigCell::new()), &memory);
     let (metrics, metrics_rx) = MetricsCollectorCell::channel();
     let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsCell::new(metrics_rx, 5, metrics.clone());

--- a/tests/digestive_pipeline_memory_test.rs
+++ b/tests/digestive_pipeline_memory_test.rs
@@ -1,0 +1,22 @@
+/* neira:meta
+id: NEI-20261124-digestive-memory-test
+intent: test
+summary: Проверяет, что DigestivePipeline сохраняет распарсенный ввод в MemoryCell.
+*/
+use backend::digestive_pipeline::{DigestivePipeline, ParsedInput};
+use backend::memory_cell::MemoryCell;
+use serde_json::json;
+use std::sync::Arc;
+
+#[test]
+fn stores_parsed_input_in_memory() {
+    let memory = Arc::new(MemoryCell::new());
+    DigestivePipeline::set_memory(memory.clone());
+    let raw = r#"{"id":"1","result":"ok","metadata":{"schema":"s"}}"#;
+    let parsed = DigestivePipeline::ingest(raw).expect("parse");
+    assert_eq!(
+        parsed,
+        ParsedInput::Json(json!({"id":"1","result":"ok","metadata":{"schema":"s"}}))
+    );
+    assert_eq!(memory.parsed_inputs(), vec![parsed]);
+}


### PR DESCRIPTION
## Summary
- DigestivePipeline теперь передаёт ParsedInput в MemoryCell
- MemoryCell хранит историю распарсенных входов
- Добавлен тест на запись в память и обновлена документация

## Testing
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b8614707f083239496829d9157369f