### PR TITLE
feat: log and query event bus events

### DIFF
--- a/spinal_cord/src/event_bus.rs
+++ b/spinal_cord/src/event_bus.rs
@@ -26,6 +26,12 @@ intent: refactor
 summary: publish отправляет типизированное FlowEvent вместо строки.
 */
 use crate::circulatory_system::{DataFlowController, FlowEvent, FlowMessage};
+/* neira:meta
+id: NEI-20270310-120100-event-bus-log-hook
+intent: feature
+summary: publish пишет событие в EventLog.
+*/
+use crate::event_log;
 use std::any::Any;
 use std::sync::{Arc, RwLock};
 
@@ -74,6 +80,7 @@ impl EventBus {
                 name: event.name().to_string(),
             }));
         }
+        event_log::append(event);
     }
 }
 

--- a/spinal_cord/src/event_log.rs
+++ b/spinal_cord/src/event_log.rs
@@ -1,0 +1,90 @@
+/* neira:meta
+id: NEI-20270310-120000-event-log
+intent: feature
+summary: |-
+  Запись событий EventBus в файл NDJSON и выборка по диапазону.
+*/
+use crate::event_bus::Event;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LoggedEvent {
+    pub id: u64,
+    pub ts_ms: i64,
+    pub name: String,
+}
+
+fn log_path() -> PathBuf {
+    std::env::var("EVENT_LOG_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("logs/events.ndjson"))
+}
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn append(event: &dyn Event) {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
+    let entry = LoggedEvent {
+        id,
+        ts_ms: Utc::now().timestamp_millis(),
+        name: event.name().to_string(),
+    };
+    if let Ok(line) = serde_json::to_string(&entry) {
+        let path = log_path();
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(file, "{}", line);
+        }
+    }
+}
+
+pub fn query(
+    start_id: Option<u64>,
+    end_id: Option<u64>,
+    start_ts_ms: Option<i64>,
+    end_ts_ms: Option<i64>,
+) -> Vec<LoggedEvent> {
+    let path = log_path();
+    let Ok(data) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    data.lines()
+        .filter_map(|ln| serde_json::from_str::<LoggedEvent>(ln).ok())
+        .filter(|ev| {
+            if let Some(s) = start_id {
+                if ev.id < s {
+                    return false;
+                }
+            }
+            if let Some(e) = end_id {
+                if ev.id > e {
+                    return false;
+                }
+            }
+            if let Some(s) = start_ts_ms {
+                if ev.ts_ms < s {
+                    return false;
+                }
+            }
+            if let Some(e) = end_ts_ms {
+                if ev.ts_ms > e {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect()
+}
+
+pub fn reset() {
+    COUNTER.store(0, Ordering::SeqCst);
+    let path = log_path();
+    let _ = fs::remove_file(path);
+}

--- a/spinal_cord/src/lib.rs
+++ b/spinal_cord/src/lib.rs
@@ -68,6 +68,12 @@ pub static GLOBAL_HUB: OnceLock<RwLock<Option<Arc<SynapseHub>>>> = OnceLock::new
 pub mod factory;
 pub mod organ_builder;
 pub mod policy;
+/* neira:meta
+id: NEI-20270310-120200-event-log-export
+intent: code
+summary: Экспортирован модуль event_log.
+*/
+pub mod event_log;
 
 /* neira:meta
 id: NEI-20240513-lib-test-allow

--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -58,6 +58,7 @@ use axum::{
     Json, Router,
 };
 use backend::context::context_storage::set_runtime_mask_config;
+use backend::event_log;
 use backend::hearing;
 #[allow(unused_imports)]
 use backend::immune_system;
@@ -70,6 +71,8 @@ use dotenvy::dotenv;
 use futures_core::stream::Stream;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use regex::Regex;
+use reqwest::header::LAST_MODIFIED;
+use reqwest::Client;
 use std::convert::Infallible;
 use std::fs;
 use std::io::{Cursor, Write};
@@ -78,8 +81,6 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tracing::error;
-use reqwest::header::LAST_MODIFIED;
-use reqwest::Client;
 use zip::ZipArchive;
 
 use backend::action::chat_cell::EchoChatCell;
@@ -1547,7 +1548,9 @@ async fn sync_schemas() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|v| v.to_str().ok())
         .and_then(|s| chrono::DateTime::parse_from_rfc2822(s).ok())
         .map(|dt| dt.timestamp());
-    let local_ts = fs::read_to_string(&meta).ok().and_then(|s| s.trim().parse::<i64>().ok());
+    let local_ts = fs::read_to_string(&meta)
+        .ok()
+        .and_then(|s| s.trim().parse::<i64>().ok());
     let need = match (remote_ts, local_ts) {
         (Some(r), Some(l)) => r > l,
         _ => true,
@@ -2317,6 +2320,23 @@ async fn main() {
         Ok(Json(serde_json::json!({"cancelled": ok})))
     }
     app = app.route("/api/neira/analysis/cancel", post(analysis_cancel));
+
+    /* neira:meta
+    id: NEI-20270310-120300-events-endpoint
+    intent: feature
+    summary: REST-ручка для чтения EventLog.
+    */
+    async fn events_get(
+        axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
+    ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
+        let start_id = q.get("start_id").and_then(|v| v.parse::<u64>().ok());
+        let end_id = q.get("end_id").and_then(|v| v.parse::<u64>().ok());
+        let start_ts_ms = q.get("start_ts_ms").and_then(|v| v.parse::<i64>().ok());
+        let end_ts_ms = q.get("end_ts_ms").and_then(|v| v.parse::<i64>().ok());
+        let events = event_log::query(start_id, end_id, start_ts_ms, end_ts_ms);
+        Ok(Json(serde_json::json!({"events": events})))
+    }
+    app = app.route("/api/neira/events", get(events_get));
 
     // Logs tail endpoint with filters: /api/neira/logs/tail?lines=&level=&since_ts_ms=
     async fn logs_tail(

--- a/spinal_cord/tests/event_log_test.rs
+++ b/spinal_cord/tests/event_log_test.rs
@@ -1,0 +1,45 @@
+/* neira:meta
+id: NEI-20270310-120400-event-log-tests
+intent: chore
+summary: Проверка записи и выборки событий из EventLog.
+*/
+use backend::event_bus::{EventBus, OrganBuilt};
+use backend::event_log;
+use serial_test::serial;
+use std::env;
+use std::thread::sleep;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn publish_and_query_by_id() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("events.ndjson");
+    env::set_var("EVENT_LOG_FILE", &file);
+    event_log::reset();
+    let bus = EventBus::new();
+    bus.publish(&OrganBuilt { id: "one".into() });
+    bus.publish(&OrganBuilt { id: "two".into() });
+    let events = event_log::query(Some(2), Some(2), None, None);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].name, "OrganBuilt");
+    assert_eq!(events[0].id, 2);
+}
+
+#[test]
+#[serial]
+fn query_by_time_range() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("events.ndjson");
+    env::set_var("EVENT_LOG_FILE", &file);
+    event_log::reset();
+    let bus = EventBus::new();
+    bus.publish(&OrganBuilt { id: "a".into() });
+    sleep(Duration::from_millis(2));
+    let ts = chrono::Utc::now().timestamp_millis();
+    bus.publish(&OrganBuilt { id: "b".into() });
+    let events = event_log::query(None, None, Some(ts), None);
+    assert_eq!(events.len(), 1);
+    assert!(events[0].ts_ms >= ts);
+}


### PR DESCRIPTION
## Summary
- log every EventBus event into append-only `logs/events.ndjson`
- expose `GET /api/neira/events` to fetch events by id or timestamp
- cover EventLog with integration tests

## Testing
- `cargo test`
- `cd spinal_cord && cargo test --test event_log_test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d638fec88323a504a894ed714eff