### PR TITLE
ci: добавить формат cargo metadata в workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ name: CI
 # intent: ci
 # summary: Обновлены actions для вывода через $GITHUB_OUTPUT.
 
+# neira:meta
+# id: NEI-20270407-ci-cargo-metadata-format
+# intent: ci
+# summary: Добавлен параметр --format-version=1 для вызова cargo metadata.
+
 on:
   push:
     branches: [ main ]
@@ -38,7 +43,7 @@ jobs:
           node-version: 20
       - uses: dtolnay/rust-toolchain@stable
       - name: Validate Cargo files
-        run: cargo metadata --locked
+        run: cargo metadata --locked --format-version 1
       - name: Install dependencies
         run: |
           npm ci


### PR DESCRIPTION
## Summary
- явно задать `--format-version 1` для шага `cargo metadata` в CI

## Testing
- `npm run lint`
- `npm test`
- `cargo metadata --locked --format-version 1`
- `scripts/check-duplicates.sh` *(падает: Duplicate crate versions detected)*
- `cargo test` *(прервано из-за длительной компиляции)*
- `cargo test --manifest-path spinal_cord/Cargo.toml` *(прервано из-за длительной загрузки зависимостей)*

------
https://chatgpt.com/codex/tasks/task_e_68b9070dd0408323a9c1bc9ac6179df3