### PR TITLE
feat(git): custom merge driver for Cargo.toml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,19 @@
+# neira:meta
+# id: NEI-20270311-120000-cargo-merge-driver
+# intent: chore
+# summary: |
+#   Настроен merge driver cargo-toml для безопасного объединения зависимостей.
+
 # Унифицируем переносы строк (все файлы в LF)
 * text=auto eol=lf
 
 # Автоматическое поведение при конфликте:
 # - Cargo.lock всегда брать из удалённой ветки (theirs)
 Cargo.lock merge=theirs
+
+# Манифесты Cargo: использовать кастомный merge driver
+Cargo.toml merge=cargo-toml
+**/Cargo.toml merge=cargo-toml
 
 # Сгенерированные артефакты: не диффить и всегда брать "наши"
 generated/** merge=ours -diff

--- a/scripts/merge-cargo-toml.sh
+++ b/scripts/merge-cargo-toml.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# neira:meta
+# id: NEI-20270311-120010-merge-cargo-script
+# intent: chore
+# summary: |
+#   Объединяет варианты Cargo.toml через toml-merge с проверкой целостности.
+
+set -euo pipefail
+
+base="$1"
+ours="$2"
+theirs="$3"
+
+if ! command -v toml-merge >/dev/null 2>&1; then
+  echo "Ошибка: toml-merge не найден. Установите: cargo install toml-merge" >&2
+  exit 1
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+toml-merge "$base" "$ours" "$theirs" >"$tmp"
+
+if command -v tomlq >/dev/null 2>&1; then
+  tomlq -r '.' "$tmp" >/dev/null || {
+    echo "Ошибка: некорректный TOML после объединения" >&2
+    exit 1
+  }
+fi
+
+mv "$tmp" "$ours"

--- a/scripts/setup-git-attributes.sh
+++ b/scripts/setup-git-attributes.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# neira:meta
+# id: NEI-20270311-120020-setup-git-attrs
+# intent: chore
+# summary: |
+#   Регистрирует merge driver cargo-toml в локальной конфигурации Git.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config merge.cargo-toml.driver 'bash scripts/merge-cargo-toml.sh %O %A %B'


### PR DESCRIPTION
## Summary
- configure custom cargo-toml merge driver in git attributes
- add merge helper script using toml-merge
- provide setup script registering merge driver

## Testing
- `pre-commit run --files .gitattributes scripts/merge-cargo-toml.sh scripts/setup-git-attributes.sh`
- `cargo test`
- `bash scripts/setup-git-attributes.sh`
- `git config --get merge.cargo-toml.driver`
- `scripts/merge-cargo-toml.sh /tmp/base.toml /tmp/ours.toml /tmp/theirs.toml`

------
https://chatgpt.com/codex/tasks/task_e_68bbc1cbb71c8323a2989c8d409b03d9