### PR TITLE
chore: объявление Node окружения в gen-neira-id

### DIFF
--- a/scripts/gen-neira-id.mjs
+++ b/scripts/gen-neira-id.mjs
@@ -3,6 +3,9 @@ id: NEI-20250904-121200-gen-id
 intent: chore
 summary: Добавлен генератор идентификаторов NEI-YYYYMMDD-HHMMSS-<slug> (UTC).
 */
+/* eslint-env node */
+
+/* global console, process */
 
 import crypto from 'node:crypto';
 


### PR DESCRIPTION
## Summary
- добавить eslint-env node и объявить глобальные console и process в scripts/gen-neira-id.mjs

## Testing
- `npm run lint` *(возвращает ошибки в scripts/normalize-meta.mjs)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9f0d9d483238072d106e2f1eb01