### PR TITLE
fix: уникальные имена ротации EventLog

### DIFF
--- a/spinal_cord/AGENTS.md
+++ b/spinal_cord/AGENTS.md
@@ -1,7 +1,13 @@
 <!-- neira:meta
-id: NEI-20270223-spinal-digestive-doc
+id: NEI-20270223-000000-spinal-digestive-doc
 intent: docs
 summary: Добавлен раздел DigestivePipeline с форматами, конфигурацией и примерами.
+-->
+
+<!-- neira:meta
+id: NEI-20270408-000000-event-log-doc
+intent: docs
+summary: Описан формат именования архивов EventLog с миллисекундами и счётчиком.
 -->
 
 # Инструкции для spinal_cord
@@ -23,3 +29,9 @@ let parsed = DigestivePipeline::ingest(raw)?; // ParsedInput
 # config/digestive.toml
 schema_path = "schemas/input.json"
 ```
+
+## EventLog
+
+- Ротация создаёт gzip-файлы вида `{stem}-{timestamp_ms}-{seq}.ndjson.gz`,
+  где `timestamp_ms` — время в миллисекундах, `seq` — счётчик `AtomicU64`.
+


### PR DESCRIPTION
## Summary
- добавлена миллисекундная метка и последовательный счётчик в имени архивов EventLog
- тест проверяет две последовательные ротации и разные gzip-файлы
- задокументирован новый формат имени ротации

## Testing
- `cargo clippy -p backend -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fae67bd883238006a68aac6794ff