### PR TITLE
fix: traverse nested items in lymphatic filter scanner

### DIFF
--- a/spinal_cord/src/immune_system/lymphatic_filter.rs
+++ b/spinal_cord/src/immune_system/lymphatic_filter.rs
@@ -13,7 +13,7 @@ use std::{
     path::{Path, PathBuf},
     time::UNIX_EPOCH,
 };
-use syn::{visit::Visit, ImplItemMethod, Item, ItemFn};
+use syn::{visit::Visit, ImplItemMethod, Item, ItemFn, ItemMod};
 use walkdir::WalkDir;
 
 /// Отчёт о найденном дубликате функции.
@@ -69,6 +69,14 @@ impl<'ast> Visit<'ast> for FnCollector {
         self.functions
             .push(fingerprint(&item_fn, self.file.clone()));
         syn::visit::visit_impl_item_method(self, node);
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        if let Some((_, items)) = &node.content {
+            for item in items {
+                self.visit_item(item);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the lymphatic fingerprint collector descends into inline modules while visiting syntax trees
- keep recording inherent methods by converting impl methods into temporary function items before fingerprinting

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing for the pinned toolchain)*
- `cargo test --quiet` *(fails: existing duplicate dependency entries in spinal_cord/Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68f6fe47f8688323968e15824055cd24