### PR TITLE
feat: stabilize tone state controller

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -162,10 +162,16 @@ capabilities:
     signals: [reflection_journal_entries, proposals_accepted_total, proposals_reverted_total]
 
   tone_state:
-    state: experimental
-    notes: эфемерное настроение/тон; не трогает ценности
+    state: stable
+    notes: эфемерное настроение/тон; авто-декей и метрики наблюдений
     safeguards: auto-reset; capped impact on latency
-    signals: [style_adherence]
+    signals:
+      [
+        persona_tone_intensity,
+        persona_tone_confidence,
+        persona_tone_transitions_total,
+        persona_tone_feedback_total,
+      ]
 
   studio_artflow:
     state: locked

--- a/docs/meta/capabilities-persona.md
+++ b/docs/meta/capabilities-persona.md
@@ -7,6 +7,10 @@ summary: |
 
 # Persona Capabilities (дополнение)
 
+## Содержание
+- [Сводка флагов](#persona-capabilities-дополнение)
+- [Связанные документы](#см-также)
+
 ```yaml
 capabilities:
   persona_kernel:
@@ -41,11 +45,17 @@ capabilities:
     signals: [reflection_journal_entries, proposals_accepted_total, proposals_reverted_total]
 
   tone_state:
-    state: experimental
-    notes: эфемерный тон/настроение; не трогает ценности
+    state: stable
+    notes: эфемерный тон/настроение; авто-декей, события и метрики обратной связи
     safeguards: bounded scope & time; cap latency impact
     rollback: reset tone; disable flag
-    signals: [style_adherence]
+    signals:
+      [
+        persona_tone_intensity,
+        persona_tone_confidence,
+        persona_tone_transitions_total,
+        persona_tone_feedback_total,
+      ]
 
   studio_artflow:
     state: locked

--- a/docs/meta/persona-kernel.md
+++ b/docs/meta/persona-kernel.md
@@ -42,12 +42,14 @@ Capabilities (см. CAPABILITIES.md)
 - persona_style_neutral: stable
 - persona_style_teen: experimental (intensity 0–3)
 - persona_reflection: experimental
-- tone_state: experimental
+- tone_state: stable (метрики интенсивности/обратной связи)
 - studio_artflow, studio_soundweaver, studio_storycells: locked
 - roleplay_mode: locked (только явно, с дисклеймером)
 
 Метрики (см. docs/reference/metrics.md)
 - persona_drift_score (gauge 0..1), style_adherence (gauge 0..1)
+- persona_tone_intensity (gauge 0..1), persona_tone_confidence (gauge 0..1)
+- persona_tone_transitions_total, persona_tone_feedback_total
 - role_switches_total, reflection_journal_entries, proposals_accepted_total, proposals_reverted_total
 - safety_breaches_total, safety_mitigations_total
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -118,6 +118,9 @@ summary: Переименована NODE_TEMPLATES_DIR в CELL_TEMPLATES_DIR с 
 | IDEMPOTENT_STORE_DIR         | string          | context               | idem store              | Каталог файла кэша                                                                                      |
 | IDEMPOTENT_TTL_SECS          | int             | 86400                 | idem store              | TTL ответов                                                                                             |
 | PERSIST_REQUIRE_SESSION_ID   | bool            | false                 | hub policies            | Запрет persist без session_id                                                                           |
+| TONE_STATE_ENABLED           | bool            | true                  | hub tone controller     | Включает способность tone_state (эмоциональные состояния)                                               |
+| TONE_STATE_DECAY_SECS        | int             | 600                   | hub tone controller     | Интервал авто-декея тона (секунды)                                                                     |
+| TONE_STATE_OBSERVATION_THRESHOLD | float        | 0.2                   | hub tone controller     | Порог чувствительности обратной связи (|score|)                                                        |
 | INDEX_KW_TTL_DAYS            | int             | 90                    | index compaction        | TTL ключевых слов в index.json                                                                          |
 | INDEX_COMPACT_INTERVAL_MS    | int             | 300000                | compaction job          | Интервал фоновой чистки                                                                                 |
 | SSE_WARN_AFTER_MS            | int             | 60000                 | SSE                     | Варнинг при долгом стриме                                                                               |

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -51,6 +51,10 @@ summary: |-
 | backpressure | gauge | count | BackpressureProbe | Суммарная длина очередей |
 | throttle_events_total | counter | events | BackpressureProbe | События троттлинга при backpressure |
 | safe_mode | gauge | 0/1 | Hub | Статус безопасного режима |
+| persona_tone_intensity | gauge | 0..1 | Tone Controller | Текущая интенсивность выбранного эмоционального тона |
+| persona_tone_confidence | gauge | 0..1 | Tone Controller | Уверенность в текущем тоне (сглаженная обратная связь) |
+| persona_tone_transitions_total{from,to,reason} | counter | transitions | Tone Controller/EventBus | Переходы тона между состояниями |
+| persona_tone_feedback_total{reason} | counter | count | Tone Controller | Обратные связи (observation/direct/reset/decay) |
 | idle_state | gauge | 0..3 | Anti-Idle | Текущее состояние простоя |
 | idle_minutes_today | counter | min | Anti-Idle | Минуты простоя за день |
 | auto_tasks_started | counter | tasks | Anti-Idle | Запуск микрозадач (лейбл `task`, вкл. TrainingOrchestrator) |

--- a/docs/reference/persona-metrics.md
+++ b/docs/reference/persona-metrics.md
@@ -7,6 +7,11 @@ summary: |
 
 # Метрики личности (Persona)
 
+## Содержание
+- [Таблица метрик](#метрики-личности-persona)
+- [Stage и связи](#stage-и-связи)
+- [См. также](#см-также)
+
 | имя | тип | единица | источник | описание |
 |---|---|---|---|---|
 | persona_drift_score | gauge | 0..1 | Analysis/Memory | Отклонение ответа от сводки ядра личности (0 — полное соответствие). |
@@ -17,10 +22,14 @@ summary: |
 | proposals_reverted_total | counter | count | Memory/Review | Откаты предложений после canary. |
 | safety_breaches_total | counter | count | Immune | Нарушения политик безопасности. |
 | safety_mitigations_total | counter | count | Immune | Сработавшие меры защиты/маскирования. |
+| persona_tone_intensity | gauge | 0..1 | Dialogue/Tone Controller | Текущая интенсивность выбранного тона. |
+| persona_tone_confidence | gauge | 0..1 | Dialogue/Tone Controller | Уверенность в выбранном тоне (агрегированная обратная связь). |
+| persona_tone_transitions_total | counter | count | EventBus/Tone Controller | Количество переходов тона (лейблы from/to/reason). |
+| persona_tone_feedback_total | counter | count | Tone Controller | Обратные связи (лейбл reason: observation/direct/reset/decay). |
 
 Stage и связи
 - Stage 0: рекомендованы к сбору `role_switches_total`, при наличии — `style_adherence` (neutral). Остальные — по готовности.
-- Stage 1: включаются полностью; мониторинг SLO и условия отката для `persona_reflection`, `persona_style_teen`.
+- Stage 1: включаются полностью; мониторинг SLO и условия отката для `persona_reflection`, `persona_style_teen`. `tone_state` переведён в Stage 0 (см. CAPABILITIES.md).
 
 См. также
 - Дорожная карта: docs/roadmap.md

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -161,11 +161,11 @@ Stage 0 (Core Stable)
 - `persona_kernel` — инварианты ценностей (честность, уважение, безопасность, полезность, воспроизводимость, краткость).
 - `persona_roles_minimal` — роли coder/editor/architect.
 - `persona_style_neutral` — стиль по умолчанию (интенсивность «teen» = 0).
-- Метрики: `role_switches_total`, (по возможности) `style_adherence`.
+- `tone_state` — эфемерный тон/настроение с авто-декеем и обратной связью.
+- Метрики: `role_switches_total`, `style_adherence`, `persona_tone_intensity`, `persona_tone_confidence`, `persona_tone_transitions_total`, `persona_tone_feedback_total`.
 
 Stage 1 (Experimental Growth)
 - `persona_reflection` — предложения микрокоррекций (review→canary→stable).
-- `tone_state` — эфемерный тон/настроение (auto‑reset; не затрагивает ценности).
 - `persona_style_teen` — экспериментальная окраска (регулятор 0–3).
 - Творческие студии: `studio_artflow`, `studio_soundweaver`, `studio_storycells` — LOCKED→EXPERIMENTAL.
 - Метрики: `persona_drift_score`, `style_adherence`, `reflection_journal_entries`, `proposals_accepted_total`, `proposals_reverted_total`.

--- a/spinal_cord/src/lib.rs
+++ b/spinal_cord/src/lib.rs
@@ -36,6 +36,7 @@ intent: code
 summary: Экспортирован модуль brain.
 */
 pub mod brain;
+pub mod persona;
 pub mod immune_system;
 pub mod memory_cell;
 /* neira:meta

--- a/spinal_cord/src/persona/mod.rs
+++ b/spinal_cord/src/persona/mod.rs
@@ -1,0 +1,11 @@
+/* neira:meta
+id: NEI-20280501-120000-persona-module
+intent: feature
+summary: Экспортирован модуль эмоциональных состояний личности (tone state).
+*/
+
+pub mod tone_state;
+
+pub use tone_state::{
+    ToneEventReason, ToneFeedback, ToneMood, ToneSnapshot, ToneStateChanged, ToneStateController,
+};

--- a/spinal_cord/src/persona/tone_state.rs
+++ b/spinal_cord/src/persona/tone_state.rs
@@ -1,0 +1,405 @@
+/* neira:meta
+id: NEI-20280501-120030-tone-state-controller
+intent: feature
+summary: |-
+  Контроллер tone_state переводит способность в stable: хранит текущее
+  настроение, применяет обратную связь, публикует события и обновляет метрики.
+*/
+
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use chrono::Utc;
+use serde::Serialize;
+use tokio::time::sleep;
+
+use crate::event_bus::{Event, EventBus};
+use crate::hearing;
+
+const EPSILON: f32 = 0.01;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToneMood {
+    Neutral,
+    Supportive,
+    Focused,
+}
+
+impl ToneMood {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Neutral => "neutral",
+            Self::Supportive => "supportive",
+            Self::Focused => "focused",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToneEventReason {
+    Observation,
+    Direct,
+    Reset,
+    Decay,
+}
+
+impl ToneEventReason {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Observation => "observation",
+            Self::Direct => "direct",
+            Self::Reset => "reset",
+            Self::Decay => "decay",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ToneSnapshot {
+    pub mood: ToneMood,
+    pub intensity: f32,
+    pub confidence: f32,
+    pub updated_ms: i64,
+}
+
+#[derive(Debug, Clone)]
+pub enum ToneFeedback {
+    Observation { score: f32 },
+    Direct {
+        mood: ToneMood,
+        intensity: f32,
+        confidence: f32,
+        reason: Option<String>,
+    },
+    Reset { reason: Option<String> },
+    Decay,
+}
+
+#[derive(Debug)]
+struct ToneInner {
+    mood: ToneMood,
+    intensity: f32,
+    confidence: f32,
+    last_update: Instant,
+    last_update_ms: i64,
+}
+
+pub struct ToneStateController {
+    state: RwLock<ToneInner>,
+    decay_period: Duration,
+    observation_threshold: f32,
+    event_bus: Arc<EventBus>,
+}
+
+impl ToneStateController {
+    pub fn new(
+        event_bus: Arc<EventBus>,
+        decay_period: Duration,
+        observation_threshold: f32,
+    ) -> Arc<Self> {
+        let period = if decay_period.is_zero() {
+            Duration::from_secs(1)
+        } else {
+            decay_period
+        };
+        let threshold = observation_threshold.clamp(0.0, 1.0);
+        let now_ms = Utc::now().timestamp_millis();
+        Arc::new(Self {
+            state: RwLock::new(ToneInner {
+                mood: ToneMood::Neutral,
+                intensity: 0.0,
+                confidence: 0.0,
+                last_update: Instant::now(),
+                last_update_ms: now_ms,
+            }),
+            decay_period: period,
+            observation_threshold: threshold,
+            event_bus,
+        })
+    }
+
+    pub fn spawn_decay_loop(self: &Arc<Self>) {
+        let controller = Arc::clone(self);
+        tokio::spawn(async move {
+            loop {
+                sleep(controller.decay_period).await;
+                controller.apply_feedback(ToneFeedback::Decay);
+            }
+        });
+    }
+
+    pub fn snapshot(&self) -> ToneSnapshot {
+        self.mutate_state(ToneEventReason::Decay, None, None, false, |_, _, _| false)
+    }
+
+    pub fn apply_feedback(&self, feedback: ToneFeedback) -> ToneSnapshot {
+        match feedback {
+            ToneFeedback::Observation { score } => {
+                let bounded = score.clamp(-1.0, 1.0);
+                metrics::histogram!("persona_tone_observation_score").record(bounded as f64);
+                let magnitude = bounded.abs();
+                self.mutate_state(
+                    ToneEventReason::Observation,
+                    None,
+                    Some(bounded),
+                    true,
+                    |state, now, now_ms| {
+                        if magnitude < self.observation_threshold {
+                            state.last_update = now;
+                            state.last_update_ms = now_ms;
+                            return false;
+                        }
+                        let target = if bounded >= 0.0 {
+                            ToneMood::Supportive
+                        } else {
+                            ToneMood::Focused
+                        };
+                        let new_intensity = ((state.intensity * 0.6) + (magnitude * 0.5))
+                            .clamp(0.0, 1.0);
+                        let new_confidence =
+                            ((state.confidence * 0.5) + (magnitude * 0.5)).clamp(0.0, 1.0);
+                        let changed = state.mood != target
+                            || (state.intensity - new_intensity).abs() > EPSILON
+                            || (state.confidence - new_confidence).abs() > EPSILON;
+                        state.mood = if new_intensity < 0.05 {
+                            ToneMood::Neutral
+                        } else {
+                            target
+                        };
+                        state.intensity = if state.mood == ToneMood::Neutral {
+                            0.0
+                        } else {
+                            new_intensity
+                        };
+                        state.confidence = if state.mood == ToneMood::Neutral {
+                            0.0
+                        } else {
+                            new_confidence
+                        };
+                        state.last_update = now;
+                        state.last_update_ms = now_ms;
+                        changed
+                    },
+                )
+            }
+            ToneFeedback::Direct {
+                mood,
+                intensity,
+                confidence,
+                reason,
+            } => {
+                self.mutate_state(
+                    ToneEventReason::Direct,
+                    reason,
+                    None,
+                    true,
+                    |state, now, now_ms| {
+                        let clamped_intensity = intensity.clamp(0.0, 1.0);
+                        let clamped_confidence = confidence.clamp(0.0, 1.0);
+                        let final_mood = if clamped_intensity < 0.05 {
+                            ToneMood::Neutral
+                        } else {
+                            mood
+                        };
+                        let changed = state.mood != final_mood
+                            || (state.intensity - clamped_intensity).abs() > EPSILON
+                            || (state.confidence - clamped_confidence).abs() > EPSILON;
+                        state.mood = final_mood;
+                        state.intensity = if final_mood == ToneMood::Neutral {
+                            0.0
+                        } else {
+                            clamped_intensity
+                        };
+                        state.confidence = if final_mood == ToneMood::Neutral {
+                            0.0
+                        } else {
+                            clamped_confidence
+                        };
+                        state.last_update = now;
+                        state.last_update_ms = now_ms;
+                        changed
+                    },
+                )
+            }
+            ToneFeedback::Reset { reason } => self.mutate_state(
+                ToneEventReason::Reset,
+                reason,
+                None,
+                true,
+                |state, now, now_ms| {
+                    let changed = state.mood != ToneMood::Neutral
+                        || state.intensity > EPSILON
+                        || state.confidence > EPSILON;
+                    state.mood = ToneMood::Neutral;
+                    state.intensity = 0.0;
+                    state.confidence = 0.0;
+                    state.last_update = now;
+                    state.last_update_ms = now_ms;
+                    changed
+                },
+            ),
+            ToneFeedback::Decay => self.mutate_state(
+                ToneEventReason::Decay,
+                None,
+                None,
+                true,
+                |_, _, _| false,
+            ),
+        }
+    }
+
+    fn mutate_state<F>(
+        &self,
+        reason: ToneEventReason,
+        note: Option<String>,
+        score: Option<f32>,
+        count_feedback: bool,
+        update: F,
+    ) -> ToneSnapshot
+    where
+        F: FnOnce(&mut ToneInner, Instant, i64) -> bool,
+    {
+        let now = Instant::now();
+        let now_ms = Utc::now().timestamp_millis();
+        let mut state = self.state.write().unwrap();
+        let previous = ToneSnapshot::from(&*state);
+        let mut changed = self.apply_decay_locked(&mut state, now, now_ms);
+        changed |= update(&mut state, now, now_ms);
+        let snapshot = ToneSnapshot::from(&*state);
+        drop(state);
+        self.record_metrics(reason, &snapshot, count_feedback && changed);
+        if changed {
+            self.publish_event(previous, snapshot.clone(), reason, note, score);
+        }
+        snapshot
+    }
+
+    fn apply_decay_locked(
+        &self,
+        state: &mut ToneInner,
+        now: Instant,
+        now_ms: i64,
+    ) -> bool {
+        if state.mood == ToneMood::Neutral {
+            state.last_update = now;
+            state.last_update_ms = now_ms;
+            return false;
+        }
+        let elapsed = now.saturating_duration_since(state.last_update);
+        if elapsed < self.decay_period {
+            return false;
+        }
+        let periods = (elapsed.as_secs_f32() / self.decay_period.as_secs_f32()).floor() as i32;
+        if periods <= 0 {
+            state.last_update = now;
+            state.last_update_ms = now_ms;
+            return false;
+        }
+        let factor = 0.5_f32.powi(periods);
+        state.intensity *= factor;
+        state.confidence *= factor;
+        if state.intensity < 0.05 {
+            state.mood = ToneMood::Neutral;
+            state.intensity = 0.0;
+            state.confidence = 0.0;
+        }
+        state.last_update = now;
+        state.last_update_ms = now_ms;
+        true
+    }
+
+    fn record_metrics(&self, reason: ToneEventReason, snapshot: &ToneSnapshot, count: bool) {
+        metrics::gauge!("persona_tone_intensity").set(snapshot.intensity as f64);
+        metrics::gauge!("persona_tone_confidence").set(snapshot.confidence as f64);
+        if count {
+            metrics::counter!(
+                "persona_tone_feedback_total",
+                "reason" => reason.as_str()
+            )
+            .increment(1);
+        }
+    }
+
+    fn publish_event(
+        &self,
+        previous: ToneSnapshot,
+        current: ToneSnapshot,
+        reason: ToneEventReason,
+        note: Option<String>,
+        score: Option<f32>,
+    ) {
+        metrics::counter!(
+            "persona_tone_transitions_total",
+            "from" => previous.mood.as_str(),
+            "to" => current.mood.as_str(),
+            "reason" => reason.as_str()
+        )
+        .increment(1);
+        hearing::info(&format!(
+            "tone_state изменён: from={} to={} intensity={:.2} reason={}",
+            previous.mood.as_str(),
+            current.mood.as_str(),
+            current.intensity,
+            reason.as_str()
+        ));
+        self.event_bus.publish(&ToneStateChanged {
+            previous,
+            current,
+            reason,
+            note,
+            score,
+        });
+    }
+}
+
+impl From<&ToneInner> for ToneSnapshot {
+    fn from(state: &ToneInner) -> Self {
+        ToneSnapshot {
+            mood: state.mood,
+            intensity: state.intensity,
+            confidence: state.confidence,
+            updated_ms: state.last_update_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ToneStateChanged {
+    pub previous: ToneSnapshot,
+    pub current: ToneSnapshot,
+    pub reason: ToneEventReason,
+    pub note: Option<String>,
+    pub score: Option<f32>,
+}
+
+impl Event for ToneStateChanged {
+    fn name(&self) -> &str {
+        "persona.tone_state.changed"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "previous": {
+                "mood": self.previous.mood.as_str(),
+                "intensity": self.previous.intensity,
+                "confidence": self.previous.confidence,
+                "updated_ms": self.previous.updated_ms,
+            },
+            "current": {
+                "mood": self.current.mood.as_str(),
+                "intensity": self.current.intensity,
+                "confidence": self.current.confidence,
+                "updated_ms": self.current.updated_ms,
+            },
+            "reason": self.reason.as_str(),
+            "note": self.note,
+            "score": self.score,
+        }))
+    }
+}

--- a/spinal_cord/src/policy/mod.rs
+++ b/spinal_cord/src/policy/mod.rs
@@ -20,6 +20,7 @@ pub enum Capability {
     LearningMicrotasks,
     TrainingPipeline,
     TrainingAutorun,
+    ToneState,
 }
 
 #[derive(Debug, Clone)]
@@ -96,6 +97,17 @@ impl PolicyEngine {
                         code: "capability_disabled",
                         reason: "training_autorun is disabled".into(),
                         capability: Some("training_autorun"),
+                    })
+                }
+            }
+            Capability::ToneState => {
+                if hub.tone_state_enabled() {
+                    Ok(())
+                } else {
+                    Err(PolicyError {
+                        code: "capability_disabled",
+                        reason: "tone_state is disabled".into(),
+                        capability: Some("tone_state"),
                     })
                 }
             }

--- a/spinal_cord/tests/chat_hub_test.rs
+++ b/spinal_cord/tests/chat_hub_test.rs
@@ -7,6 +7,7 @@ use backend::cell_registry::CellRegistry;
 use backend::config::Config;
 use backend::context::context_storage::FileContextStorage;
 use backend::memory_cell::MemoryCell;
+use backend::persona::tone_state::ToneMood;
 use backend::synapse_hub::SynapseHub;
 
 #[tokio::test]
@@ -41,10 +42,51 @@ async fn chat_hub_rejects_empty_message() {
     assert!(res.is_err());
 }
 
+#[tokio::test]
+async fn chat_positive_message_updates_tone_state() {
+    let templates_dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(CellRegistry::new(templates_dir.path()).expect("registry"));
+    let memory = Arc::new(MemoryCell::new());
+    let (metrics, rx) = MetricsCollectorCell::channel();
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsCell::new(rx, 5, metrics.clone());
+    let cfg = Config::default();
+    let hub = SynapseHub::new(registry.clone(), memory, metrics, diagnostics, &cfg);
+    hub.add_auth_token("secret");
+    registry.register_chat_cell(Arc::new(EchoChatCell::default()));
+
+    let storage_dir = tempfile::tempdir().unwrap();
+    let storage = FileContextStorage::new(storage_dir.path().join("context"));
+    let phrase = "Спасибо огромное, ты сегодня супер!";
+
+    let response = hub
+        .chat(
+            "echo.chat",
+            "tone_chat",
+            Some("sess1".to_string()),
+            phrase,
+            &storage,
+            "secret",
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("chat success");
+
+    assert_eq!(response.response, phrase);
+
+    let snapshot = hub
+        .tone_state_snapshot()
+        .expect("tone state enabled");
+    assert_eq!(snapshot.mood, ToneMood::Supportive);
+    assert!(snapshot.intensity > 0.0);
+}
+
 /* neira:meta
-id: NEI-20250227-chat-hub-test-update
-intent: tests
+id: NEI-20280501-120150-chat-hub-tone-test
+intent: chore
 summary: |
-  Обновлен вызов `SynapseHub::chat` в тесте в соответствии с новым
-  интерфейсом (добавлены `source` и `thread_id`).
+  Расширены интеграционные тесты чата проверкой обновления тонального состояния
+  и приведён вызов `SynapseHub::chat` к актуальной сигнатуре.
 */

--- a/spinal_cord/tests/tone_state_test.rs
+++ b/spinal_cord/tests/tone_state_test.rs
@@ -1,0 +1,72 @@
+/* neira:meta
+id: NEI-20280501-120200-tone-state-tests
+intent: chore
+summary: Добавлены юнит-тесты контроллера тонов с проверкой метрик и событий.
+*/
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use backend::event_bus::{Event, EventBus, Subscriber};
+use backend::persona::tone_state::{
+    ToneEventReason, ToneFeedback, ToneMood, ToneStateChanged, ToneStateController,
+};
+
+mod common;
+use common::init_recorder;
+
+struct ToneCollector {
+    events: Arc<Mutex<Vec<ToneStateChanged>>>,
+}
+
+impl Subscriber for ToneCollector {
+    fn on_event(&self, event: &dyn Event) {
+        if let Some(changed) = event.as_any().downcast_ref::<ToneStateChanged>() {
+            self.events.lock().unwrap().push(changed.clone());
+        }
+    }
+}
+
+#[tokio::test]
+async fn tone_state_observation_changes_and_decays() {
+    let metrics = init_recorder();
+    let bus = EventBus::new();
+    let events = Arc::new(Mutex::new(Vec::new()));
+    bus.subscribe(Arc::new(ToneCollector {
+        events: events.clone(),
+    }));
+    let controller = ToneStateController::new(bus, Duration::from_millis(50), 0.2);
+    controller.spawn_decay_loop();
+
+    let first = controller.apply_feedback(ToneFeedback::Observation { score: 0.9 });
+    assert_eq!(first.mood, ToneMood::Supportive);
+    assert!(first.intensity > 0.4);
+
+    tokio::time::sleep(Duration::from_millis(140)).await;
+
+    let decayed = controller.snapshot();
+    assert!(decayed.intensity < first.intensity);
+
+    let collected = events.lock().unwrap();
+    assert!(
+        collected
+            .iter()
+            .any(|evt| evt.reason == ToneEventReason::Observation),
+        "observation event missing"
+    );
+    assert!(
+        collected
+            .iter()
+            .any(|evt| evt.reason == ToneEventReason::Decay),
+        "decay event missing"
+    );
+    drop(collected);
+
+    let metrics_data = metrics.lock().unwrap();
+    assert!(
+        metrics_data
+            .iter()
+            .any(|(name, _)| name == "persona_tone_feedback_total"),
+        "feedback counter not recorded"
+    );
+}


### PR DESCRIPTION
## Summary
- add persona tone state controller with event feedback, metrics, and event bus integration
- wire tone state gating and observation into the synapse hub, update policies, and document new env flags and metrics
- cover tone state behaviour with dedicated unit tests and chat integration test, update capability docs and roadmap

## Testing
- cargo fmt --manifest-path spinal_cord/Cargo.toml
- cargo test --manifest-path spinal_cord/Cargo.toml tone_state_observation_changes_and_decays -- --exact
- cargo test --manifest-path spinal_cord/Cargo.toml --test tone_state_test tone_state_observation_changes_and_decays -- --exact
- cargo test --manifest-path spinal_cord/Cargo.toml chat_positive_message_updates_tone_state -- --exact

------
https://chatgpt.com/codex/tasks/task_e_68fc2e8d53188323946a5e080444dd30