### PR TITLE
feat: add async action engine with permission checks

### DIFF
--- a/spinal_cord/src/action_cell.rs
+++ b/spinal_cord/src/action_cell.rs
@@ -4,14 +4,36 @@ intent: docs
 summary: |
   Базовый интерфейс клеток действий и стандартная реализация предзагрузки.
 */
+/* neira:meta
+id: NEI-20270520-action-cell-engine
+intent: feature
+summary: |
+  Добавлена поддержка ActionEngine для выполнения команд клетками.
+*/
 
 use std::sync::Arc;
 
+use crate::action_engine::{ActionCommand, ActionEngine, ActionError};
 use crate::memory_cell::MemoryCell;
+use async_trait::async_trait;
 
+#[async_trait]
 pub trait ActionCell: Send + Sync {
     fn id(&self) -> &str;
     fn preload(&self, triggers: &[String], memory: &Arc<MemoryCell>);
+
+    fn command(&self) -> Option<ActionCommand> {
+        None
+    }
+
+    async fn execute(&self, engine: &ActionEngine) -> Result<Option<String>, ActionError> {
+        if let Some(cmd) = self.command() {
+            let res = engine.execute(cmd).await?;
+            Ok(Some(res))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 pub struct PreloadAction;

--- a/spinal_cord/src/action_engine.rs
+++ b/spinal_cord/src/action_engine.rs
@@ -1,0 +1,52 @@
+/* neira:meta
+id: NEI-20270520-action-engine
+intent: feature
+summary: |
+  Асинхронный движок для файловых, сетевых и системных операций с проверкой прав.
+*/
+use crate::security::{check_operation, Operation, SecurityError};
+use reqwest;
+use thiserror::Error;
+use tokio::{fs, process::Command};
+
+#[derive(Debug, Clone)]
+pub enum ActionCommand {
+    ReadFile { path: String },
+    HttpGet { url: String },
+    RunCommand { program: String, args: Vec<String> },
+}
+
+pub struct ActionEngine;
+
+impl ActionEngine {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn execute(&self, cmd: ActionCommand) -> Result<String, ActionError> {
+        let op = match &cmd {
+            ActionCommand::ReadFile { path } => Operation::FileRead(path.clone()),
+            ActionCommand::HttpGet { url } => Operation::NetworkRequest(url.clone()),
+            ActionCommand::RunCommand { program, .. } => Operation::SystemCommand(program.clone()),
+        };
+        check_operation(&op)?;
+        match cmd {
+            ActionCommand::ReadFile { path } => Ok(fs::read_to_string(path).await?),
+            ActionCommand::HttpGet { url } => Ok(reqwest::get(&url).await?.text().await?),
+            ActionCommand::RunCommand { program, args } => {
+                let output = Command::new(program).args(args).output().await?;
+                Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+            }
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ActionError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Network(#[from] reqwest::Error),
+    #[error(transparent)]
+    Security(#[from] SecurityError),
+}

--- a/spinal_cord/src/lib.rs
+++ b/spinal_cord/src/lib.rs
@@ -6,6 +6,12 @@ summary: Экспортирован модуль immune_system.
 #![cfg_attr(test, allow(clippy::type_complexity))]
 pub mod action;
 pub mod action_cell;
+/* neira:meta
+id: NEI-20270520-lib-action-engine-export
+intent: code
+summary: Экспортирован модуль action_engine.
+*/
+pub mod action_engine;
 pub mod analysis_cell;
 pub mod cell_registry;
 pub mod cell_template;
@@ -38,8 +44,8 @@ id: NEI-20261005-time-metrics-export
 intent: code
 summary: Экспортирован модуль time_metrics.
 */
-pub mod time_metrics;
 pub mod nervous_system;
+pub mod time_metrics;
 /* neira:meta
 id: NEI-20250226-circulatory-export
 intent: code

--- a/spinal_cord/src/security/mod.rs
+++ b/spinal_cord/src/security/mod.rs
@@ -1,4 +1,33 @@
-pub mod integrity_checker_cell;
+/* neira:meta
+id: NEI-20270520-security-perms
+intent: security
+summary: |
+  Добавлен контроль прав для файловых, сетевых и системных операций.
+*/
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub enum Operation {
+    FileRead(String),
+    NetworkRequest(String),
+    SystemCommand(String),
+}
+
+#[derive(Debug, Error)]
+pub enum SecurityError {
+    #[error("operation not permitted: {0:?}")]
+    PermissionDenied(Operation),
+}
+
+pub fn check_operation(op: &Operation) -> Result<(), SecurityError> {
+    if matches!(op, Operation::SystemCommand(_)) && std::env::var("NEIRA_ALLOW_SYSTEM").is_err() {
+        Err(SecurityError::PermissionDenied(op.clone()))
+    } else {
+        Ok(())
+    }
+}
+
 pub mod init_config_cell;
+pub mod integrity_checker_cell;
 pub mod quarantine_cell;
 pub mod safe_mode_controller;

--- a/spinal_cord/tests/action_engine_test.rs
+++ b/spinal_cord/tests/action_engine_test.rs
@@ -1,0 +1,47 @@
+/* neira:meta
+id: NEI-20270520-action-engine-test
+intent: test
+summary: Проверяет работу ActionEngine и контроль прав.
+*/
+use backend::action_engine::{ActionCommand, ActionEngine, ActionError};
+use serial_test::serial;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+#[serial]
+async fn file_read_executes() {
+    let mut tmp = NamedTempFile::new().unwrap();
+    writeln!(tmp, "hi").unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let engine = ActionEngine::new();
+    let cmd = ActionCommand::ReadFile { path };
+    let res = engine.execute(cmd).await.unwrap();
+    assert!(res.contains("hi"));
+}
+
+#[tokio::test]
+#[serial]
+async fn system_command_denied_without_env() {
+    std::env::remove_var("NEIRA_ALLOW_SYSTEM");
+    let engine = ActionEngine::new();
+    let cmd = ActionCommand::RunCommand {
+        program: "echo".into(),
+        args: vec!["ok".into()],
+    };
+    let err = engine.execute(cmd).await.unwrap_err();
+    matches!(err, ActionError::Security(_));
+}
+
+#[tokio::test]
+#[serial]
+async fn system_command_allowed_with_env() {
+    std::env::set_var("NEIRA_ALLOW_SYSTEM", "1");
+    let engine = ActionEngine::new();
+    let cmd = ActionCommand::RunCommand {
+        program: "echo".into(),
+        args: vec!["ok".into()],
+    };
+    let res = engine.execute(cmd).await.unwrap();
+    assert_eq!(res, "ok");
+}


### PR DESCRIPTION
## Summary
- добавить модуль `ActionEngine` с файловыми, сетевыми и системными командами
- клетки действий теперь могут исполнять команды через `ActionEngine`
- система безопасности проверяет права перед каждой операцией

## Testing
- `cargo test`
- `cargo test --test action_engine_test`


------
https://chatgpt.com/codex/tasks/task_e_68b895d357f88323bf53c3127e53e223