### PR TITLE
Добавлены фильтры токсичности перед TriggerDetector

### DIFF
--- a/spinal_cord/src/trigger_detector.rs
+++ b/spinal_cord/src/trigger_detector.rs
@@ -4,6 +4,11 @@ intent: docs
 summary: |
   Выявляет ключевые слова и запускает микрорефлексы.
 */
+/* neira:meta
+id: NEI-20270405-trigger-detector-lowercase
+intent: refactor
+summary: Убрана дублирующая проверка регистра в detect_text.
+*/
 
 use crate::digestive_pipeline::{DigestivePipeline, ParsedInput};
 use std::sync::RwLock;
@@ -38,7 +43,7 @@ impl Default for TriggerDetector {
 
 impl TriggerDetector {
     pub fn add_keyword(&self, keyword: String) {
-        self.keywords.write().unwrap().push(keyword);
+        self.keywords.write().unwrap().push(keyword.to_lowercase());
     }
 
     pub fn add_micro_reflex<F>(&self, pattern: impl Into<String>, action: F)
@@ -46,7 +51,7 @@ impl TriggerDetector {
         F: Fn() + Send + Sync + 'static,
     {
         self.micro_reflexes.write().unwrap().push(MicroReflex {
-            pattern: pattern.into(),
+            pattern: pattern.into().to_lowercase(),
             action: Box::new(action),
         });
     }
@@ -60,21 +65,22 @@ impl TriggerDetector {
         let text = match DigestivePipeline::ingest(raw) {
             Ok(ParsedInput::Json(v)) => v.to_string(),
             Ok(ParsedInput::Text(t)) => t,
-            Err(_) => raw.to_string(),
+            Err(_) => DigestivePipeline::sanitize(raw),
         };
         self.detect_text(&text)
     }
 
     fn detect_text(&self, text: &str) -> Vec<String> {
+        let lower = text.to_lowercase();
         let kws = self.keywords.read().unwrap();
         let found: Vec<String> = kws
             .iter()
-            .filter(|k| text.to_lowercase().contains(&k.to_lowercase()))
+            .filter(|k| lower.contains(k.as_str()))
             .cloned()
             .collect();
         let reflexes = self.micro_reflexes.read().unwrap();
         for reflex in reflexes.iter() {
-            if text.to_lowercase().contains(&reflex.pattern.to_lowercase()) {
+            if lower.contains(&reflex.pattern) {
                 (reflex.action)();
             }
         }

--- a/tests/trigger_detector_toxicity_test.rs
+++ b/tests/trigger_detector_toxicity_test.rs
@@ -1,0 +1,21 @@
+/* neira:meta
+id: NEI-20270405-trigger-toxicity-test
+intent: test
+summary: Проверяет фильтрацию токсичных слов перед TriggerDetector.
+*/
+use backend::trigger_detector::TriggerDetector;
+
+#[test]
+fn censors_toxic_words_before_detection() {
+    let detector = TriggerDetector::default();
+    detector.add_keyword("идиот".into());
+    let found = detector.detect("Ты ИДИОТ");
+    assert!(found.is_empty());
+}
+
+#[test]
+fn detects_keywords_case_insensitive() {
+    let detector = TriggerDetector::default();
+    let found = detector.detect("RUST делает системы живыми");
+    assert_eq!(found, vec!["rust".to_string()]);
+}


### PR DESCRIPTION
## Summary
- фильтруем токсичные слова в DigestivePipeline
- TriggerDetector использует очищенный ввод и избегает лишней проверки регистра
- тесты на фильтрацию и регистронезависимое совпадение

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b87ebe7c408323b127406061295b85