### PR TITLE
Add interaction verb detection to SynapseHub

### DIFF
--- a/spinal_cord/src/persona/interaction_verbs.rs
+++ b/spinal_cord/src/persona/interaction_verbs.rs
@@ -1,0 +1,231 @@
+/* neira:meta
+id: NEI-20280502-120000-interaction-verbs
+intent: feature
+summary: |-
+  Детектор глаголов взаимодействия определяет ожидаемое действие собеседника,
+  нормализует сообщения и публикует событие для шины EventBus.
+*/
+
+use crate::event_bus::Event;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Serialize;
+use serde_json::json;
+use std::any::Any;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionVerb {
+    Give,
+    Show,
+    Explain,
+    Repeat,
+    Find,
+}
+
+impl InteractionVerb {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Give => "give",
+            Self::Show => "show",
+            Self::Explain => "explain",
+            Self::Repeat => "repeat",
+            Self::Find => "find",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionVerbActor {
+    User,
+    Assistant,
+}
+
+impl InteractionVerbActor {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VerbPattern {
+    verb: InteractionVerb,
+    regex: Regex,
+}
+
+static VERB_PATTERNS: Lazy<Vec<VerbPattern>> = Lazy::new(|| {
+    vec![
+        VerbPattern {
+            verb: InteractionVerb::Give,
+            regex: Regex::new(r"(?iu)\bдай(те)?\b").unwrap(),
+        },
+        VerbPattern {
+            verb: InteractionVerb::Show,
+            regex: Regex::new(r"(?iu)\bпокаж(и|ите)\b").unwrap(),
+        },
+        VerbPattern {
+            verb: InteractionVerb::Explain,
+            regex: Regex::new(r"(?iu)\bобъясн(и|ите)\b").unwrap(),
+        },
+        VerbPattern {
+            verb: InteractionVerb::Repeat,
+            regex: Regex::new(r"(?iu)\bповтор(и|ите)\b").unwrap(),
+        },
+        VerbPattern {
+            verb: InteractionVerb::Find,
+            regex: Regex::new(r"(?iu)\bнайд(и|ите)\b").unwrap(),
+        },
+    ]
+});
+
+#[derive(Debug, Clone, Default)]
+pub struct InteractionVerbDetector;
+
+impl InteractionVerbDetector {
+    pub fn detect(&self, text: &str) -> Vec<InteractionVerb> {
+        let mut found = Vec::new();
+        for pattern in VERB_PATTERNS.iter() {
+            if pattern.regex.is_match(text) && !found.contains(&pattern.verb) {
+                found.push(pattern.verb);
+            }
+        }
+        found
+    }
+
+    pub fn detect_primary(&self, text: &str) -> Option<InteractionVerb> {
+        VERB_PATTERNS
+            .iter()
+            .filter_map(|pattern| pattern.regex.find(text).map(|m| (m.start(), pattern.verb)))
+            .min_by_key(|(idx, _)| *idx)
+            .map(|(_, verb)| verb)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InteractionVerbObserved {
+    actor: InteractionVerbActor,
+    verb: InteractionVerb,
+    chat_id: String,
+    session_id: Option<String>,
+    message_preview: String,
+}
+
+impl InteractionVerbObserved {
+    pub fn new(
+        actor: InteractionVerbActor,
+        verb: InteractionVerb,
+        chat_id: impl Into<String>,
+        session_id: Option<String>,
+        message: &str,
+    ) -> Self {
+        Self {
+            actor,
+            verb,
+            chat_id: chat_id.into(),
+            session_id,
+            message_preview: sanitize_preview(message),
+        }
+    }
+
+    pub fn verb(&self) -> InteractionVerb {
+        self.verb
+    }
+
+    pub fn actor(&self) -> InteractionVerbActor {
+        self.actor
+    }
+
+    pub fn chat_id(&self) -> &str {
+        &self.chat_id
+    }
+
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+
+    pub fn message_preview(&self) -> &str {
+        &self.message_preview
+    }
+}
+
+impl Event for InteractionVerbObserved {
+    fn name(&self) -> &str {
+        "persona.interaction_verb.observed"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data(&self) -> Option<serde_json::Value> {
+        Some(json!({
+            "actor": self.actor.as_str(),
+            "verb": self.verb.as_str(),
+            "chat_id": self.chat_id,
+            "session_id": self.session_id.clone(),
+            "message_preview": self.message_preview,
+        }))
+    }
+}
+
+const PREVIEW_MAX_CHARS: usize = 120;
+
+fn sanitize_preview(message: &str) -> String {
+    let normalized = message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let normalized = normalized.trim();
+    if normalized.is_empty() {
+        return String::new();
+    }
+    let mut preview = String::new();
+    let mut truncated = false;
+    let mut count = 0usize;
+    for ch in normalized.chars() {
+        if count >= PREVIEW_MAX_CHARS {
+            truncated = true;
+            break;
+        }
+        preview.push(ch);
+        count += 1;
+    }
+    if truncated {
+        preview.push('…');
+    }
+    preview
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_multiple_verbs_and_primary() {
+        let detector = InteractionVerbDetector::default();
+        let verbs = detector.detect("Пожалуйста, покажите и объясните ещё раз.");
+        assert!(verbs.contains(&InteractionVerb::Show));
+        assert!(verbs.contains(&InteractionVerb::Explain));
+        assert_eq!(verbs.len(), 2);
+        let primary = detector
+            .detect_primary("Объясни и покажи, а потом найди")
+            .expect("primary verb");
+        assert_eq!(primary, InteractionVerb::Explain);
+    }
+
+    #[test]
+    fn sanitize_preview_trims_and_limits() {
+        let preview = sanitize_preview("  дай\nпожалуйста   список   ");
+        assert_eq!(preview, "дай пожалуйста список");
+        let long_text = "найди ".repeat(40);
+        let preview_long = sanitize_preview(&long_text);
+        assert!(preview_long.chars().count() <= PREVIEW_MAX_CHARS + 1);
+        if preview_long.chars().count() > PREVIEW_MAX_CHARS {
+            assert!(preview_long.ends_with('…'));
+        }
+    }
+}

--- a/spinal_cord/src/persona/mod.rs
+++ b/spinal_cord/src/persona/mod.rs
@@ -3,9 +3,18 @@ id: NEI-20280501-120000-persona-module
 intent: feature
 summary: Экспортирован модуль эмоциональных состояний личности (tone state).
 */
+/* neira:meta
+id: NEI-20280502-120100-persona-interaction-verbs
+intent: feature
+summary: Экспортирован детектор глаголов взаимодействия и событие наблюдения.
+*/
 
+pub mod interaction_verbs;
 pub mod tone_state;
 
+pub use interaction_verbs::{
+    InteractionVerb, InteractionVerbActor, InteractionVerbDetector, InteractionVerbObserved,
+};
 pub use tone_state::{
     ToneEventReason, ToneFeedback, ToneMood, ToneSnapshot, ToneStateChanged, ToneStateController,
 };

--- a/spinal_cord/tests/interaction_verbs_test.rs
+++ b/spinal_cord/tests/interaction_verbs_test.rs
@@ -1,0 +1,102 @@
+/* neira:meta
+id: NEI-20280502-120800-interaction-verbs-test
+intent: chore
+summary: Проверяет детектор глаголов взаимодействия и публикацию события SynapseHub.
+*/
+
+use std::sync::{Arc, Mutex};
+
+use backend::action::chat_cell::EchoChatCell;
+use backend::action::diagnostics_cell::DiagnosticsCell;
+use backend::action::metrics_collector_cell::MetricsCollectorCell;
+use backend::cell_registry::CellRegistry;
+use backend::config::Config;
+use backend::context::context_storage::FileContextStorage;
+use backend::event_bus::{Event, Subscriber};
+use backend::memory_cell::MemoryCell;
+use backend::persona::interaction_verbs::{
+    InteractionVerb, InteractionVerbActor, InteractionVerbDetector,
+};
+use backend::synapse_hub::SynapseHub;
+use serde_json::Value;
+
+mod common;
+use common::init_recorder;
+
+struct CaptureSubscriber {
+    events: Arc<Mutex<Vec<Value>>>,
+}
+
+impl Subscriber for CaptureSubscriber {
+    fn on_event(&self, event: &dyn Event) {
+        if event.name() == "persona.interaction_verb.observed" {
+            if let Some(data) = event.data() {
+                self.events.lock().unwrap().push(data);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn detector_recognizes_variants_and_synapse_hub_emits_event() {
+    let detector = InteractionVerbDetector::default();
+    let verbs = detector.detect("Дайте, пожалуйста, объясните и повторите примеры.");
+    assert!(verbs.contains(&InteractionVerb::Give));
+    assert!(verbs.contains(&InteractionVerb::Explain));
+    assert!(verbs.contains(&InteractionVerb::Repeat));
+
+    let metrics_data = init_recorder();
+
+    let templates_dir = tempfile::tempdir().unwrap();
+    let registry = Arc::new(CellRegistry::new(templates_dir.path()).expect("registry"));
+    let memory = Arc::new(MemoryCell::new());
+    let (metrics, rx) = MetricsCollectorCell::channel();
+    let (diagnostics, _dev_rx, _alert_rx) = DiagnosticsCell::new(rx, 5, metrics.clone());
+    let cfg = Config::default();
+    let hub = SynapseHub::new(registry.clone(), memory, metrics, diagnostics, &cfg);
+    hub.add_auth_token("secret");
+    registry.register_chat_cell(Arc::new(EchoChatCell::default()));
+
+    let storage_dir = tempfile::tempdir().unwrap();
+    let storage = FileContextStorage::new(storage_dir.path().join("context"));
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    hub.subscribe_event(Arc::new(CaptureSubscriber {
+        events: events.clone(),
+    }));
+
+    let phrase = "Покажи, пожалуйста, список и найди последние записи.";
+
+    let response = hub
+        .chat(
+            "echo.chat",
+            "chat1",
+            Some("session1".to_string()),
+            phrase,
+            &storage,
+            "secret",
+            true,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("chat success");
+
+    assert_eq!(response.response, phrase);
+
+    let recorded = events.lock().unwrap();
+    assert!(!recorded.is_empty(), "expected interaction verb event");
+    let show_event = recorded
+        .iter()
+        .find(|value| value["verb"] == "show")
+        .expect("show verb recorded");
+    assert_eq!(show_event["actor"], InteractionVerbActor::User.as_str());
+    assert_eq!(show_event["chat_id"], "chat1");
+    drop(recorded);
+
+    let metrics_snapshot = metrics_data.lock().unwrap();
+    assert!(metrics_snapshot
+        .iter()
+        .any(|(name, _)| name == "interaction_verbs_detected_total"));
+}


### PR DESCRIPTION
## Summary
- add a persona::interaction_verbs module that classifies commands and publishes persona events
- wire interaction verb detection into SynapseHub chat handling with trigger labels, metrics, and event bus publishing
- add an integration test covering detection, event emission, and metrics recording

## Testing
- cargo test --test interaction_verbs_test

------
https://chatgpt.com/codex/tasks/task_e_68fc92a66b1c83238628345b71628754