### PR TITLE
fix: use const for chat facade reference

### DIFF
--- a/sensory_organs/src/main.ts
+++ b/sensory_organs/src/main.ts
@@ -44,7 +44,7 @@ const statusPanel = createStatusPanel(API_URL);
 layout.append(chatPanel.container, statusPanel.container);
 appRoot.append(hero.container, layout);
 
-let chatFacade: ChatPanel | null = chatPanel;
+const chatFacade: ChatPanel | null = chatPanel;
 
 const pollingOptions: PollingOptions = {
   apiUrl: API_URL,


### PR DESCRIPTION
## Summary
- update the chat facade reference to use const so the linter no longer reports prefer-const

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fce31d65e88323b8a5a013c508ec27