### PR TITLE
fix: align concurrency keys for conflict workflows

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -34,7 +34,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-conflict-${{ github.ref }}
+  group: pr-conflict-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-conflict-fixer.yml
+++ b/.github/workflows/pr-conflict-fixer.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: pr-conflict-${{ github.ref }}
+  group: pr-conflict-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary
- key both conflict-resolution workflows' concurrency groups off of the PR head ref
- ensure automation touching the same pull request branch serializes correctly regardless of trigger

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f703f1abe48323a5068a77971c3f61