### PR TITLE
chore: запуск pre-commit на застейдженных файлах

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,9 +3,14 @@
 # id: NEI-20260413-pre-commit-rename
 # intent: chore
 # summary: Обновлён путь к spinal_cord в cargo test.
+# neira:meta
+# id: NEI-20250301-pre-commit-staged
+# intent: chore
+# summary: Добавлен запуск pre-commit для стадированных файлов перед lint.
 set -e
 
 node scripts/check-meta.mjs --staged
+pre-commit run --files $(git diff --staged --name-only)
 npm run lint
 npm test
 cargo metadata --locked

--- a/README.md
+++ b/README.md
@@ -560,11 +560,18 @@ summary: |
 -->
 ### Pre-commit
 
-Установите локальные хуки для форматирования и линтинга:
+Установите `pre-commit` и локальные хуки для форматирования и линтинга:
 
 ```bash
+pip install pre-commit
 pre-commit install
 ```
+
+<!-- neira:meta
+id: NEI-20250301-pre-commit-pip-doc
+intent: docs
+summary: Добавлена команда установки pre-commit через pip.
+-->
 
 ## Схемы
 


### PR DESCRIPTION
## Summary
- запускаем `pre-commit` для застейдженных файлов перед линтингом
- обновляем документацию по установке `pre-commit`

## Testing
- `pre-commit run --files README.md .husky/pre-commit`
- `npm test`
- `npm run lint`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bac7c555808323af7de696680008ba