### PR TITLE
fix: refine lymphatic filter semantic detection

### DIFF
--- a/spinal_cord/tests/voice_organ_test.rs
+++ b/spinal_cord/tests/voice_organ_test.rs
@@ -82,16 +82,17 @@ async fn voice_bootstrap_registers_cells_and_factory_records() {
     assert!(registry.get(SPEAK_ADAPTER_ID).is_some());
     assert!(registry.get_analysis_cell(TEXT_NORMALIZE_ID).is_some());
     assert!(registry.get_analysis_cell(SPEAK_ADAPTER_ID).is_some());
-    assert!(
-        registry
-            .action_cells()
-            .iter()
-            .any(|cell| cell.id() == SPEAK_ACTION_ID)
-    );
+    assert!(registry
+        .action_cells()
+        .iter()
+        .any(|cell| cell.id() == SPEAK_ACTION_ID));
 
     let (total, active) = hub.factory_counts();
     assert_eq!(total, 3, "фабрика должна создать три записи шаблонов");
-    assert_eq!(active, 3, "все шаблоны должны быть активны после регистрации");
+    assert_eq!(
+        active, 3,
+        "все шаблоны должны быть активны после регистрации"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend the lymphatic filter fingerprint with structured semantic tokens and combined similarity scoring to drop low-relevance matches
- apply rustfmt updates to keep the voice organ test consistent with project style

## Testing
- cargo test --manifest-path spinal_cord/Cargo.toml --test lymphatic_filter -- --test-threads=1


------
https://chatgpt.com/codex/tasks/task_e_68fc2ade52b08323957b6eefb5d4fccb