### PR TITLE
fix(ci): remove duplicated core in auto-resolve workflow

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -1,5 +1,10 @@
 name: Auto-resolve PR conflicts (prefer PR branch)
 
+# neira:meta
+# id: NEI-20250217-github-script-core-fix
+# intent: ci
+# summary: Убрано повторное объявление core/github и исправлена передача списка PR.
+
 on:
   # Обновили PR — попробуем починить конфликты
   pull_request:
@@ -28,9 +33,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
-            const github = require('@actions/github');
-
             // Когда триггер push, нужно пробежать все открытые PR
             if (github.context.eventName === 'push') {
               const { data: prs } = await github.rest.pulls.list({
@@ -63,13 +65,12 @@ jobs:
         uses: actions/github-script@v7
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRS: ${{ steps.ctx.outputs.prs }}
         with:
           script: |
-            const core = require('@actions/core');
-            const github = require('@actions/github');
             const exec = require('child_process').execSync;
 
-            const prs = JSON.parse(core.getInput('prs'));
+            const prs = JSON.parse(process.env.PRS);
             const isCodex = (ref) => /^codex\//.test(ref) || /codex/i.test(ref);
 
             for (const pr of prs) {


### PR DESCRIPTION
## Summary
- fix auto-resolve workflow by using provided core/github and passing PR list via env

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b11bdd08323aa544e43fb1984db