### PR TITLE
docs: документирован лимфатический фильтр

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -8,6 +8,11 @@ id: NEI-20250207-capabilities-sample-organs
 intent: docs
 summary: добавлены ссылки на примеры шаблонов органов.
 -->
+<!-- neira:meta
+id: NEI-20250214-120500-lymph-filter-capability
+intent: docs
+summary: Добавлен компонент «Лимфатический фильтр» в перечень способностей.
+-->
 
 # Neira Capabilities & Feature Gates
 
@@ -288,4 +293,7 @@ capabilities:
   organ_net_probe:
     state: locked
     notes: безопасные HEAD/GET для проверок доступности; без POST
+  lymphatic_filter:
+    state: experimental
+    notes: фильтрация входящих сигналов через лимфатический фильтр
 ```

--- a/COMMENTING.md
+++ b/COMMENTING.md
@@ -11,6 +11,11 @@ id: NEI-20260413-commenting-rename
 intent: docs
 summary: Обновлён пример scope для каталога spinal_cord.
 -->
+<!-- neira:meta
+id: NEI-20250214-121000-commenting-lymph-filter-example
+intent: docs
+summary: Добавлен пример блока для lymphatic_filter.md.
+-->
 
 См. [META_COVERAGE.md](META_COVERAGE.md) для определения, когда использовать полный или упрощённый блок.
 
@@ -33,6 +38,16 @@ intent: docs
 summary: |
   Короткое описание изменения.
 */
+```
+
+Пример блока для документа `lymphatic_filter.md`
+```markdown
+<!-- neira:meta
+id: NEI-YYYYMMDD-HHMMSS-lymphatic-filter-doc
+intent: docs
+summary: |
+  Описание подсистемы «Лимфатический фильтр».
+-->
 ```
 
 Purpose

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,11 @@ intent: docs
 summary: |
   Уточнено название каталога: backend/services -> spinal_cord/services.
 -->
+<!-- neira:meta
+id: NEI-20250214-120000-lymph-filter
+intent: docs
+summary: Добавлено решение о подсистеме «Лимфатический фильтр».
+-->
 // Architectural Decision Records (ADR Index)
 
 Format
@@ -15,6 +20,7 @@ Format
 
 Index
 - ADR-001 Rust as primary language — Accepted
+- ADR-002 Лимфатический фильтр — Accepted
 
 Templates
 - Use this skeleton when adding a new ADR under `docs/adrs/ADR-XXX-<slug>.md`.
@@ -25,3 +31,10 @@ ADR-001 Rust as primary language — Accepted
 - Context: Safety (memory correctness), performance, strong tooling, suitability for long-running services with low overhead and predictable behavior. Owner prefers Rust for control and reliability.
 - Decision: Implement spinal_cord/services in Rust; prefer Rust-first libs; keep interfaces simple for future polyglot modules.
 - Consequences: Higher initial complexity vs scripting, but better long-term stability; need strict coding guidelines and documentation to mitigate onboarding cost.
+
+ADR-002 Лимфатический фильтр — Accepted
+- Date: 2025-02-14
+- Responsible: С. Иванов
+- Context: Требуется очистка входящих сигналов и защита от вредных артефактов.
+- Decision: Принять подсистему «Лимфатический фильтр» для анализа и фильтрации данных.
+- Consequences: Повышает устойчивость и безопасность, но требует мониторинга расхода ресурсов.


### PR DESCRIPTION
## Summary
- add decision entry for subsystem "Лимфатический фильтр"
- document lymphatic_filter capability as experimental
- show example neira:meta block for `lymphatic_filter.md`

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bb354eff708323a9094c2e3b75fa1f