### PR TITLE
docs: describe DigestivePipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ summary: Добавлен раздел о DataFlowController и связи ор�
 Так обеспечивается единая циркуляция данных: органы сообщают о событиях,
 мозг принимает решения и возвращает команды обратно в систему.
 
+<!-- neira:meta
+id: NEI-20270223-readme-digestive-overview
+intent: docs
+summary: Кратко описан DigestivePipeline и пример использования.
+-->
+
+### DigestivePipeline — нормализация входа
+
+`DigestivePipeline` принимает сырой текст в форматах JSON, YAML или XML,
+проверяет его по JSON Schema из `spinal_cord/config/digestive.toml`
+(переопределяется переменной `DIGESTIVE_CONFIG`) и сохраняет результат в
+`MemoryCell`. Использование:
+
+```rust
+use backend::digestive_pipeline::DigestivePipeline;
+
+DigestivePipeline::init().expect("digestive config");
+let parsed = DigestivePipeline::ingest(raw)?; // ParsedInput
+```
+
 Пример отключения мониторинга в `.env`:
 
 ```

--- a/docs/digestive_pipeline_flow.md
+++ b/docs/digestive_pipeline_flow.md
@@ -1,0 +1,18 @@
+<!-- neira:meta
+id: NEI-20270223-digestive-diagram
+intent: docs
+summary: Добавлена диаграмма потока данных DigestivePipeline.
+-->
+
+# Поток данных DigestivePipeline
+
+```mermaid
+flowchart LR
+    A[Raw input (JSON/YAML/XML)] --> B[DigestivePipeline]
+    B --> C[JSON Schema validation]
+    C --> D[ParsedInput]
+    D --> E[MemoryCell]
+```
+
+DigestivePipeline нормализует вход и сохраняет результат в память, что позволяет
+остальным органам работать с унифицированными данными.

--- a/spinal_cord/AGENTS.md
+++ b/spinal_cord/AGENTS.md
@@ -1,0 +1,25 @@
+<!-- neira:meta
+id: NEI-20270223-spinal-digestive-doc
+intent: docs
+summary: Добавлен раздел DigestivePipeline с форматами, конфигурацией и примерами.
+-->
+
+# Инструкции для spinal_cord
+
+## DigestivePipeline
+
+- **Поддерживаемые форматы**: JSON, YAML, XML — автоматически определяется по содержимому.
+- **Конфигурация**: `spinal_cord/config/digestive.toml` (ключ `schema_path`), переопределяется переменной `DIGESTIVE_CONFIG`.
+- **Пример**:
+
+```rust
+use backend::digestive_pipeline::DigestivePipeline;
+
+DigestivePipeline::init().expect("digestive config");
+let parsed = DigestivePipeline::ingest(raw)?; // ParsedInput
+```
+
+```toml
+# config/digestive.toml
+schema_path = "schemas/input.json"
+```


### PR DESCRIPTION
## Summary
- document DigestivePipeline formats, config and usage for spinal cord
- add DigestivePipeline overview to README and a flow diagram

## Testing
- `pre-commit run --files README.md spinal_cord/AGENTS.md docs/digestive_pipeline_flow.md`
- `npm test`
- `cargo test` *(fails: logs_validation_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b872d4a16c83238e02e0ae8dabe762