### PR TITLE
ci: запуск cargo-deny только в Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,12 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: ./scripts/check-duplicates.ps1
+      # neira:meta
+      # id: NEI-20250905-ci-cargo-deny-linux
+      # intent: ci
+      # summary: Шаг cargo-deny (bans) выполняется только на Linux.
       - name: Cargo deny (bans)
+        if: matrix.os == 'ubuntu-latest'
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check bans


### PR DESCRIPTION
## Summary
- ограничили запуск шага Cargo deny (bans) в job `dependency-hygiene` только средой Ubuntu

## Testing
- `cargo test`
- `npm test`
- `npm test --prefix sensory_organs`


------
https://chatgpt.com/codex/tasks/task_e_68b98fec2aa8832385e3d42ef19cffdb