### PR TITLE
fix: расширена проверка дубликатов crate

### DIFF
--- a/scripts/check-duplicates.sh
+++ b/scripts/check-duplicates.sh
@@ -9,7 +9,10 @@ neira:meta
 set -euo pipefail
 
 # Detect duplicate crate versions in Cargo dependencies.
-output=$(cargo tree -d)
+output=$(cargo tree -d --target all 2>/dev/null)
+if [ "$output" = "nothing to print" ]; then
+  output=""
+fi
 if [ -n "$output" ]; then
   echo "$output"
   echo "Duplicate crate versions detected. Ensure a single version per crate." >&2


### PR DESCRIPTION
## Summary
- расширен вызов `cargo tree` на все `targets`
- игнорируется сообщение "nothing to print" при отсутствии дублей

## Testing
- `cargo test --quiet`
- `bash scripts/check-duplicates.sh | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68b903762da48323ab331476c06f1e01