### PR TITLE
ci: group duplicate crates in ps check

### DIFF
--- a/scripts/check-duplicates.ps1
+++ b/scripts/check-duplicates.ps1
@@ -2,6 +2,10 @@
 # id: NEI-20250904-check-duplicates-ps1
 # intent: ci
 # summary: PowerShell-скрипт для локальной проверки дублей зависимостей с игнором Windows/WASI семейств.
+# neira:meta
+# id: NEI-20250905-group-duplicates
+# intent: ci
+# summary: Группирует дубли по crate и выводит только блоки с несколькими версиями; синхронизирован regex allowlist.
 
 param()
 Set-StrictMode -Version Latest
@@ -37,20 +41,38 @@ if ($raw -match '^nothing to print\s*$') {
   exit 0
 }
 
-# Разбиваем на абзацы по пустой строке
+# Разбиваем вывод на абзацы и группируем по имени crate
 $paragraphs = $raw -split "(\r?\n){2,}" | Where-Object { $_.Trim().Length -gt 0 }
-$filtered = @()
+$groups = @{}
 foreach ($para in $paragraphs) {
-  $first = ($para -split "\r?\n")[0].Trim()
+  $lines = $para -split "\r?\n"
+  $first = $lines[0].Trim()
   if (-not $first) { continue }
-  $name = ($first -split '\s+')[0]
+  $parts = $first -split '\s+'
+  if ($parts.Count -lt 2) { continue }
+  $name = $parts[0]
+  $ver = $parts[1]
   # Ignore known Windows/WASI families (transitive duplicates upstream)
-  if ($name -match '^(wasi|windows([_-].*)?|windows_[A-Za-z0-9_]+)$') { continue }
-  $filtered += $para
+  if ($name -match '^(wasi|windows(|-sys|-core|-targets)|windows_[A-Za-z0-9_]+)$') { continue }
+  if (-not $groups.ContainsKey($name)) {
+    $groups[$name] = @{
+      Versions = [System.Collections.Generic.HashSet[string]]::new()
+      Blocks   = New-Object System.Collections.Generic.List[string]
+    }
+  }
+  $null = $groups[$name].Versions.Add($ver)
+  $null = $groups[$name].Blocks.Add($para)
 }
 
-if ($filtered.Count -gt 0) {
-  $filtered -join "`n`n" | Write-Output
+$toOutput = @()
+foreach ($entry in $groups.GetEnumerator()) {
+  if ($entry.Value.Versions.Count -gt 1) {
+    $toOutput += $entry.Value.Blocks
+  }
+}
+
+if ($toOutput.Count -gt 0) {
+  $toOutput -join "`n`n" | Write-Output
   Write-Error 'Duplicate crate versions detected (excluding Windows/WASI families).'
   exit 1
 }


### PR DESCRIPTION
## Summary
- group cargo tree duplicates by crate in PowerShell script
- skip Windows/WASI families using unified allowlist

## Testing
- `pwsh -NoLogo -File scripts/check-duplicates.ps1`
- `bash scripts/check-duplicates.sh` *(fails: Duplicate crate versions detected (excluding known Windows/WASI families).)*

------
https://chatgpt.com/codex/tasks/task_e_68bba29417f08323a52a93529608e0fa