### PR TITLE
chore: исправлены ошибки ESLint в скриптах

### DIFF
--- a/scripts/check-commit-msg.mjs
+++ b/scripts/check-commit-msg.mjs
@@ -6,23 +6,16 @@ summary: |
   Подключается через .husky/commit-msg.
 */
 
-import { readFileSync } from 'node:fs';
+/* neira:meta
+id: NEI-20250904-134900-commit-msg-lint
+intent: chore
+summary: Исправлены ошибки lint: удалён неиспользуемый массив, объявлена среда Node.
+*/
 
-// Basic Conventional Commits pattern
-// type(scope?): subject
-const TYPES = [
-  'feat',
-  'fix',
-  'docs',
-  'style',
-  'refactor',
-  'perf',
-  'test',
-  'chore',
-  'ci',
-  'build',
-  'revert',
-];
+/* eslint-env node */
+/* global console, process */
+
+import { readFileSync } from 'node:fs';
 
 const TYPE_RE = /^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\([^)]+\))?(!)?:\s.+$/;
 

--- a/scripts/gen-neira-id.mjs
+++ b/scripts/gen-neira-id.mjs
@@ -4,6 +4,15 @@ intent: chore
 summary: Добавлен генератор идентификаторов NEI-YYYYMMDD-HHMMSS-<slug> (UTC).
 */
 
+/* neira:meta
+id: NEI-20250904-134900-gen-id-lint
+intent: chore
+summary: Объявлена среда Node для корректной работы ESLint.
+*/
+
+/* eslint-env node */
+/* global console, process */
+
 import crypto from 'node:crypto';
 
 function tsUTC(date = new Date()) {


### PR DESCRIPTION
## Summary
- объявлены глобалы console и process для Node-скриптов
- удалён неиспользуемый код и обработаны пустые catch-блоки
- скорректированы строки примеров meta-блоков

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b998621a5c8323a75c814e5deed7ef