### PR TITLE
chore: запуск pre-commit на застейдженных файлах

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,9 +3,21 @@
 # id: NEI-20260413-pre-commit-rename
 # intent: chore
 # summary: Обновлён путь к spinal_cord в cargo test.
+# neira:meta
+# id: NEI-20250301-pre-commit-staged
+# intent: chore
+# summary: Добавлен запуск pre-commit для стадированных файлов перед lint.
+# neira:meta
+# id: NEI-20260701-pre-commit-ignore-deletions
+# intent: fix
+# summary: Исключены удалённые файлы из списка для pre-commit.
 set -e
 
 node scripts/check-meta.mjs --staged
+staged_files="$(git diff --cached --name-only --diff-filter=ACM)"
+if [ -n "$staged_files" ]; then
+  pre-commit run --files $staged_files
+fi
 npm run lint
 npm test
 cargo metadata --locked

--- a/README.md
+++ b/README.md
@@ -560,11 +560,18 @@ summary: |
 -->
 ### Pre-commit
 
-Установите локальные хуки для форматирования и линтинга:
+Установите `pre-commit` и локальные хуки для форматирования и линтинга:
 
 ```bash
+pip install pre-commit
 pre-commit install
 ```
+
+<!-- neira:meta
+id: NEI-20250301-pre-commit-pip-doc
+intent: docs
+summary: Добавлена команда установки pre-commit через pip.
+-->
 
 ## Схемы
 


### PR DESCRIPTION
## Summary
- запускаем `pre-commit` для застейдженных файлов перед линтингом
- обновляем документацию по установке `pre-commit`
- фильтруем удалённые файлы перед запуском `pre-commit`

## Testing
- `pre-commit run --files .husky/pre-commit`
- `npm test`
- `npm run lint`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bac7c555808323af7de696680008ba