### PR TITLE
Add voice organ integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64",
  "chrono",
  "dotenvy",
  "flate2",

--- a/docs/design/organ-systems.md
+++ b/docs/design/organ-systems.md
@@ -45,7 +45,9 @@ summary: |
   - Метрики: hearing_minutes_captured, stt_latency_ms, stt_tokens
 
 - Voice System (речь)
-  - Клетки: TTS
+  - Клетки: text_normalize → text_to_phonemes → speak_adapter (analysis) + speak_adapter (action)
+  - Встроенный кодек WAV и опциональные внешние команды TTS/STT через окружение
+  - API: POST /voice/speak, POST /voice/transcribe; результаты кешируются в VoiceOrgan
   - Гейт: organ_voice (experimental)
   - Safe‑mode: чтение допустимо
 

--- a/docs/guides/voice-v1-runbook.md
+++ b/docs/guides/voice-v1-runbook.md
@@ -63,6 +63,11 @@ Steps (PowerShell)
 - Убедитесь, что в каталоге `templates/` появились файлы `analysis.*.json`.
 - Перезапустите spinal_cord — CellRegistry загрузит шаблоны из каталога (есть файловый watcher).
 - Проверьте `/cells/:id` (или Admin UI) и `logs/factory_audit.ndjson`.
+
+HTTP API голосового органа
+- `POST /voice/speak` — вход: `{ "text": "Привет" }` или `{ "normalized": "привет" }`. Ответ содержит `request_id`, путь к WAV и base64 аудио.
+- `POST /voice/transcribe` — вход: `{ "audio_base64": "..." }` или `{ "file_path": "voice_output/voice-1.wav" }`. Ответ: `request_id`, текст.
+- Переменные окружения: `VOICE_BACKEND`, `VOICE_TTS_CMD`, `VOICE_STT_CMD`, `VOICE_PLAY_CMD`, `VOICE_OUTPUT_DIR`.
   Notes
 - Organ Builder (маршруты `/organs/*`) пока не реализован — работаем на уровне клеток.
 - Политики/гейты: ошибки приходят JSON `{ code, reason, capability }`; включение адаптера — `FACTORY_ADAPTER_ENABLED=1`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -224,3 +224,4 @@ Consistency & Taxonomy
 5) Voice v1 pipeline
 - Клетки: `analysis.text_normalize.v1`, `analysis.text_to_phonemes.v1`, `analysis.speak_adapter.v1`.
 - Орган: `organ.voice.v1` (normalize→phonemes→speak_adapter); dry‑run→canary; метрики organ_build_* и factory_*.
+- Реализация: VoiceOrgan регистрирует клетки, TTS/STT доступны через `/voice/speak` и `/voice/transcribe`.

--- a/spinal_cord/Cargo.lock
+++ b/spinal_cord/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "dotenvy",
  "flate2",
@@ -372,6 +373,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "quick-xml",
+ "quote",
  "regex",
  "reqwest",
  "semver",
@@ -380,6 +382,8 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2",
+ "strsim",
+ "syn 2.0.106",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.16",
@@ -393,6 +397,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "trybuild",
+ "walkdir",
  "zip",
 ]
 
@@ -2481,6 +2486,12 @@ dependencies = [
  "phf_shared",
  "precomputed-hash",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/spinal_cord/Cargo.toml
+++ b/spinal_cord/Cargo.toml
@@ -20,6 +20,7 @@ axum = { git = "https://github.com/tokio-rs/axum", rev = "ee1519c82f60fc3a14890d
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread", "sync", "io-util", "net", "time", "fs", "signal", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 dotenvy = "0.15"
 jsonschema-valid = "0.5.2"
 once_cell = "1"

--- a/spinal_cord/src/lib.rs
+++ b/spinal_cord/src/lib.rs
@@ -74,6 +74,7 @@ intent: code
 summary: Экспортирован модуль event_log.
 */
 pub mod event_log;
+pub mod voice;
 
 /* neira:meta
 id: NEI-20240513-lib-test-allow

--- a/spinal_cord/src/voice/backend.rs
+++ b/spinal_cord/src/voice/backend.rs
@@ -1,0 +1,229 @@
+/* neira:meta
+id: NEI-20280105-voice-backend
+intent: code
+summary: |
+  Бэкенды голосового контура: командный исполнитель и офлайн кодек,
+  обеспечивающие двустороннее преобразование текста и аудио.
+*/
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use crate::hearing;
+
+use super::error::VoiceError;
+
+pub trait VoiceBackend: Send + Sync {
+    fn synthesize(&self, text: &str) -> Result<Vec<u8>, VoiceError>;
+    fn transcribe(&self, audio: &[u8]) -> Result<String, VoiceError>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VoiceBackendMode {
+    Codec,
+    Command,
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandVoiceBackend {
+    tts_program: String,
+    tts_args: Vec<String>,
+    stt_program: String,
+    stt_args: Vec<String>,
+}
+
+impl CommandVoiceBackend {
+    pub fn new(
+        tts_program: String,
+        tts_args: Vec<String>,
+        stt_program: String,
+        stt_args: Vec<String>,
+    ) -> Self {
+        Self {
+            tts_program,
+            tts_args,
+            stt_program,
+            stt_args,
+        }
+    }
+
+    fn run_command(
+        program: &str,
+        args: &[String],
+        input: Option<&[u8]>,
+    ) -> Result<Vec<u8>, VoiceError> {
+        let mut cmd = Command::new(program);
+        cmd.args(args);
+        if input.is_some() {
+            cmd.stdin(Stdio::piped());
+        }
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let mut child = cmd.spawn()?;
+        if let Some(data) = input {
+            if let Some(stdin) = child.stdin.as_mut() {
+                stdin.write_all(data)?;
+            }
+        }
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            hearing::warn(&format!(
+                "voice command failed; program={} code={:?} stderr={}",
+                program,
+                output.status.code(),
+                stderr
+            ));
+            return Err(VoiceError::Command(format!(
+                "команда {program} завершилась с кодом {:?}",
+                output.status.code()
+            )));
+        }
+        Ok(output.stdout)
+    }
+}
+
+impl VoiceBackend for CommandVoiceBackend {
+    fn synthesize(&self, text: &str) -> Result<Vec<u8>, VoiceError> {
+        Self::run_command(&self.tts_program, &self.tts_args, Some(text.as_bytes()))
+    }
+
+    fn transcribe(&self, audio: &[u8]) -> Result<String, VoiceError> {
+        let stdout = Self::run_command(&self.stt_program, &self.stt_args, Some(audio))?;
+        let text = String::from_utf8(stdout)?.trim().to_string();
+        Ok(text)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CodecVoiceBackend {
+    sample_rate: u32,
+}
+
+impl Default for CodecVoiceBackend {
+    fn default() -> Self {
+        Self {
+            sample_rate: 16_000,
+        }
+    }
+}
+
+impl CodecVoiceBackend {
+    pub fn new(sample_rate: u32) -> Self {
+        Self { sample_rate }
+    }
+
+    fn encode(&self, text: &str) -> Result<Vec<u8>, VoiceError> {
+        let chars: Vec<char> = text.chars().collect();
+        let samples = chars.len() * 2;
+        let data_size = (samples * 2) as u32;
+        let mut buffer = Vec::with_capacity(44 + data_size as usize);
+        buffer.extend_from_slice(b"RIFF");
+        buffer.extend_from_slice(&(36 + data_size).to_le_bytes());
+        buffer.extend_from_slice(b"WAVE");
+        buffer.extend_from_slice(b"fmt ");
+        buffer.extend_from_slice(&16u32.to_le_bytes());
+        buffer.extend_from_slice(&1u16.to_le_bytes());
+        buffer.extend_from_slice(&1u16.to_le_bytes());
+        buffer.extend_from_slice(&self.sample_rate.to_le_bytes());
+        let byte_rate = self.sample_rate * 2;
+        buffer.extend_from_slice(&byte_rate.to_le_bytes());
+        buffer.extend_from_slice(&2u16.to_le_bytes());
+        buffer.extend_from_slice(&16u16.to_le_bytes());
+        buffer.extend_from_slice(b"data");
+        buffer.extend_from_slice(&data_size.to_le_bytes());
+        for ch in chars {
+            let code = ch as u32;
+            let lower = (code & 0xFFFF) as u16;
+            let upper = ((code >> 16) & 0xFFFF) as u16;
+            buffer.extend_from_slice(&lower.to_le_bytes());
+            buffer.extend_from_slice(&upper.to_le_bytes());
+        }
+        Ok(buffer)
+    }
+
+    fn decode(&self, audio: &[u8]) -> Result<String, VoiceError> {
+        if audio.len() < 44 {
+            return Err(VoiceError::with_context("слишком короткий WAV"));
+        }
+        if &audio[0..4] != b"RIFF" || &audio[8..12] != b"WAVE" {
+            return Err(VoiceError::with_context("неподдерживаемый формат WAV"));
+        }
+        if &audio[12..16] != b"fmt " {
+            return Err(VoiceError::with_context("отсутствует блок fmt"));
+        }
+        let bits_per_sample = u16::from_le_bytes([audio[34], audio[35]]);
+        if bits_per_sample != 16 {
+            return Err(VoiceError::with_context(
+                "поддерживается только 16-битный PCM",
+            ));
+        }
+        let channels = u16::from_le_bytes([audio[22], audio[23]]);
+        if channels != 1 {
+            return Err(VoiceError::with_context("поддерживается только моно"));
+        }
+        let mut offset = 36;
+        while offset + 8 <= audio.len() {
+            let chunk_id = &audio[offset..offset + 4];
+            let chunk_size = u32::from_le_bytes([
+                audio[offset + 4],
+                audio[offset + 5],
+                audio[offset + 6],
+                audio[offset + 7],
+            ]) as usize;
+            offset += 8;
+            if chunk_id == b"data" {
+                if offset + chunk_size > audio.len() {
+                    return Err(VoiceError::with_context("повреждённый блок data"));
+                }
+                let data = &audio[offset..offset + chunk_size];
+                if data.len() % 4 != 0 {
+                    return Err(VoiceError::with_context(
+                        "длина блока data не кратна четырём",
+                    ));
+                }
+                let mut text = String::new();
+                for chunk in data.chunks_exact(4) {
+                    let lower = u16::from_le_bytes([chunk[0], chunk[1]]) as u32;
+                    let upper = u16::from_le_bytes([chunk[2], chunk[3]]) as u32;
+                    let code = lower | (upper << 16);
+                    match char::from_u32(code) {
+                        Some(ch) => text.push(ch),
+                        None => {
+                            return Err(VoiceError::with_context("получен неверный код символа"));
+                        }
+                    }
+                }
+                return Ok(text);
+            } else {
+                offset += chunk_size;
+            }
+        }
+        Err(VoiceError::with_context("в WAV нет блока data"))
+    }
+}
+
+impl VoiceBackend for CodecVoiceBackend {
+    fn synthesize(&self, text: &str) -> Result<Vec<u8>, VoiceError> {
+        self.encode(text)
+    }
+
+    fn transcribe(&self, audio: &[u8]) -> Result<String, VoiceError> {
+        self.decode(audio)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CodecVoiceBackend, VoiceBackend};
+
+    #[test]
+    fn codec_roundtrip_preserves_text() {
+        let backend = CodecVoiceBackend::default();
+        let phrase = "Привет, Нейра!";
+        let wav = backend.synthesize(phrase).expect("encode");
+        assert!(wav.len() > 44);
+        let decoded = backend.transcribe(&wav).expect("decode");
+        assert_eq!(decoded, phrase);
+    }
+}

--- a/spinal_cord/src/voice/cells.rs
+++ b/spinal_cord/src/voice/cells.rs
@@ -1,0 +1,329 @@
+/* neira:meta
+id: NEI-20280105-voice-cells
+intent: code
+summary: |
+  Клетки голосового контура: нормализация текста, фонемизация и адаптер
+  речи с действием проигрывания.
+*/
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+use crate::action_cell::ActionCell;
+use crate::action_engine::{ActionCommand, ActionEngine, ActionError};
+use crate::analysis_cell::{AnalysisCell, AnalysisResult, CellStatus};
+use crate::digestive_pipeline::ParsedInput;
+use crate::hearing;
+use crate::memory_cell::MemoryCell;
+
+use super::organ::{VoiceOrgan, VoiceSynthesis};
+use super::phonemes::phonemize;
+use super::VoiceError;
+
+pub const TEXT_NORMALIZE_ID: &str = "analysis.text_normalize.v1";
+pub const TEXT_TO_PHONEMES_ID: &str = "analysis.text_to_phonemes.v1";
+pub const SPEAK_ADAPTER_ID: &str = "analysis.speak_adapter.v1";
+pub const SPEAK_ACTION_ID: &str = "action.speak_adapter.v1";
+
+fn extract_text(input: &ParsedInput) -> Option<String> {
+    match input {
+        ParsedInput::Json(v) => v
+            .get("text")
+            .and_then(|t| t.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| v.as_str().map(|s| s.to_string())),
+        ParsedInput::Text(t) => Some(t.clone()),
+    }
+}
+
+fn analysis_error(id: &str, message: &str) -> AnalysisResult {
+    let mut res = AnalysisResult::new(id, message, vec![message.to_string()]);
+    res.status = CellStatus::Error;
+    res.explanation = Some(message.to_string());
+    res
+}
+
+pub struct VoiceTextNormalizeCell;
+
+impl VoiceTextNormalizeCell {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for VoiceTextNormalizeCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisCell for VoiceTextNormalizeCell {
+    fn id(&self) -> &str {
+        TEXT_NORMALIZE_ID
+    }
+
+    fn analysis_type(&self) -> &str {
+        "text_normalize"
+    }
+
+    fn status(&self) -> CellStatus {
+        CellStatus::Active
+    }
+
+    fn links(&self) -> &[String] {
+        &[]
+    }
+
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
+
+    fn analyze_parsed(&self, input: &ParsedInput, _: &CancellationToken) -> AnalysisResult {
+        let Some(text) = extract_text(input) else {
+            return analysis_error(TEXT_NORMALIZE_ID, "не удалось извлечь текст");
+        };
+        let trimmed = text.trim();
+        let normalized = trimmed
+            .split_whitespace()
+            .filter(|chunk| !chunk.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let lower = normalized.to_lowercase();
+        let output = json!({
+            "text": text,
+            "normalized": lower,
+        });
+        let mut result = AnalysisResult::new(
+            TEXT_NORMALIZE_ID,
+            output.to_string(),
+            vec!["удалены лишние пробелы".to_string()],
+        );
+        result.metadata.schema = "voice.text_normalize/1.0".into();
+        result
+    }
+
+    fn explain(&self) -> String {
+        "Приводит фразы к единому виду перед синтезом".into()
+    }
+}
+
+pub struct VoiceTextToPhonemesCell;
+
+impl VoiceTextToPhonemesCell {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for VoiceTextToPhonemesCell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AnalysisCell for VoiceTextToPhonemesCell {
+    fn id(&self) -> &str {
+        TEXT_TO_PHONEMES_ID
+    }
+
+    fn analysis_type(&self) -> &str {
+        "text_to_phonemes"
+    }
+
+    fn status(&self) -> CellStatus {
+        CellStatus::Active
+    }
+
+    fn links(&self) -> &[String] {
+        &[]
+    }
+
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
+
+    fn analyze_parsed(&self, input: &ParsedInput, _: &CancellationToken) -> AnalysisResult {
+        let Some(base_text) = extract_text(input) else {
+            return analysis_error(TEXT_TO_PHONEMES_ID, "не удалось извлечь текст");
+        };
+        let normalized = match input {
+            ParsedInput::Json(v) => v
+                .get("normalized")
+                .and_then(|t| t.as_str())
+                .unwrap_or(base_text.as_str())
+                .to_string(),
+            ParsedInput::Text(_) => base_text.clone(),
+        };
+        let phonemes = phonemize(&normalized);
+        let output = json!({
+            "text": base_text,
+            "normalized": normalized,
+            "phonemes": phonemes,
+        });
+        let mut result = AnalysisResult::new(
+            TEXT_TO_PHONEMES_ID,
+            output.to_string(),
+            vec!["подготовлены фонемы".to_string()],
+        );
+        result.metadata.schema = "voice.text_to_phonemes/1.0".into();
+        result
+    }
+
+    fn explain(&self) -> String {
+        "Готовит фонемный ряд для синтеза речи".into()
+    }
+}
+
+#[derive(Deserialize)]
+struct SpeakPayload {
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    normalized: Option<String>,
+    #[serde(default)]
+    phonemes: Option<String>,
+}
+
+pub struct VoiceSpeakAdapterCell {
+    organ: Arc<VoiceOrgan>,
+}
+
+impl VoiceSpeakAdapterCell {
+    pub fn new(organ: Arc<VoiceOrgan>) -> Self {
+        Self { organ }
+    }
+
+    fn synthesize(&self, payload: SpeakPayload) -> Result<VoiceSynthesis, VoiceError> {
+        let text = payload
+            .normalized
+            .or(payload.text)
+            .ok_or_else(|| VoiceError::with_context("отсутствует текст для синтеза"))?;
+        let phonemes = payload.phonemes.unwrap_or_else(|| phonemize(&text));
+        self.organ
+            .synthesize(payload.request_id.as_deref(), &text, Some(&phonemes))
+    }
+}
+
+impl AnalysisCell for VoiceSpeakAdapterCell {
+    fn id(&self) -> &str {
+        SPEAK_ADAPTER_ID
+    }
+
+    fn analysis_type(&self) -> &str {
+        "speak_adapter"
+    }
+
+    fn status(&self) -> CellStatus {
+        CellStatus::Active
+    }
+
+    fn links(&self) -> &[String] {
+        &[]
+    }
+
+    fn confidence_threshold(&self) -> f32 {
+        0.0
+    }
+
+    fn analyze_parsed(
+        &self,
+        input: &ParsedInput,
+        cancel_token: &CancellationToken,
+    ) -> AnalysisResult {
+        if cancel_token.is_cancelled() {
+            return analysis_error(SPEAK_ADAPTER_ID, "запрос синтеза отменён");
+        }
+        let payload: SpeakPayload = match input {
+            ParsedInput::Json(v) => {
+                serde_json::from_value(v.clone()).unwrap_or_else(|_| SpeakPayload {
+                    request_id: None,
+                    text: v.as_str().map(|s| s.to_string()),
+                    normalized: None,
+                    phonemes: None,
+                })
+            }
+            ParsedInput::Text(t) => SpeakPayload {
+                request_id: None,
+                text: Some(t.clone()),
+                normalized: None,
+                phonemes: None,
+            },
+        };
+        match self.synthesize(payload) {
+            Ok(synth) => {
+                hearing::info(&format!("voice synthesis готов; id={}", synth.request_id));
+                let output = json!({
+                    "request_id": synth.request_id,
+                    "file": synth.file_path,
+                    "audio_base64": synth.audio_base64,
+                    "text": synth.text,
+                    "phonemes": synth.phonemes,
+                });
+                let mut result = AnalysisResult::new(
+                    SPEAK_ADAPTER_ID,
+                    output.to_string(),
+                    vec!["аудиофайл сохранён".to_string()],
+                );
+                result.metadata.schema = "voice.speak_adapter/1.0".into();
+                result
+            }
+            Err(err) => analysis_error(SPEAK_ADAPTER_ID, &format!("ошибка синтеза: {err}")),
+        }
+    }
+
+    fn explain(&self) -> String {
+        "Запускает TTS и сохраняет аудио".into()
+    }
+}
+
+pub struct VoiceSpeakActionCell {
+    organ: Arc<VoiceOrgan>,
+}
+
+impl VoiceSpeakActionCell {
+    pub fn new(organ: Arc<VoiceOrgan>) -> Self {
+        Self { organ }
+    }
+}
+
+#[async_trait]
+impl ActionCell for VoiceSpeakActionCell {
+    fn id(&self) -> &str {
+        SPEAK_ACTION_ID
+    }
+
+    fn preload(&self, _triggers: &[String], _memory: &Arc<MemoryCell>) {}
+
+    fn command(&self) -> Option<ActionCommand> {
+        None
+    }
+
+    async fn execute(&self, engine: &ActionEngine) -> Result<Option<String>, ActionError> {
+        let Some(latest) = self.organ.latest_output() else {
+            return Ok(Some("нет готового аудио для воспроизведения".to_string()));
+        };
+        if let Some(cfg) = self.organ.play_command_config() {
+            let path = latest.file_path.to_string_lossy().to_string();
+            let args = cfg
+                .args
+                .iter()
+                .map(|arg| arg.replace("{file}", &path))
+                .collect::<Vec<_>>();
+            let response = engine
+                .execute(ActionCommand::RunCommand {
+                    program: cfg.program.clone(),
+                    args,
+                })
+                .await?;
+            Ok(Some(response))
+        } else {
+            Ok(Some(latest.file_path.to_string_lossy().to_string()))
+        }
+    }
+}

--- a/spinal_cord/src/voice/error.rs
+++ b/spinal_cord/src/voice/error.rs
@@ -1,0 +1,35 @@
+/* neira:meta
+id: NEI-20280105-voice-error
+intent: code
+summary: |-
+  Унифицированная ошибка голосового контура: покрывает I/O, команды,
+  декодирование и интеграцию с фабрикой.
+*/
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum VoiceError {
+    #[error("ошибка ввода-вывода: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("неверные данные: {0}")]
+    InvalidInput(String),
+    #[error("ошибка внешней команды: {0}")]
+    Command(String),
+    #[error("ошибка преобразования UTF-8: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
+    #[error("ошибка base64: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("ошибка JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("ошибка схемы фабрики: {0}")]
+    Validation(String),
+    #[error("недоступен SynapseHub для голосового органа")]
+    HubUnavailable,
+}
+
+impl VoiceError {
+    pub fn with_context(msg: impl Into<String>) -> Self {
+        VoiceError::InvalidInput(msg.into())
+    }
+}

--- a/spinal_cord/src/voice/mod.rs
+++ b/spinal_cord/src/voice/mod.rs
@@ -1,0 +1,17 @@
+/* neira:meta
+id: NEI-20280105-voice-module
+intent: code
+summary: |
+  Голосовой контур: конфигурация, бэкенды TTS/STT и клетки органа речи
+  с интеграцией фабрики и HTTP-обработчиками.
+*/
+
+pub mod backend;
+pub mod cells;
+pub mod error;
+pub mod organ;
+pub mod phonemes;
+
+pub use backend::{CodecVoiceBackend, CommandVoiceBackend, VoiceBackend, VoiceBackendMode};
+pub use error::VoiceError;
+pub use organ::{VoiceConfig, VoiceOrgan, VoiceSynthesis, VoiceTranscription};

--- a/spinal_cord/src/voice/organ.rs
+++ b/spinal_cord/src/voice/organ.rs
@@ -1,0 +1,382 @@
+/* neira:meta
+id: NEI-20280105-voice-organ
+intent: code
+summary: |
+  Орган речи: конфигурация из окружения, регистрация клеток в фабрике
+  и синхронный API TTS/STT с хранением последнего результата.
+*/
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock, Weak};
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde::Serialize;
+
+use crate::cell_registry::CellRegistry;
+use crate::cell_template::{ActionCellTemplate, CellTemplate, Metadata};
+use crate::hearing;
+use crate::synapse_hub::SynapseHub;
+
+use super::backend::{CodecVoiceBackend, CommandVoiceBackend, VoiceBackend, VoiceBackendMode};
+use super::cells::{
+    VoiceSpeakActionCell, VoiceSpeakAdapterCell, VoiceTextNormalizeCell, VoiceTextToPhonemesCell,
+    SPEAK_ACTION_ID, SPEAK_ADAPTER_ID, TEXT_NORMALIZE_ID, TEXT_TO_PHONEMES_ID,
+};
+use super::phonemes::phonemize;
+use super::VoiceError;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct VoiceSynthesis {
+    pub request_id: String,
+    pub file_path: PathBuf,
+    pub audio_base64: String,
+    pub text: String,
+    pub phonemes: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct VoiceTranscription {
+    pub request_id: String,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandConfig {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct VoiceConfig {
+    pub backend_mode: VoiceBackendMode,
+    pub output_dir: PathBuf,
+    pub sample_rate: u32,
+    pub play_command: Option<CommandConfig>,
+    pub tts_command: Option<CommandConfig>,
+    pub stt_command: Option<CommandConfig>,
+}
+
+impl VoiceConfig {
+    pub fn from_env() -> Self {
+        let backend_mode = std::env::var("VOICE_BACKEND")
+            .map(|v| v.to_lowercase())
+            .map(|v| {
+                if v == "command" {
+                    VoiceBackendMode::Command
+                } else {
+                    VoiceBackendMode::Codec
+                }
+            })
+            .unwrap_or(VoiceBackendMode::Codec);
+        let output_dir = std::env::var("VOICE_OUTPUT_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("voice_output"));
+        let sample_rate = std::env::var("VOICE_SAMPLE_RATE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(16_000);
+        let play_command = parse_command("VOICE_PLAY_CMD", "VOICE_PLAY_ARGS");
+        let tts_command = parse_command("VOICE_TTS_CMD", "VOICE_TTS_ARGS");
+        let stt_command = parse_command("VOICE_STT_CMD", "VOICE_STT_ARGS");
+        Self {
+            backend_mode,
+            output_dir,
+            sample_rate,
+            play_command,
+            tts_command,
+            stt_command,
+        }
+    }
+
+    pub fn resolve_backend(&self) -> (Arc<dyn VoiceBackend>, VoiceBackendMode) {
+        match self.backend_mode {
+            VoiceBackendMode::Command => {
+                if let (Some(tts), Some(stt)) = (&self.tts_command, &self.stt_command) {
+                    let backend: Arc<dyn VoiceBackend> = Arc::new(CommandVoiceBackend::new(
+                        tts.program.clone(),
+                        tts.args.clone(),
+                        stt.program.clone(),
+                        stt.args.clone(),
+                    ));
+                    (backend, VoiceBackendMode::Command)
+                } else {
+                    hearing::warn(
+                        "VOICE_BACKEND=command, но команды TTS/STT не заданы; используется кодек",
+                    );
+                    let backend: Arc<dyn VoiceBackend> =
+                        Arc::new(CodecVoiceBackend::new(self.sample_rate));
+                    (backend, VoiceBackendMode::Codec)
+                }
+            }
+            VoiceBackendMode::Codec => {
+                let backend: Arc<dyn VoiceBackend> =
+                    Arc::new(CodecVoiceBackend::new(self.sample_rate));
+                (backend, VoiceBackendMode::Codec)
+            }
+        }
+    }
+}
+
+fn parse_command(cmd_key: &str, args_key: &str) -> Option<CommandConfig> {
+    let program = std::env::var(cmd_key).ok()?;
+    let args = std::env::var(args_key)
+        .ok()
+        .map(parse_list)
+        .unwrap_or_default();
+    Some(CommandConfig { program, args })
+}
+
+fn parse_list(raw: String) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+pub struct VoiceOrgan {
+    hub: Weak<SynapseHub>,
+    registry: Arc<CellRegistry>,
+    backend: Arc<dyn VoiceBackend>,
+    backend_mode: VoiceBackendMode,
+    output_dir: PathBuf,
+    play_command: Option<CommandConfig>,
+    latest: RwLock<Option<VoiceSynthesis>>,
+    counter: AtomicU64,
+}
+
+impl VoiceOrgan {
+    pub fn new(
+        hub: Option<Arc<SynapseHub>>,
+        registry: Arc<CellRegistry>,
+        config: VoiceConfig,
+    ) -> Result<Arc<Self>, VoiceError> {
+        let (backend, mode) = config.resolve_backend();
+        if !config.output_dir.exists() {
+            fs::create_dir_all(&config.output_dir)?;
+        }
+        let organ = Arc::new(Self {
+            hub: hub.as_ref().map(Arc::downgrade).unwrap_or_else(Weak::new),
+            registry,
+            backend,
+            backend_mode: mode,
+            output_dir: config.output_dir.clone(),
+            play_command: config.play_command.clone(),
+            latest: RwLock::new(None),
+            counter: AtomicU64::new(1),
+        });
+        hearing::info(&format!(
+            "voice organ инициализирован; режим={:?} каталог={}",
+            organ.backend_mode,
+            organ.output_dir.display()
+        ));
+        Ok(organ)
+    }
+
+    pub fn bootstrap(self: &Arc<Self>) -> Result<(), VoiceError> {
+        self.ensure_templates()?;
+        self.register_cells();
+        Ok(())
+    }
+
+    fn ensure_templates(&self) -> Result<(), VoiceError> {
+        let hub = self.hub.upgrade();
+        let factory_enabled = hub
+            .as_ref()
+            .map(|h| h.factory_is_adapter_enabled())
+            .unwrap_or(false);
+        for tpl in analysis_templates() {
+            if self.registry.get(&tpl.id).is_none() {
+                self.registry
+                    .register_template(tpl.clone())
+                    .map_err(VoiceError::Validation)?;
+                metrics::counter!("voice_templates_registered_total", "kind" => "analysis")
+                    .increment(1);
+                if let Some(h) = hub.as_ref() {
+                    if factory_enabled {
+                        if let Err(err) = h.factory_create("adapter", &tpl) {
+                            hearing::warn(&format!("factory_create отказал: {err}"));
+                        }
+                    }
+                }
+            }
+        }
+        for tpl in action_templates() {
+            if self.registry.get_action_template(&tpl.id).is_none() {
+                self.registry
+                    .register_action_template(tpl.clone())
+                    .map_err(VoiceError::Validation)?;
+                metrics::counter!("voice_templates_registered_total", "kind" => "action")
+                    .increment(1);
+            }
+        }
+        Ok(())
+    }
+
+    fn register_cells(self: &Arc<Self>) {
+        if self.registry.get_analysis_cell(TEXT_NORMALIZE_ID).is_none() {
+            self.registry
+                .register_analysis_cell(Arc::new(VoiceTextNormalizeCell::new()));
+        }
+        if self
+            .registry
+            .get_analysis_cell(TEXT_TO_PHONEMES_ID)
+            .is_none()
+        {
+            self.registry
+                .register_analysis_cell(Arc::new(VoiceTextToPhonemesCell::new()));
+        }
+        if self.registry.get_analysis_cell(SPEAK_ADAPTER_ID).is_none() {
+            self.registry
+                .register_analysis_cell(Arc::new(VoiceSpeakAdapterCell::new(Arc::clone(self))));
+        }
+        let already_registered = self
+            .registry
+            .action_cells()
+            .iter()
+            .any(|cell| cell.id() == SPEAK_ACTION_ID);
+        if !already_registered {
+            self.registry
+                .register_action_cell(Arc::new(VoiceSpeakActionCell::new(Arc::clone(self))));
+        }
+    }
+
+    pub fn synthesize(
+        &self,
+        request_id: Option<&str>,
+        text: &str,
+        phonemes: Option<&str>,
+    ) -> Result<VoiceSynthesis, VoiceError> {
+        if text.trim().is_empty() {
+            return Err(VoiceError::with_context("пустой текст для синтеза"));
+        }
+        let id = request_id
+            .filter(|v| !v.is_empty())
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| format!("voice-{}", self.counter.fetch_add(1, Ordering::Relaxed)));
+        metrics::counter!("voice_tts_requests_total").increment(1);
+        let audio = match self.backend.synthesize(text) {
+            Ok(data) => data,
+            Err(err) => {
+                metrics::counter!("voice_tts_errors_total").increment(1);
+                return Err(err);
+            }
+        };
+        let path = self.output_dir.join(format!("{id}.wav"));
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&path, &audio)?;
+        let audio_base64 = BASE64_STANDARD.encode(&audio);
+        let phoneme_str = phonemes
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| phonemize(text));
+        let synthesis = VoiceSynthesis {
+            request_id: id.clone(),
+            file_path: path.clone(),
+            audio_base64,
+            text: text.to_string(),
+            phonemes: phoneme_str,
+        };
+        *self.latest.write().unwrap() = Some(synthesis.clone());
+        hearing::info(&format!(
+            "voice синтез завершён; request_id={} файл={}",
+            id,
+            path.display()
+        ));
+        Ok(synthesis)
+    }
+
+    pub fn transcribe_bytes(&self, audio: &[u8]) -> Result<VoiceTranscription, VoiceError> {
+        metrics::counter!("voice_stt_requests_total").increment(1);
+        let text = match self.backend.transcribe(audio) {
+            Ok(txt) => txt,
+            Err(err) => {
+                metrics::counter!("voice_stt_errors_total").increment(1);
+                return Err(err);
+            }
+        };
+        let id = format!("voice-stt-{}", self.counter.fetch_add(1, Ordering::Relaxed));
+        Ok(VoiceTranscription {
+            request_id: id,
+            text,
+        })
+    }
+
+    pub fn transcribe_file(&self, path: &Path) -> Result<VoiceTranscription, VoiceError> {
+        let data = fs::read(path)?;
+        self.transcribe_bytes(&data)
+    }
+
+    pub fn transcribe_base64(&self, audio_base64: &str) -> Result<VoiceTranscription, VoiceError> {
+        let data = BASE64_STANDARD.decode(audio_base64)?;
+        self.transcribe_bytes(&data)
+    }
+
+    pub fn latest_output(&self) -> Option<VoiceSynthesis> {
+        self.latest.read().unwrap().clone()
+    }
+
+    pub fn play_command_config(&self) -> Option<CommandConfig> {
+        self.play_command.clone()
+    }
+
+    pub fn backend_mode(&self) -> VoiceBackendMode {
+        self.backend_mode
+    }
+}
+
+fn metadata() -> Metadata {
+    Metadata {
+        schema: "v1".into(),
+        extra: HashMap::new(),
+    }
+}
+
+fn analysis_templates() -> Vec<CellTemplate> {
+    vec![
+        CellTemplate {
+            id: TEXT_NORMALIZE_ID.into(),
+            version: "0.1.0".into(),
+            analysis_type: "text_normalize".into(),
+            links: vec![],
+            confidence_threshold: None,
+            draft_content: None,
+            metadata: metadata(),
+        },
+        CellTemplate {
+            id: TEXT_TO_PHONEMES_ID.into(),
+            version: "0.1.0".into(),
+            analysis_type: "text_to_phonemes".into(),
+            links: vec![TEXT_NORMALIZE_ID.into()],
+            confidence_threshold: None,
+            draft_content: None,
+            metadata: metadata(),
+        },
+        CellTemplate {
+            id: SPEAK_ADAPTER_ID.into(),
+            version: "0.1.0".into(),
+            analysis_type: "speak_adapter".into(),
+            links: vec![TEXT_TO_PHONEMES_ID.into()],
+            confidence_threshold: None,
+            draft_content: None,
+            metadata: metadata(),
+        },
+    ]
+}
+
+fn action_templates() -> Vec<ActionCellTemplate> {
+    vec![ActionCellTemplate {
+        id: SPEAK_ACTION_ID.into(),
+        version: "0.1.0".into(),
+        action_type: "speak_adapter".into(),
+        links: vec![SPEAK_ADAPTER_ID.into()],
+        confidence_threshold: None,
+        draft_content: None,
+        metadata: metadata(),
+    }]
+}

--- a/spinal_cord/src/voice/phonemes.rs
+++ b/spinal_cord/src/voice/phonemes.rs
@@ -1,0 +1,79 @@
+/* neira:meta
+id: NEI-20280105-voice-phonemes
+intent: code
+summary: |
+  Простая фонетическая карта для русского текста: даёт стабильный вывод
+  для TTS и вспомогательных метрик.
+*/
+
+pub fn phonemize(text: &str) -> String {
+    text.split_whitespace()
+        .map(phonemize_word)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn phonemize_word(word: &str) -> String {
+    let mut result = Vec::new();
+    for ch in word.chars() {
+        let mapped = match ch.to_lowercase().next().unwrap_or(ch) {
+            'а' => Some("A".to_string()),
+            'б' => Some("B".to_string()),
+            'в' => Some("V".to_string()),
+            'г' => Some("G".to_string()),
+            'д' => Some("D".to_string()),
+            'е' | 'ё' => Some("YE".to_string()),
+            'ж' => Some("ZH".to_string()),
+            'з' => Some("Z".to_string()),
+            'и' | 'й' => Some("I".to_string()),
+            'к' => Some("K".to_string()),
+            'л' => Some("L".to_string()),
+            'м' => Some("M".to_string()),
+            'н' => Some("N".to_string()),
+            'о' => Some("O".to_string()),
+            'п' => Some("P".to_string()),
+            'р' => Some("R".to_string()),
+            'с' => Some("S".to_string()),
+            'т' => Some("T".to_string()),
+            'у' => Some("U".to_string()),
+            'ф' => Some("F".to_string()),
+            'х' => Some("H".to_string()),
+            'ц' => Some("TS".to_string()),
+            'ч' => Some("CH".to_string()),
+            'ш' => Some("SH".to_string()),
+            'щ' => Some("SCH".to_string()),
+            'ы' => Some("Y".to_string()),
+            'э' => Some("E".to_string()),
+            'ю' => Some("YU".to_string()),
+            'я' => Some("YA".to_string()),
+            'ъ' | 'ь' => None,
+            '-' => Some("-".to_string()),
+            other => {
+                if other.is_ascii_alphanumeric() {
+                    Some(other.to_uppercase().collect::<String>())
+                } else {
+                    None
+                }
+            }
+        };
+        if let Some(p) = mapped {
+            result.push(p);
+        }
+    }
+    if result.is_empty() {
+        word.to_uppercase()
+    } else {
+        result.join("-")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::phonemize;
+
+    #[test]
+    fn basic_phonemize() {
+        let res = phonemize("Нейра говорит");
+        assert_eq!(res, "N-YE-I-R-A G-O-V-O-R-I-T");
+    }
+}

--- a/spinal_cord/tests/voice_organ_test.rs
+++ b/spinal_cord/tests/voice_organ_test.rs
@@ -1,0 +1,125 @@
+/* neira:meta
+id: NEI-20280106-120000-voice-tests
+intent: chore
+summary: Покрывают голосовой орган: регистрация клеток, интеграция с фабрикой и TTS/STT через кодек.
+*/
+use backend::action::diagnostics_cell::DiagnosticsCell;
+use backend::action::metrics_collector_cell::MetricsCollectorCell;
+use backend::cell_registry::CellRegistry;
+use backend::config::Config;
+use backend::memory_cell::MemoryCell;
+use backend::synapse_hub::SynapseHub;
+use backend::voice::cells::{
+    SPEAK_ACTION_ID, SPEAK_ADAPTER_ID, TEXT_NORMALIZE_ID, TEXT_TO_PHONEMES_ID,
+};
+use backend::voice::{VoiceConfig, VoiceOrgan};
+use serial_test::serial;
+use std::sync::Arc;
+
+mod common;
+use common::init_recorder;
+
+struct EnvGuard {
+    keys: Vec<&'static str>,
+}
+
+impl EnvGuard {
+    fn set(pairs: &[(&'static str, String)]) -> Self {
+        for (key, value) in pairs {
+            std::env::set_var(key, value);
+        }
+        Self {
+            keys: pairs.iter().map(|(key, _)| *key).collect(),
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for key in &self.keys {
+            std::env::remove_var(key);
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn voice_bootstrap_registers_cells_and_factory_records() {
+    let _metrics = init_recorder();
+    let registry_dir = tempfile::tempdir().expect("registry dir");
+    let output_dir = tempfile::tempdir().expect("voice output dir");
+    let _env = EnvGuard::set(&[
+        (
+            "VOICE_OUTPUT_DIR",
+            output_dir.path().to_string_lossy().into_owned(),
+        ),
+        ("FACTORY_ADAPTER_ENABLED", "1".to_string()),
+        ("LYMPHATIC_FILTER_ENABLED", "0".to_string()),
+    ]);
+
+    let registry = Arc::new(CellRegistry::new(registry_dir.path()).expect("registry"));
+    let memory = Arc::new(MemoryCell::new());
+    let (metrics_cell, rx) = MetricsCollectorCell::channel();
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsCell::new(rx, 5, metrics_cell.clone());
+    let cfg = Config::default();
+    let hub = Arc::new(SynapseHub::new(
+        registry.clone(),
+        memory,
+        metrics_cell.clone(),
+        diagnostics,
+        &cfg,
+    ));
+
+    assert!(hub.factory_is_adapter_enabled());
+
+    let voice_config = VoiceConfig::from_env();
+    let organ = VoiceOrgan::new(Some(hub.clone()), registry.clone(), voice_config)
+        .expect("voice organ init");
+    organ.bootstrap().expect("voice organ bootstrap");
+
+    assert!(registry.get(TEXT_NORMALIZE_ID).is_some());
+    assert!(registry.get(TEXT_TO_PHONEMES_ID).is_some());
+    assert!(registry.get(SPEAK_ADAPTER_ID).is_some());
+    assert!(registry.get_analysis_cell(TEXT_NORMALIZE_ID).is_some());
+    assert!(registry.get_analysis_cell(SPEAK_ADAPTER_ID).is_some());
+    assert!(
+        registry
+            .action_cells()
+            .iter()
+            .any(|cell| cell.id() == SPEAK_ACTION_ID)
+    );
+
+    let (total, active) = hub.factory_counts();
+    assert_eq!(total, 3, "фабрика должна создать три записи шаблонов");
+    assert_eq!(active, 3, "все шаблоны должны быть активны после регистрации");
+}
+
+#[test]
+#[serial]
+fn voice_codec_backend_roundtrip() {
+    let _metrics = init_recorder();
+    let registry_dir = tempfile::tempdir().expect("registry dir");
+    let output_dir = tempfile::tempdir().expect("voice output dir");
+    let _env = EnvGuard::set(&[(
+        "VOICE_OUTPUT_DIR",
+        output_dir.path().to_string_lossy().into_owned(),
+    )]);
+
+    let registry = Arc::new(CellRegistry::new(registry_dir.path()).expect("registry"));
+    let voice_config = VoiceConfig::from_env();
+    let organ = VoiceOrgan::new(None, registry.clone(), voice_config).expect("voice organ init");
+    organ.bootstrap().expect("voice organ bootstrap");
+
+    let phrase = "Привет, Нейра!";
+    let synthesis = organ
+        .synthesize(None, phrase, None)
+        .expect("synthesis successful");
+    assert_eq!(synthesis.text, phrase);
+    assert!(synthesis.file_path.exists());
+    assert!(!synthesis.audio_base64.is_empty());
+
+    let transcription = organ
+        .transcribe_file(&synthesis.file_path)
+        .expect("transcription successful");
+    assert_eq!(transcription.text, phrase);
+}


### PR DESCRIPTION
## Summary
- add a dedicated test module that boots VoiceOrgan, registers analysis/action cells, and ensures factory records are created when the adapter gate is enabled
- cover the codec backend roundtrip (synthesize + transcribe) and guard environment side effects for voice output and lymphatic filter scans

## Testing
- npm run lint
- npm test
- cargo metadata --locked > /tmp/cargo_metadata.json
- cargo clippy
- scripts/check-duplicates.sh
- cargo test voice_bootstrap_registers_cells_and_factory_records -- --nocapture
- cargo test voice_codec_backend_roundtrip -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68fc1d6d7b948323b17b532612f240b6