### PR TITLE
feat: async event log with metrics

### DIFF
--- a/spinal_cord/src/event_bus.rs
+++ b/spinal_cord/src/event_bus.rs
@@ -1,6 +1,6 @@
 /* neira:meta
-id: NEI-20251227-event-bus
-intent: code
+id: NEI-20251227-000000-event-bus
+intent: feature
 summary: |-
   Простой шина событий с трейтом Event и подписчиками.
 */
@@ -29,7 +29,7 @@ use crate::circulatory_system::{DataFlowController, FlowEvent, FlowMessage};
 /* neira:meta
 id: NEI-20270310-120100-event-bus-log-hook
 intent: feature
-summary: publish пишет событие в EventLog.
+summary: publish пишет событие в EventLog и учитывает метрики публикаций.
 */
 use crate::event_log;
 use std::any::Any;
@@ -80,7 +80,11 @@ impl EventBus {
                 name: event.name().to_string(),
             }));
         }
-        event_log::append(event);
+        if event_log::append(event).is_ok() {
+            metrics::counter!("event_bus_publish_total").increment(1);
+        } else {
+            metrics::counter!("event_bus_publish_failures_total").increment(1);
+        }
     }
 }
 

--- a/spinal_cord/src/event_log.rs
+++ b/spinal_cord/src/event_log.rs
@@ -10,15 +10,29 @@ intent: feature
 summary: |-
   Добавлена ротация журнала с gzip‑сжатием и настройкой пути через переменные окружения.
 */
+/* neira:meta
+id: NEI-20270501-event-log-async
+intent: refactor
+summary: Запись событий через асинхронный канал и поддержка flush().
+*/
+/* neira:meta
+id: NEI-20270501-event-log-name-filter
+intent: feature
+summary: query фильтрует события по имени.
+*/
 use crate::event_bus::Event;
 use chrono::Utc;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
-use std::io::{copy, Write};
+use std::io::{copy, Error as IoError, ErrorKind, Result as IoResult, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Sender};
+use std::thread;
+use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LoggedEvent {
@@ -75,24 +89,40 @@ fn rotate_if_needed(path: &Path) {
 
 static ROTATE_SEQ: AtomicU64 = AtomicU64::new(0);
 static COUNTER: AtomicU64 = AtomicU64::new(0);
+static PENDING: AtomicU64 = AtomicU64::new(0);
 
-pub fn append(event: &dyn Event) {
+static SENDER: Lazy<Sender<LoggedEvent>> = Lazy::new(|| {
+    let (tx, rx) = mpsc::channel::<LoggedEvent>();
+    thread::spawn(move || {
+        for entry in rx {
+            let path = log_path();
+            if let Some(parent) = path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            rotate_if_needed(&path);
+            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
+                if let Ok(line) = serde_json::to_string(&entry) {
+                    let _ = writeln!(file, "{}", line);
+                }
+            }
+            PENDING.fetch_sub(1, Ordering::SeqCst);
+        }
+    });
+    tx
+});
+
+pub fn append(event: &dyn Event) -> IoResult<()> {
     let id = COUNTER.fetch_add(1, Ordering::SeqCst) + 1;
     let entry = LoggedEvent {
         id,
         ts_ms: Utc::now().timestamp_millis(),
         name: event.name().to_string(),
     };
-    if let Ok(line) = serde_json::to_string(&entry) {
-        let path = log_path();
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        rotate_if_needed(&path);
-        if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
-            let _ = writeln!(file, "{}", line);
-        }
-    }
+    PENDING.fetch_add(1, Ordering::SeqCst);
+    SENDER.send(entry).map_err(|e| {
+        PENDING.fetch_sub(1, Ordering::SeqCst);
+        IoError::new(ErrorKind::Other, e)
+    })
 }
 
 pub fn query(
@@ -100,6 +130,7 @@ pub fn query(
     end_id: Option<u64>,
     start_ts_ms: Option<i64>,
     end_ts_ms: Option<i64>,
+    name: Option<&str>,
 ) -> Vec<LoggedEvent> {
     let path = log_path();
     let Ok(data) = fs::read_to_string(path) else {
@@ -128,13 +159,25 @@ pub fn query(
                     return false;
                 }
             }
+            if let Some(n) = name {
+                if ev.name != n {
+                    return false;
+                }
+            }
             true
         })
         .collect()
 }
 
 pub fn reset() {
+    flush();
     COUNTER.store(0, Ordering::SeqCst);
     let path = log_path();
     let _ = fs::remove_file(path);
+}
+
+pub fn flush() {
+    while PENDING.load(Ordering::SeqCst) > 0 {
+        thread::sleep(Duration::from_millis(1));
+    }
 }

--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -2339,6 +2339,11 @@ async fn main() {
     intent: feature
     summary: REST-ручка для чтения EventLog.
     */
+    /* neira:meta
+    id: NEI-20270501-000000-events-name-filter
+    intent: feature
+    summary: Эндпоинт поддерживает фильтр по имени события.
+    */
     async fn events_get(
         axum::extract::Query(q): axum::extract::Query<std::collections::HashMap<String, String>>,
     ) -> Result<Json<serde_json::Value>, axum::http::StatusCode> {
@@ -2346,7 +2351,8 @@ async fn main() {
         let end_id = q.get("end_id").and_then(|v| v.parse::<u64>().ok());
         let start_ts_ms = q.get("start_ts_ms").and_then(|v| v.parse::<i64>().ok());
         let end_ts_ms = q.get("end_ts_ms").and_then(|v| v.parse::<i64>().ok());
-        let events = event_log::query(start_id, end_id, start_ts_ms, end_ts_ms);
+        let name = q.get("name").map(|s| s.as_str());
+        let events = event_log::query(start_id, end_id, start_ts_ms, end_ts_ms, name);
         Ok(Json(serde_json::json!({"events": events})))
     }
     app = app.route("/api/neira/events", get(events_get));

--- a/spinal_cord/tests/event_log_test.rs
+++ b/spinal_cord/tests/event_log_test.rs
@@ -3,7 +3,7 @@ id: NEI-20270310-120400-event-log-tests
 intent: chore
 summary: Проверка записи и выборки событий из EventLog.
 */
-use backend::event_bus::{EventBus, OrganBuilt};
+use backend::event_bus::{Event, EventBus, OrganBuilt};
 use backend::event_log;
 use serial_test::serial;
 use std::env;
@@ -18,11 +18,13 @@ fn publish_and_query_by_id() {
     let dir = tempdir().unwrap();
     let file = dir.path().join("events.ndjson");
     env::set_var("EVENT_LOG_FILE", &file);
+    env::remove_var("EVENT_LOG_ROTATE_SIZE");
     event_log::reset();
     let bus = EventBus::new();
     bus.publish(&OrganBuilt { id: "one".into() });
     bus.publish(&OrganBuilt { id: "two".into() });
-    let events = event_log::query(Some(2), Some(2), None, None);
+    event_log::flush();
+    let events = event_log::query(Some(2), Some(2), None, None, None);
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].name, "OrganBuilt");
     assert_eq!(events[0].id, 2);
@@ -40,7 +42,8 @@ fn query_by_time_range() {
     sleep(Duration::from_millis(2));
     let ts = chrono::Utc::now().timestamp_millis();
     bus.publish(&OrganBuilt { id: "b".into() });
-    let events = event_log::query(None, None, Some(ts), None);
+    event_log::flush();
+    let events = event_log::query(None, None, Some(ts), None, None);
     assert_eq!(events.len(), 1);
     assert!(events[0].ts_ms >= ts);
 }
@@ -62,6 +65,7 @@ fn rotates_twice_with_unique_names() {
     for id in ["a", "b", "c"] {
         bus.publish(&OrganBuilt { id: id.into() });
     }
+    event_log::flush();
     let mut gz_files: Vec<_> = fs::read_dir(dir.path())
         .unwrap()
         .filter_map(|e| {
@@ -76,4 +80,36 @@ fn rotates_twice_with_unique_names() {
     gz_files.sort();
     assert_eq!(gz_files.len(), 2, "expected two rotated files");
     assert_ne!(gz_files[0], gz_files[1], "rotated file names must differ");
+}
+
+/* neira:meta
+id: NEI-20270501-event-log-name-filter-test
+intent: test
+summary: Проверка фильтрации событий по имени.
+*/
+#[test]
+#[serial]
+fn filter_by_name() {
+    let dir = tempdir().unwrap();
+    let file = dir.path().join("events.ndjson");
+    env::set_var("EVENT_LOG_FILE", &file);
+    event_log::reset();
+    let bus = EventBus::new();
+
+    struct Foo;
+    impl Event for Foo {
+        fn name(&self) -> &str {
+            "Foo"
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    bus.publish(&Foo);
+    bus.publish(&OrganBuilt { id: "x".into() });
+    event_log::flush();
+    let events = event_log::query(None, None, None, None, Some("Foo"));
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].name, "Foo");
 }


### PR DESCRIPTION
## Summary
- log events asynchronously and support filtering by name
- track publish success/fail metrics in EventBus
- test event log filtering and rotation

## Testing
- `cargo clippy -p backend` *(fails: initial attempt with --tests could not resolve dev deps)*
- `cargo test --test event_log_test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68b9fb3c76c48323ae53c1f72d2eabf3