### PR TITLE
feat(event_log): ротация и gzip-сжатие

### DIFF
--- a/spinal_cord/src/event_log.rs
+++ b/spinal_cord/src/event_log.rs
@@ -4,12 +4,20 @@ intent: feature
 summary: |-
   Запись событий EventBus в файл NDJSON и выборка по диапазону.
 */
+/* neira:meta
+id: NEI-20270310-rotating-log
+intent: feature
+summary: |-
+  Добавлена ротация журнала с gzip‑сжатием и настройкой пути через переменные окружения.
+*/
 use crate::event_bus::Event;
 use chrono::Utc;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use serde::{Deserialize, Serialize};
-use std::fs::{self, OpenOptions};
-use std::io::Write;
-use std::path::PathBuf;
+use std::fs::{self, File, OpenOptions};
+use std::io::{copy, Write};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -20,9 +28,39 @@ pub struct LoggedEvent {
 }
 
 fn log_path() -> PathBuf {
-    std::env::var("EVENT_LOG_FILE")
+    std::env::var("EVENT_LOG_PATH")
+        .or_else(|_| std::env::var("EVENT_LOG_FILE"))
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("logs/events.ndjson"))
+}
+
+fn rotate_limit() -> u64 {
+    std::env::var("EVENT_LOG_ROTATE_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5 * 1024 * 1024)
+}
+
+fn rotate_if_needed(path: &Path) {
+    let limit = rotate_limit();
+    if let Ok(meta) = fs::metadata(path) {
+        if meta.len() >= limit {
+            let ts = Utc::now().format("%Y%m%d%H%M%S");
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("events");
+            let rotated = path.with_file_name(format!("{}-{}.ndjson.gz", stem, ts));
+            if let Ok(mut input) = File::open(path) {
+                if let Ok(out) = File::create(&rotated) {
+                    let mut enc = GzEncoder::new(out, Compression::default());
+                    let _ = copy(&mut input, &mut enc);
+                    let _ = enc.finish();
+                }
+            }
+            let _ = fs::remove_file(path);
+        }
+    }
 }
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -39,6 +77,7 @@ pub fn append(event: &dyn Event) {
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }
+        rotate_if_needed(&path);
         if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
             let _ = writeln!(file, "{}", line);
         }


### PR DESCRIPTION
## Summary
- добавить ротацию журнала с gzip-сжатием
- сделать путь и порог размера настраиваемыми через EVENT_LOG_PATH и EVENT_LOG_ROTATE_SIZE
- протестировать ротацию EventLog

## Testing
- `cargo clippy --tests -p backend`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f4b7ae888323a288ffe806dc0ad0