### PR TITLE
fix(ci): ensure cargo-edit available during manifest merge fallback

### DIFF
--- a/.github/workflows/pr-conflict-fixer.yml
+++ b/.github/workflows/pr-conflict-fixer.yml
@@ -38,6 +38,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      - name: Ensure cargo-edit is available
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v cargo >/dev/null 2>&1; then
+            echo "cargo is not available on runner; cannot install cargo-edit" >&2
+            exit 1
+          fi
+          if ! cargo --list 2>/dev/null | grep -q '\bcargo-add\b'; then
+            cargo install cargo-edit --locked
+          fi
+
       - name: Setup git
         run: |
           git config user.name "github-actions[bot]"

--- a/scripts/merge-manifest.sh
+++ b/scripts/merge-manifest.sh
@@ -33,6 +33,14 @@ merge_cargo() {
     mv "$ours_tmp" "$file"
     rm -f "$theirs_tmp"
   else
+    if ! command -v cargo >/dev/null 2>&1; then
+      echo "cargo executable not found; install Rust toolchain or provide tomlq for manifest merging" >&2
+      return 1
+    fi
+    if ! cargo add --version >/dev/null 2>&1; then
+      echo "cargo add (cargo-edit) is required for manifest merge fallback; install via 'cargo install cargo-edit --locked' or make tomlq available" >&2
+      return 1
+    fi
     local ours_dir theirs_dir
     ours_dir="$(mktemp -d)"
     theirs_dir="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- guard the manifest merge fallback against missing cargo or cargo add
- install cargo-edit in the PR conflict fixer workflow so the fallback path can run on GitHub runners

## Testing
- `bash -n scripts/merge-manifest.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f700fc10ac83238fe4755f4d6284c1