### PR TITLE
feat: кэширование чтения файлов в ActionEngine

### DIFF
--- a/spinal_cord/tests/action_engine_test.rs
+++ b/spinal_cord/tests/action_engine_test.rs
@@ -45,3 +45,17 @@ async fn system_command_allowed_with_env() {
     let res = engine.execute(cmd).await.unwrap();
     assert_eq!(res, "ok");
 }
+
+#[tokio::test]
+#[serial]
+async fn file_read_uses_cache() {
+    let mut tmp = NamedTempFile::new().unwrap();
+    write!(tmp, "cached").unwrap();
+    let path = tmp.path().to_string_lossy().to_string();
+    let engine = ActionEngine::new();
+    let cmd = ActionCommand::ReadFile { path: path.clone() };
+    let first = engine.execute(cmd.clone()).await.unwrap();
+    tmp.close().unwrap();
+    let second = engine.execute(cmd).await.unwrap();
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary
- добавить FileCache для повторного чтения файлов
- использовать FileCache в ActionEngine
- проверить кеширование чтений

## Testing
- `cargo clippy -p backend -- -D warnings`
- `cargo test --manifest-path spinal_cord/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68b8efc163108323b80b77e170eee5ee