### PR TITLE
chore: заменить блоковый neira:meta на однострочный

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "syn",
  "sysinfo",
  "thiserror",
  "tokio",
@@ -200,6 +201,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "walkdir",
  "zip",
 ]
 

--- a/spinal_cord/Cargo.toml
+++ b/spinal_cord/Cargo.toml
@@ -44,11 +44,10 @@ serde_yaml = "0.9"
 # intent: chore
 # summary: Заменена зависимость serde-xml-rs на quick-xml для разбора XML.
 quick-xml = { version = "0.31", features = ["serialize"] }
-/* neira:meta
-id: NEI-20270615-lymphatic-deps
-intent: chore
-summary: Добавлены зависимости walkdir и syn для лимфатического фильтра.
-*/
+# neira:meta
+# id: NEI-20270615-lymphatic-deps
+# intent: chore
+# summary: Добавлены зависимости walkdir и syn для лимфатического фильтра.
 walkdir = "2"
 syn = { version = "2", features = ["full"] }
 toml = "0.8"


### PR DESCRIPTION
## Summary
- привести блок neira:meta в spinal_cord/Cargo.toml к однострочному формату
- обновить Cargo.lock для синхронизации манифеста

## Testing
- `cargo fmt --all`
- `rg '/\*' spinal_cord/Cargo.toml`
- `cargo check` *(ошибка: cannot find type `PathBuf` in this scope, Signature doesn't implement Debug, syn::Block doesn't implement Debug, no method named `parse_meta`)*
- `cargo test` *(ошибка: cannot find type `PathBuf` in this scope, Signature doesn't implement Debug, syn::Block doesn't implement Debug, no method named `parse_meta`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4aaa6bf88323afe18956f49787dc