### PR TITLE
chore: dedupe quote dependency in spinal_cord

### DIFF
--- a/spinal_cord/Cargo.toml
+++ b/spinal_cord/Cargo.toml
@@ -78,10 +78,9 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 tower-http = { version = "0.6", features = ["cors"] }
 
 # neira:meta
-# id: NEI-20270920-lymphatic-quote-dep
+# id: NEI-20271005-quote-dedupe
 # intent: chore
-# summary: Добавлена зависимость quote для токенизации AST в лимфатическом фильтре.
-quote = "1"
+# summary: Удалён дублирующийся dependency quote = "1".
 
 # neira:meta
 # id: NEI-20270904-windows-wasi-patch


### PR DESCRIPTION
## Summary
- remove the duplicate `quote` dependency entry from `spinal_cord/Cargo.toml`
- document the cleanup with a neira:meta note to keep dependency history tidy

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f8d0114470832399d216b2146150d8