### PR TITLE
fix: restore sensory_organs vite dependency

### DIFF
--- a/sensory_organs/package.json
+++ b/sensory_organs/package.json
@@ -9,5 +9,8 @@
     "start": "vite preview",
     "test": "echo \"No tests\""
   },
+  "devDependencies": {
+    "vite": "workspace:^7.1.4"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add a local devDependency on vite for the sensory_organs workspace so pnpm can link it

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f4350c709c8323800643786f9061a6