### PR TITLE
feat: централизованный выбор директории контекста

### DIFF
--- a/spinal_cord/src/action/scripted_training_cell.rs
+++ b/spinal_cord/src/action/scripted_training_cell.rs
@@ -14,6 +14,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::action_cell::ActionCell;
+/* neira:meta
+id: NEI-20250101-000003-scripted-training-context
+intent: refactor
+summary: Сценарный узел обучения пишет результаты через context_dir().
+*/
+use crate::context::context_dir;
 use crate::context::context_storage::ContextStorage;
 use crate::memory_cell::MemoryCell;
 use serde::{Deserialize, Serialize};
@@ -341,8 +347,7 @@ impl ScriptedTrainingCell {
     }
 
     fn err_with_attachment(msg: &str, body: &str) -> String {
-        let base = std::env::var("CONTEXT_DIR").unwrap_or_else(|_| "context".into());
-        let dir = std::path::Path::new(&base).join("training");
+        let dir = context_dir().join("training");
         let _ = std::fs::create_dir_all(&dir);
         let ts = chrono::Utc::now().timestamp_millis();
         let path_rel = format!("training/failure_{}.txt", ts);
@@ -529,8 +534,7 @@ impl ScriptedTrainingCell {
     }
 
     fn write_reports(name: &str, results: &[TrainingResult]) -> Result<(), String> {
-        let base = std::env::var("CONTEXT_DIR").unwrap_or_else(|_| "context".into());
-        let dir = std::path::Path::new(&base).join("training");
+        let dir = context_dir().join("training");
         let _ = std::fs::create_dir_all(&dir);
         let tests = results.len();
         let failures = results.iter().filter(|r| !r.3).count();

--- a/spinal_cord/src/context/context_storage.rs
+++ b/spinal_cord/src/context/context_storage.rs
@@ -250,10 +250,16 @@ fn update_storage_metrics(cfg: &Config, added_bytes: u64, lines: usize) {
 
 impl FileContextStorage {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        let root = std::env::var("CONTEXT_DIR")
-            .ok()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| root.into());
+        /* neira:meta
+        id: NEI-20250101-000001-context-storage-env
+        intent: refactor
+        summary: new() использует context_dir() при наличии CONTEXT_DIR.
+        */
+        let root = if std::env::var_os("CONTEXT_DIR").is_some() {
+            crate::context::context_dir()
+        } else {
+            root.into()
+        };
         let cfg = Config::from_env(&root);
         if cfg.flush_interval_ms > 0 {
             let (tx, mut rx) = mpsc::channel::<(String, String, ChatMessage)>(1024);

--- a/spinal_cord/src/context/mod.rs
+++ b/spinal_cord/src/context/mod.rs
@@ -1,2 +1,19 @@
+/* neira:meta
+id: NEI-20250101-000000-context-dir-helper
+intent: code
+summary: Добавлена функция context_dir с учётом переменной CONTEXT_DIR.
+*/
+use std::path::PathBuf;
+
 pub mod context_storage;
+
+/// Возвращает путь к директории хранения контекста.
+///
+/// Приоритет отдаётся переменной окружения `CONTEXT_DIR`.
+/// Если переменная отсутствует, используется директория `context`.
+pub fn context_dir() -> PathBuf {
+    std::env::var_os("CONTEXT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("context"))
+}
 

--- a/tests/context_dir_test.rs
+++ b/tests/context_dir_test.rs
@@ -1,0 +1,37 @@
+/* neira:meta
+id: NEI-20250101-000005-context-dir-test
+intent: test
+summary: Проверяет дефолтный путь и переопределение CONTEXT_DIR.
+*/
+use backend::context::context_dir;
+use serial_test::serial;
+use std::env;
+use std::path::PathBuf;
+
+#[test]
+#[serial]
+fn context_dir_default() {
+    let prev = env::var_os("CONTEXT_DIR");
+    env::remove_var("CONTEXT_DIR");
+    let dir = context_dir();
+    assert_eq!(dir, PathBuf::from("context"));
+    if let Some(val) = prev {
+        env::set_var("CONTEXT_DIR", val);
+    } else {
+        env::remove_var("CONTEXT_DIR");
+    }
+}
+
+#[test]
+#[serial]
+fn context_dir_overridden() {
+    let prev = env::var_os("CONTEXT_DIR");
+    env::set_var("CONTEXT_DIR", "/tmp/ctx_override");
+    let dir = context_dir();
+    assert_eq!(dir, PathBuf::from("/tmp/ctx_override"));
+    if let Some(val) = prev {
+        env::set_var("CONTEXT_DIR", val);
+    } else {
+        env::remove_var("CONTEXT_DIR");
+    }
+}


### PR DESCRIPTION
## Summary
- добавлена функция `context_dir()` с учётом `CONTEXT_DIR` и дефолта
- все модули переведены на `context_dir()` вместо прямого `env`
- покрытие тестами дефолта и переопределения `CONTEXT_DIR`

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bae01a361c832395eab607d4129426