### PR TITLE
chore: фиксируем версию yaml 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "ts-jest": "^29.1.1",
                 "typescript": "^5.4.0",
                 "typescript-eslint": "^8.41.0",
-                "yaml": "^2.8.0"
+                "yaml": "2.8.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -5884,10 +5884,11 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -7639,7 +7640,8 @@
                     }
                 },
                 "p-limit": {
-                    "version": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
@@ -7652,7 +7654,7 @@
                     "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^3.0.2"
+                        "p-limit": "^2.3.0"
                     }
                 }
             }
@@ -8220,11 +8222,12 @@
             "requires": {
                 "execa": "^5.0.0",
                 "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0"
+                "p-limit": "^2.3.0"
             },
             "dependencies": {
                 "p-limit": {
-                    "version": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
@@ -8254,7 +8257,7 @@
                 "jest-runtime": "^29.7.0",
                 "jest-snapshot": "^29.7.0",
                 "jest-util": "^29.7.0",
-                "p-limit": "^3.1.0",
+                "p-limit": "^2.3.0",
                 "pretty-format": "^29.7.0",
                 "pure-rand": "^6.0.0",
                 "slash": "^3.0.0",
@@ -8262,7 +8265,8 @@
             },
             "dependencies": {
                 "p-limit": {
-                    "version": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
@@ -8509,12 +8513,13 @@
                 "jest-util": "^29.7.0",
                 "jest-watcher": "^29.7.0",
                 "jest-worker": "^29.7.0",
-                "p-limit": "^3.1.0",
+                "p-limit": "^2.3.0",
                 "source-map-support": "0.5.13"
             },
             "dependencies": {
                 "p-limit": {
-                    "version": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
                     "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
@@ -8774,7 +8779,7 @@
                 "nano-spawn": "^1.0.2",
                 "pidtree": "^0.6.0",
                 "string-argv": "^0.3.2",
-                "yaml": "^2.8.1"
+                "yaml": "2.8.0"
             },
             "dependencies": {
                 "chalk": {
@@ -9142,7 +9147,7 @@
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "requires": {
-                "p-limit": "^2.2.0"
+                "p-limit": "^2.3.0"
             },
             "dependencies": {
                 "p-limit": {
@@ -9785,9 +9790,9 @@
             "dev": true
         },
         "yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
                             "ts-jest":  "^29.1.1",
                             "typescript":  "^5.4.0",
                             "typescript-eslint":  "^8.41.0",
-                            "yaml": "^2.8.0"
+                            "yaml": "2.8.0"
                         },
     "overrides":  {
                       "p-limit":  "^2.3.0",


### PR DESCRIPTION
## Summary
- закреплена версия `yaml` 2.8.0 и обновлён `package-lock.json`

## Testing
- `npm ci`
- `npm test`
- `npm ci --prefix sensory_organs`
- `npm test --prefix sensory_organs`


------
https://chatgpt.com/codex/tasks/task_e_68b99655ef9c8323a816a3702a70dde6