### PR TITLE
ci: кэширование npm и Cargo зависимостей

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ name: CI
 # intent: ci
 # summary: Удалено повторное объявление переменной context в шаге github-script, устранён SyntaxError.
 
+# neira:meta
+# id: NEI-20250215-ci-cache-deps
+# intent: ci
+# summary: Добавлено кэширование npm и Cargo зависимостей для ускорения CI.
+
 on:
   push:
     branches: [ main ]
@@ -48,6 +53,15 @@ jobs:
         with:
           node-version: 20
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Validate Cargo files
         run: cargo metadata --locked --format-version 1
       # neira:meta
@@ -58,6 +72,11 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check bans
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json', 'sensory_organs/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-npm-
       - name: Install dependencies
         run: |
           npm ci
@@ -149,6 +168,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Cargo metadata (locked)
         run: cargo metadata --locked --format-version 1
       - name: Cargo tree (duplicates overview)


### PR DESCRIPTION
## Summary
- добавить кэш npm
- добавить кэш Cargo

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `npm test`
- `npm test --prefix sensory_organs`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68badad8bb4083239b3bacd4d8830f6d