### PR TITLE
feat: add env flag helper

### DIFF
--- a/spinal_cord/src/action/metrics_collector_cell.rs
+++ b/spinal_cord/src/action/metrics_collector_cell.rs
@@ -9,8 +9,8 @@ env:
   - METRICS_LOW_INTERVAL_MS
 */
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
@@ -72,15 +72,13 @@ impl MetricsCollectorCell {
 
     /// Переключает коллектор в режим «normal».
     pub fn set_normal(&self) {
-        self
-            .current_interval_ms
+        self.current_interval_ms
             .store(self.normal_interval_ms, Ordering::SeqCst);
     }
 
     /// Переключает коллектор в режим «low».
     pub fn set_low(&self) {
-        self
-            .current_interval_ms
+        self.current_interval_ms
             .store(self.low_interval_ms, Ordering::SeqCst);
     }
 }
@@ -92,4 +90,3 @@ impl ActionCell for MetricsCollectorCell {
 
     fn preload(&self, _triggers: &[String], _memory: &Arc<MemoryCell>) {}
 }
-

--- a/spinal_cord/src/action/mod.rs
+++ b/spinal_cord/src/action/mod.rs
@@ -1,4 +1,4 @@
 pub mod chat_cell;
-pub mod scripted_training_cell;
-pub mod metrics_collector_cell;
 pub mod diagnostics_cell;
+pub mod metrics_collector_cell;
+pub mod scripted_training_cell;

--- a/spinal_cord/src/action/scripted_training_cell.rs
+++ b/spinal_cord/src/action/scripted_training_cell.rs
@@ -9,6 +9,11 @@ env:
   - TRAINING_PROGRESS
   - TRAINING_DRY_RUN
 */
+/* neira:meta
+id: NEI-20250220-env-flag-training
+intent: refactor
+summary: Читает TRAINING_* флаги через env_flag.
+*/
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -121,9 +126,7 @@ impl ScriptedTrainingCell {
             .unwrap_or_else(|_| "examples/training_script.yaml".into());
         let progress = std::env::var("TRAINING_PROGRESS")
             .unwrap_or_else(|_| "context/training/progress.json".into());
-        let dry_run = std::env::var("TRAINING_DRY_RUN")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let dry_run = crate::config::env_flag("TRAINING_DRY_RUN", false);
         Self {
             id: "scripted.training".into(),
             script_path: script.into(),
@@ -421,9 +424,7 @@ impl ScriptedTrainingCell {
                 }
             }
             Hook::Shell { cmd } => {
-                let allow = std::env::var("TRAINING_ALLOW_SHELL")
-                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                    .unwrap_or(false);
+                let allow = crate::config::env_flag("TRAINING_ALLOW_SHELL", false);
                 if !allow {
                     return;
                 }

--- a/spinal_cord/src/bin/diagnose.rs
+++ b/spinal_cord/src/bin/diagnose.rs
@@ -2,18 +2,32 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
-    let base = std::env::args().nth(1).unwrap_or("http://127.0.0.1:3000".into());
-    let client = reqwest::Client::builder().timeout(Duration::from_secs(3)).build().unwrap();
+    let base = std::env::args()
+        .nth(1)
+        .unwrap_or("http://127.0.0.1:3000".into());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .unwrap();
     println!("Endpoint: {}", base);
     // status
-    match client.get(format!("{}/api/neira/control/status", base)).send().await {
-        Ok(r) => match r.text().await { Ok(t) => println!("status: {}", t), Err(_) => println!("status: <read err>") },
+    match client
+        .get(format!("{}/api/neira/control/status", base))
+        .send()
+        .await
+    {
+        Ok(r) => match r.text().await {
+            Ok(t) => println!("status: {}", t),
+            Err(_) => println!("status: <read err>"),
+        },
         Err(e) => println!("status error: {}", e),
     }
     // metrics
     match client.get(format!("{}/metrics", base)).send().await {
-        Ok(r) => match r.text().await { Ok(_t) => println!("metrics: OK"), Err(_) => println!("metrics: <read err>") },
+        Ok(r) => match r.text().await {
+            Ok(_t) => println!("metrics: OK"),
+            Err(_) => println!("metrics: <read err>"),
+        },
         Err(e) => println!("metrics error: {}", e),
     }
 }
-

--- a/spinal_cord/src/context/context_storage.rs
+++ b/spinal_cord/src/context/context_storage.rs
@@ -1,3 +1,8 @@
+/* neira:meta
+id: NEI-20250220-context-env-flag
+intent: refactor
+summary: Флаги контекста читаются через общую функцию env_flag.
+*/
 use crate::nervous_system::anti_idle;
 use chrono::{Datelike, Utc};
 use flate2::write::GzEncoder;
@@ -450,19 +455,13 @@ impl Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(metrics.max_bytes);
-        let daily_rotation = std::env::var("CONTEXT_DAILY_ROTATION")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
-        let archive_gz = std::env::var("CONTEXT_ARCHIVE_GZ")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let daily_rotation = crate::config::env_flag("CONTEXT_DAILY_ROTATION", true);
+        let archive_gz = crate::config::env_flag("CONTEXT_ARCHIVE_GZ", true);
         let flush_interval_ms = std::env::var("CONTEXT_FLUSH_MS")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
-        let mask_enabled = std::env::var("MASK_PII")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let mask_enabled = crate::config::env_flag("MASK_PII", true);
         let mask_regex = std::env::var("MASK_REGEX")
             .ok()
             .map(|s| s.split(';').filter_map(|p| Regex::new(p).ok()).collect())

--- a/spinal_cord/src/context/mod.rs
+++ b/spinal_cord/src/context/mod.rs
@@ -16,4 +16,3 @@ pub fn context_dir() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("context"))
 }
-

--- a/spinal_cord/src/factory/mod.rs
+++ b/spinal_cord/src/factory/mod.rs
@@ -19,6 +19,11 @@ id: NEI-20251227-factory-event-bus
 intent: refactor
 summary: Прямые вызовы watch/observe убраны в пользу событий.
 */
+/* neira:meta
+id: NEI-20250220-env-flag-factory
+intent: refactor
+summary: Переменная FACTORY_ADAPTER_ENABLED парсится через env_flag.
+*/
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -63,9 +68,7 @@ pub struct StemCellFactory {
 
 impl StemCellFactory {
     pub fn new() -> Arc<Self> {
-        let adapter_enabled = std::env::var("FACTORY_ADAPTER_ENABLED")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let adapter_enabled = crate::config::env_flag("FACTORY_ADAPTER_ENABLED", false);
         Arc::new(Self {
             records: RwLock::new(HashMap::new()),
             adapter_enabled,

--- a/spinal_cord/src/main.rs
+++ b/spinal_cord/src/main.rs
@@ -1,9 +1,15 @@
-use backend::context::context_dir;
 /* neira:meta
 id: NEI-20250101-000004-main-context-dir
 intent: refactor
 summary: Основной сервис использует context_dir() вместо прямого чтения CONTEXT_DIR.
 */
+/* neira:meta
+id: NEI-20250220-env-flag-main
+intent: refactor
+summary: Булевы переменные в main читаются через config::env_flag.
+*/
+use backend::config;
+use backend::context::context_dir;
 use backend::digestive_pipeline::{DigestivePipeline, ParsedInput};
 use std::sync::{Arc, Mutex};
 
@@ -1085,9 +1091,7 @@ async fn chat_stream(
         let mut chars = 0usize;
         let start = Instant::now();
         let dev_delay_ms = std::env::var("SSE_DEV_DELAY_MS").ok().and_then(|v| v.parse::<u64>().ok()).unwrap_or(0);
-        let loop_enabled = std::env::var("LOOP_DETECT_ENABLED")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let loop_enabled = config::env_flag("LOOP_DETECT_ENABLED", true);
         let loop_win: usize = std::env::var("LOOP_WINDOW_TOKENS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -1611,9 +1615,7 @@ async fn main() {
 
     let file_appender = tracing_appender::rolling::daily(logs_dir, "backend.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-    let json_logs = std::env::var("NERVOUS_SYSTEM_JSON_LOGS")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+    let json_logs = config::env_flag("NERVOUS_SYSTEM_JSON_LOGS", false);
     let fmt_builder = tracing_subscriber::fmt()
         .with_writer(non_blocking)
         .with_ansi(false)
@@ -1780,9 +1782,7 @@ async fn main() {
             let _deep_secs = t.deep_secs;
             let alpha = anti_idle::ema_alpha();
             let dry_depth_env = anti_idle::dryrun_queue_depth();
-            let dryrun_enabled = std::env::var("LEARNING_MICROTASKS_DRYRUN")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+            let dryrun_enabled = config::env_flag("LEARNING_MICROTASKS_DRYRUN", false);
             let mut accum_idle_secs: u64 = 0;
             let mut idle_ema: f64 = 0.0;
             loop {
@@ -1967,9 +1967,7 @@ async fn main() {
         {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
-        let allow = std::env::var("CONTROL_ALLOW_PAUSE")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let allow = config::env_flag("CONTROL_ALLOW_PAUSE", true);
         if !allow {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
@@ -2034,9 +2032,7 @@ async fn main() {
         {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
-        let allow = std::env::var("CONTROL_ALLOW_PAUSE")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let allow = config::env_flag("CONTROL_ALLOW_PAUSE", true);
         if !allow {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
@@ -2098,9 +2094,7 @@ async fn main() {
         {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
-        let allow = std::env::var("CONTROL_ALLOW_KILL")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let allow = config::env_flag("CONTROL_ALLOW_KILL", true);
         if !allow {
             return Err(axum::http::StatusCode::FORBIDDEN);
         }
@@ -2641,12 +2635,17 @@ async fn main() {
         let (idle_state, since) = anti_idle::idle_state(active);
         let t = *anti_idle::thresholds();
         metrics::gauge!("time_since_activity_seconds").set(since as f64);
+        /* neira:meta
+        id: NEI-20250220-env-flag-main-caps
+        intent: refactor
+        summary: Сводка возможностей использует env_flag.
+        */
         let caps = serde_json::json!({
             "trace_requests": state.hub.is_trace_enabled(),
             "inspect_snapshot": true,
-            "control_pause_resume": std::env::var("CONTROL_ALLOW_PAUSE").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true),
-            "control_kill_switch": std::env::var("CONTROL_ALLOW_KILL").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(true),
-            "dev_routes": std::env::var("DEV_ROUTES_ENABLED").map(|v| v=="1"||v.eq_ignore_ascii_case("true")).unwrap_or(false),
+            "control_pause_resume": config::env_flag("CONTROL_ALLOW_PAUSE", true),
+            "control_kill_switch": config::env_flag("CONTROL_ALLOW_KILL", true),
+            "dev_routes": config::env_flag("DEV_ROUTES_ENABLED", false),
             "factory_adapter": state.hub.factory_is_adapter_enabled(),
             "organs_builder": state.hub.organ_builder_enabled()
         });
@@ -2722,10 +2721,7 @@ async fn main() {
         .route("/api/neira/plugins", get(list_plugins))
         .route("/api/neira/ui/tools", get(list_ui_tools));
 
-    if std::env::var("DEV_ROUTES_ENABLED")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-    {
+    if config::env_flag("DEV_ROUTES_ENABLED", false) {
         // register dev slow analysis cell
         struct DevSlowCell;
         impl AnalysisCell for DevSlowCell {

--- a/spinal_cord/src/memory_cell.rs
+++ b/spinal_cord/src/memory_cell.rs
@@ -17,8 +17,8 @@ use std::sync::{Arc, RwLock};
 use lru::LruCache;
 
 use chrono::{DateTime, Utc};
-use tokio::spawn;
 use std::time::Instant;
+use tokio::spawn;
 
 use crate::analysis_cell::{AnalysisResult, QualityMetrics, ReasoningStep};
 use crate::digestive_pipeline::ParsedInput;
@@ -130,13 +130,7 @@ impl MemoryCell {
         let mut key = triggers.to_vec();
         key.sort();
         let cache_key = key.join("|");
-        if let Some(records) = self
-            .preload_cache
-            .write()
-            .unwrap()
-            .get(&cache_key)
-            .cloned()
-        {
+        if let Some(records) = self.preload_cache.write().unwrap().get(&cache_key).cloned() {
             let elapsed = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("memory_cell_preload_duration_ms").record(elapsed);
             metrics::histogram!("memory_cell_preload_duration_ms_p95").record(elapsed);

--- a/spinal_cord/src/nervous_system/backpressure_probe.rs
+++ b/spinal_cord/src/nervous_system/backpressure_probe.rs
@@ -4,6 +4,11 @@ intent: docs
 summary: |-
   Монитор очередей планировщика, публикующий backpressure и выполняющий троттлинг.
 */
+/* neira:meta
+id: NEI-20250220-env-flag-backpressure
+intent: refactor
+summary: Добавлен флаг AUTO_BACKOFF_ENABLED через env_flag.
+*/
 
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
@@ -55,11 +60,7 @@ impl BackpressureProbe {
             metrics::counter!("throttle_events_total").increment(1);
             sleep(Duration::from_millis(bp_sleep)).await;
         }
-        if std::env::var("AUTO_BACKOFF_ENABLED")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-            && bp > bp_high
-        {
+        if crate::config::env_flag("AUTO_BACKOFF_ENABLED", false) && bp > bp_high {
             let max_backoff = std::env::var("BP_MAX_BACKOFF_MS")
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())

--- a/spinal_cord/src/nervous_system/loop_detector.rs
+++ b/spinal_cord/src/nervous_system/loop_detector.rs
@@ -36,7 +36,11 @@ pub fn check_sequence(
     let ratio = max_rep / (win.len() as f32);
     let mut ent: f32 = 0.0;
     if entropy_min > 0.0 {
-        let concat = win.iter().map(|s| s.as_str()).collect::<Vec<&str>>().join(" ");
+        let concat = win
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>()
+            .join(" ");
         let mut cf: HashMap<char, usize> = HashMap::new();
         for ch in concat.chars() {
             *cf.entry(ch).or_insert(0) += 1;

--- a/spinal_cord/src/organ_builder.rs
+++ b/spinal_cord/src/organ_builder.rs
@@ -18,6 +18,11 @@ intent: code
 summary: переименована переменная на ORGANS_BUILDER_STAGE_DELAYS.
 */
 /* neira:meta
+id: NEI-20250220-env-flag-organ-builder
+intent: refactor
+summary: Флаг ORGANS_BUILDER_ENABLED обрабатывается через env_flag.
+*/
+/* neira:meta
 id: NEI-20251115-organ-cancel-build
 intent: code
 summary: сохраняются JoinHandle задач и добавлен cancel_build для их остановки.
@@ -74,9 +79,7 @@ impl OrganBuilder {
     /// Создаёт новый орган-билдер. Включение контролируется переменной окружения
     /// `ORGANS_BUILDER_ENABLED`.
     pub fn new() -> Arc<Self> {
-        let enabled = std::env::var("ORGANS_BUILDER_ENABLED")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let enabled = crate::config::env_flag("ORGANS_BUILDER_ENABLED", false);
         let dir = std::env::var("ORGANS_BUILDER_TEMPLATES_DIR")
             .unwrap_or_else(|_| "organ_templates".into());
         let templates_dir = PathBuf::from(dir);

--- a/spinal_cord/src/synapse_hub.rs
+++ b/spinal_cord/src/synapse_hub.rs
@@ -6,6 +6,11 @@ summary: |
   переопределяются через переменные окружения.
 */
 /* neira:meta
+id: NEI-20250220-env-flag-hub
+intent: refactor
+summary: Несколько флагов хаба парсятся через env_flag.
+*/
+/* neira:meta
 id: NEI-20250214-watchdog-refactor
 intent: refactor
 summary: Логика watchdog вынесена в модуль nervous_system::watchdog.
@@ -177,9 +182,7 @@ impl SynapseHub {
             "session" => RateKeyMode::Session,
             _ => RateKeyMode::Auth,
         };
-        let idem_persist = std::env::var("IDEMPOTENT_PERSIST")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let idem_persist = crate::config::env_flag("IDEMPOTENT_PERSIST", false);
         let idem = if idem_persist {
             let dir = std::env::var("IDEMPOTENT_STORE_DIR").unwrap_or_else(|_| "context".into());
             let ttl = std::env::var("IDEMPOTENT_TTL_SECS")
@@ -190,9 +193,8 @@ impl SynapseHub {
         } else {
             None
         };
-        let persist_require_session_id = std::env::var("PERSIST_REQUIRE_SESSION_ID")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let persist_require_session_id =
+            crate::config::env_flag("PERSIST_REQUIRE_SESSION_ID", false);
         let io_watcher_threshold_ms = std::env::var("IO_WATCHER_THRESHOLD_MS")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -264,11 +266,7 @@ impl SynapseHub {
             cancels: RwLock::new(std::collections::HashMap::new()),
             analysis_cancels: RwLock::new(std::collections::HashMap::new()),
             traces: RwLock::new(std::collections::HashMap::new()),
-            trace_enabled: AtomicBool::new(
-                std::env::var("TRACE_ENABLED")
-                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                    .unwrap_or(false),
-            ),
+            trace_enabled: AtomicBool::new(crate::config::env_flag("TRACE_ENABLED", false)),
             trace_max_events: std::env::var("TRACE_MAX_EVENTS")
                 .ok()
                 .and_then(|v| v.parse().ok())

--- a/spinal_cord/src/time_metrics.rs
+++ b/spinal_cord/src/time_metrics.rs
@@ -18,4 +18,3 @@ pub fn record_validation_duration_ms(ms: f64) {
     histogram!("digestive_validation_duration_ms_p95").record(ms);
     histogram!("digestive_validation_duration_ms_p99").record(ms);
 }
-

--- a/spinal_cord/tests/chat_hub_test.rs
+++ b/spinal_cord/tests/chat_hub_test.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use backend::action::chat_cell::EchoChatCell;
 use backend::action::diagnostics_cell::DiagnosticsCell;
 use backend::action::metrics_collector_cell::MetricsCollectorCell;
+use backend::cell_registry::CellRegistry;
 use backend::config::Config;
 use backend::context::context_storage::FileContextStorage;
-use backend::synapse_hub::SynapseHub;
 use backend::memory_cell::MemoryCell;
-use backend::cell_registry::CellRegistry;
+use backend::synapse_hub::SynapseHub;
 
 #[tokio::test]
 async fn chat_hub_rejects_empty_message() {

--- a/spinal_cord/tests/io_watcher_env_test.rs
+++ b/spinal_cord/tests/io_watcher_env_test.rs
@@ -8,22 +8,24 @@ fn io_watcher_env_fallback_and_override() {
     // Legacy variable works when new one is absent
     std::env::set_var("IO_WATCHER_ENABLED", "1");
     let cfg = Config::from_env();
-    assert!(cfg
-        .probes
-        .get("io_watcher")
-        .expect("io watcher probe")
-        .enabled);
+    assert!(
+        cfg.probes
+            .get("io_watcher")
+            .expect("io watcher probe")
+            .enabled
+    );
     std::env::remove_var("IO_WATCHER_ENABLED");
 
     // New variable overrides legacy value
     std::env::set_var("PROBES_IO_WATCHER_ENABLED", "0");
     std::env::set_var("IO_WATCHER_ENABLED", "1");
     let cfg = Config::from_env();
-    assert!(!cfg
-        .probes
-        .get("io_watcher")
-        .expect("io watcher probe")
-        .enabled);
+    assert!(
+        !cfg.probes
+            .get("io_watcher")
+            .expect("io watcher probe")
+            .enabled
+    );
     std::env::remove_var("PROBES_IO_WATCHER_ENABLED");
     std::env::remove_var("IO_WATCHER_ENABLED");
 }


### PR DESCRIPTION
## Summary
- centralize boolean env parsing via `env_flag`
- use `env_flag` across modules (anti-idle, factory, hub, etc.)
- cover `env_flag` with unit tests

## Testing
- `cargo clippy -p backend --lib --bins`
- `cargo test --manifest-path spinal_cord/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68bae6215cfc832386a60ec62eddcef6