### PR TITLE
feat: add configurable training tabs and settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "toml 0.5.11",
  "tower 0.4.13",
  "tower-http 0.4.4",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ winapi = { version = "0.3.9", features = ["winuser", "processthreadsapi", "winba
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 once_cell = "1.19"
+toml = "0.5"
 
 [build-dependencies]
 winres = "0.1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -41,7 +41,7 @@ impl MetricsServer {
 
         let app = Router::new()
             .nest("/metrics", metrics::router())
-            .route("/training/attempt", post(training::record_attempt))
+            .nest("/training", training::router())
             .route("/chat", post(chat::handle_message))
             .nest_service("/", ServeDir::new("static"))
             .with_state(self.metrics.clone())

--- a/src/server/training.rs
+++ b/src/server/training.rs
@@ -4,11 +4,24 @@ intent: feature
 summary: |
   Добавил endpoint /training/attempt для фиксации попыток и обновления сложности.
 */
-use axum::{extract::State, response::Json};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::Json,
+    routing::get,
+    Router,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::training::config::{TrainingConfig, TrainingConfigUpdate};
 use crate::training::metrics::LearningMetrics;
+
+pub fn router() -> Router<Arc<LearningMetrics>> {
+    Router::new()
+        .route("/attempt", axum::routing::post(record_attempt))
+        .route("/config", get(get_config).put(update_config))
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AttemptRequest {
@@ -21,6 +34,19 @@ pub struct AttemptResponse {
     pub new_difficulty: f64,
 }
 
+#[derive(Debug, Serialize)]
+pub struct TrainingConfigResponse {
+    pub success_threshold: f64,
+    pub failure_threshold: f64,
+    pub min_attempts: u64,
+    pub data_dir: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub message: String,
+}
+
 pub async fn record_attempt(
     State(metrics): State<Arc<LearningMetrics>>,
     Json(payload): Json<AttemptRequest>,
@@ -31,4 +57,35 @@ pub async fn record_attempt(
     let new_difficulty = metrics.adjust_difficulty().await;
 
     Json(AttemptResponse { new_difficulty })
+}
+
+pub async fn get_config(State(metrics): State<Arc<LearningMetrics>>) -> Json<TrainingConfigResponse> {
+    let config = metrics.get_training_config().await;
+    Json(TrainingConfigResponse::from(config))
+}
+
+pub async fn update_config(
+    State(metrics): State<Arc<LearningMetrics>>,
+    Json(payload): Json<TrainingConfigUpdate>,
+) -> Result<Json<TrainingConfigResponse>, (StatusCode, Json<ErrorResponse>)> {
+    match metrics.update_training_config(payload).await {
+        Ok(config) => Ok(Json(TrainingConfigResponse::from(config))),
+        Err(error) => Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                message: error.to_string(),
+            }),
+        )),
+    }
+}
+
+impl From<TrainingConfig> for TrainingConfigResponse {
+    fn from(value: TrainingConfig) -> Self {
+        Self {
+            success_threshold: value.success_threshold,
+            failure_threshold: value.failure_threshold,
+            min_attempts: value.min_attempts,
+            data_dir: value.data_dir.to_string_lossy().into_owned(),
+        }
+    }
 }

--- a/src/training/config.rs
+++ b/src/training/config.rs
@@ -1,12 +1,74 @@
-use serde::Deserialize;
-use std::path::PathBuf;
+/* neira:meta
+id: NEI-20250211-163500-training-config-api
+intent: feature
+summary: |
+  Добавил в конфиг обучения валидацию, загрузку из файла и частичные обновления.
+*/
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-#[derive(Debug, Deserialize)]
+const DEFAULT_CONFIG_PATH: &str = "config/training.toml";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrainingConfig {
     pub success_threshold: f64,
     pub failure_threshold: f64,
     pub min_attempts: u64,
     pub data_dir: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum TrainingConfigError {
+    Io(std::io::Error),
+    ParseToml(toml::de::Error),
+    SerializeToml(toml::ser::Error),
+    Validation(String),
+}
+
+impl Display for TrainingConfigError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            TrainingConfigError::Io(err) => write!(f, "Ошибка ввода-вывода: {}", err),
+            TrainingConfigError::ParseToml(err) => write!(f, "Не удалось разобрать TOML: {}", err),
+            TrainingConfigError::SerializeToml(err) => {
+                write!(f, "Не удалось сериализовать TOML: {}", err)
+            }
+            TrainingConfigError::Validation(message) => write!(f, "Конфигурация недопустима: {}", message),
+        }
+    }
+}
+
+impl Error for TrainingConfigError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            TrainingConfigError::Io(err) => Some(err),
+            TrainingConfigError::ParseToml(err) => Some(err),
+            TrainingConfigError::SerializeToml(err) => Some(err),
+            TrainingConfigError::Validation(_) => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for TrainingConfigError {
+    fn from(value: std::io::Error) -> Self {
+        TrainingConfigError::Io(value)
+    }
+}
+
+impl From<toml::de::Error> for TrainingConfigError {
+    fn from(value: toml::de::Error) -> Self {
+        TrainingConfigError::ParseToml(value)
+    }
+}
+
+impl From<toml::ser::Error> for TrainingConfigError {
+    fn from(value: toml::ser::Error) -> Self {
+        TrainingConfigError::SerializeToml(value)
+    }
 }
 
 impl Default for TrainingConfig {
@@ -20,9 +82,133 @@ impl Default for TrainingConfig {
     }
 }
 
+#[derive(Debug, Default, Deserialize)]
+pub struct TrainingConfigUpdate {
+    pub success_threshold: Option<f64>,
+    pub failure_threshold: Option<f64>,
+    pub min_attempts: Option<u64>,
+    pub data_dir: Option<PathBuf>,
+}
+
 impl TrainingConfig {
-    pub fn from_file(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let content = std::fs::read_to_string(path)?;
-        Ok(toml::from_str(&content)?)
+    pub fn resolve_path() -> PathBuf {
+        env::var("NEIRA_TRAINING_CONFIG")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(DEFAULT_CONFIG_PATH))
+    }
+
+    pub fn load_or_default(path: &Path) -> Result<Self, TrainingConfigError> {
+        if path.exists() {
+            let content = fs::read_to_string(path)?;
+            let config: TrainingConfig = toml::from_str(&content)?;
+            config.validate()?;
+            Ok(config)
+        } else {
+            Ok(TrainingConfig::default())
+        }
+    }
+
+    pub fn save_to_path(&self, path: &Path) -> Result<(), TrainingConfigError> {
+        self.validate()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self)?;
+        fs::write(path, content)?;
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<(), TrainingConfigError> {
+        if !(0.0..=1.0).contains(&self.success_threshold) {
+            return Err(TrainingConfigError::Validation(
+                "success_threshold должен быть в диапазоне [0, 1]".to_string(),
+            ));
+        }
+        if !(0.0..=1.0).contains(&self.failure_threshold) {
+            return Err(TrainingConfigError::Validation(
+                "failure_threshold должен быть в диапазоне [0, 1]".to_string(),
+            ));
+        }
+        if self.success_threshold < self.failure_threshold {
+            return Err(TrainingConfigError::Validation(
+                "success_threshold не может быть меньше failure_threshold".to_string(),
+            ));
+        }
+        if self.min_attempts == 0 {
+            return Err(TrainingConfigError::Validation(
+                "min_attempts должен быть больше нуля".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn apply_update(&mut self, update: TrainingConfigUpdate) {
+        if let Some(value) = update.success_threshold {
+            self.success_threshold = value;
+        }
+        if let Some(value) = update.failure_threshold {
+            self.failure_threshold = value;
+        }
+        if let Some(value) = update.min_attempts {
+            self.min_attempts = value;
+        }
+        if let Some(value) = update.data_dir {
+            self.data_dir = value;
+        }
+    }
+}
+
+pub fn config_path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn validate_default_config() {
+        let config = TrainingConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn reject_invalid_thresholds() {
+        let mut config = TrainingConfig::default();
+        config.success_threshold = 1.2;
+        assert!(matches!(
+            config.validate(),
+            Err(TrainingConfigError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn load_and_save_roundtrip() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("training.toml");
+        let mut config = TrainingConfig::default();
+        config.min_attempts = 10;
+        config.save_to_path(&path).unwrap();
+
+        let loaded = TrainingConfig::load_or_default(&path).unwrap();
+        assert_eq!(loaded.min_attempts, 10);
+    }
+
+    #[test]
+    fn apply_update_changes_fields() {
+        let mut config = TrainingConfig::default();
+        let mut update = TrainingConfigUpdate::default();
+        update.success_threshold = Some(0.9);
+        update.failure_threshold = Some(0.7);
+        update.min_attempts = Some(12);
+        update.data_dir = Some(PathBuf::from("alt"));
+
+        config.apply_update(update);
+
+        assert_eq!(config.success_threshold, 0.9);
+        assert_eq!(config.failure_threshold, 0.7);
+        assert_eq!(config.min_attempts, 12);
+        assert_eq!(config.data_dir, PathBuf::from("alt"));
     }
 }

--- a/src/training/metrics.rs
+++ b/src/training/metrics.rs
@@ -1,17 +1,23 @@
+/* neira:meta
+id: NEI-20250211-163700-training-metrics-settings
+intent: feature
+summary: |
+  Подключил метрики обучения к файлу конфигурации и добавил обновление параметров.
+*/
 use crate::autopilot::AutoPilot;
+use crate::training::config::{
+    config_path_to_string, TrainingConfig, TrainingConfigError, TrainingConfigUpdate,
+};
 use chrono::{DateTime, Utc};
 use prometheus::{Gauge, IntCounter, Registry};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::env;
 use std::error::Error as StdError;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::{env, path::PathBuf};
 use tokio::sync::RwLock;
 use tracing::{info, warn};
-
-const DEFAULT_SUCCESS_THRESHOLD: f64 = 0.8;
-const DEFAULT_FAILURE_THRESHOLD: f64 = 0.6;
-const DEFAULT_MIN_ATTEMPTS: u64 = 5;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct LearningStats {
@@ -28,6 +34,8 @@ pub struct LearningMetrics {
     attempts: IntCounter,
     difficulty_level: Gauge,
     pub stats: Arc<RwLock<LearningStats>>,
+    config: Arc<RwLock<TrainingConfig>>,
+    config_path: PathBuf,
 }
 
 #[derive(Debug)]
@@ -55,6 +63,11 @@ impl Pipeline for PipelineResult {
 
 impl LearningMetrics {
     pub fn new() -> Self {
+        let config_path = TrainingConfig::resolve_path();
+        Self::with_config_path(config_path)
+    }
+
+    pub fn with_config_path(config_path: PathBuf) -> Self {
         let registry = Registry::new();
         let success_rate = Gauge::new("learning_success_rate", "Процент успешных ответов").unwrap();
         let attempts = IntCounter::new("learning_attempts", "Количество попыток").unwrap();
@@ -66,6 +79,17 @@ impl LearningMetrics {
         registry
             .register(Box::new(difficulty_level.clone()))
             .unwrap();
+        let config = match TrainingConfig::load_or_default(&config_path) {
+            Ok(cfg) => cfg,
+            Err(error) => {
+                warn!(
+                    path = config_path_to_string(&config_path),
+                    error = %error,
+                    "Не удалось загрузить конфигурацию обучения, используем значения по умолчанию"
+                );
+                TrainingConfig::default()
+            }
+        };
 
         Self {
             registry,
@@ -73,6 +97,8 @@ impl LearningMetrics {
             attempts,
             difficulty_level,
             stats: Arc::new(RwLock::new(LearningStats::default())),
+            config: Arc::new(RwLock::new(config)),
+            config_path,
         }
     }
 
@@ -129,12 +155,13 @@ impl LearningMetrics {
 
     pub async fn adjust_difficulty(&self) -> f64 {
         let stats = self.stats.read().await;
+        let config = self.config.read().await.clone();
         let current = stats.current_level;
-        let new_level = if stats.should_increase_difficulty() {
+        let new_level = if stats.should_increase_difficulty(&config) {
             let level = (current + 0.1).min(1.0);
             info!(from = current, to = level, "Increasing difficulty");
             level
-        } else if stats.should_decrease_difficulty() {
+        } else if stats.should_decrease_difficulty(&config) {
             let level = (current - 0.1).max(0.1);
             warn!(from = current, to = level, "Decreasing difficulty");
             level
@@ -161,27 +188,23 @@ impl LearningMetrics {
         Arc::new(pilot)
     }
 
-    fn get_thresholds() -> (f64, f64, u64) {
-        let success = env::var("NEIRA_SUCCESS_THRESHOLD")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_SUCCESS_THRESHOLD);
-
-        let failure = env::var("NEIRA_FAILURE_THRESHOLD")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_FAILURE_THRESHOLD);
-
-        let attempts = env::var("NEIRA_MIN_ATTEMPTS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_MIN_ATTEMPTS);
-
-        (success, failure, attempts)
-    }
-
     pub async fn get_current_level(&self) -> f64 {
         self.stats.read().await.current_level
+    }
+
+    pub async fn get_training_config(&self) -> TrainingConfig {
+        self.config.read().await.clone()
+    }
+
+    pub async fn update_training_config(
+        &self,
+        update: TrainingConfigUpdate,
+    ) -> Result<TrainingConfig, TrainingConfigError> {
+        let mut guard = self.config.write().await;
+        guard.apply_update(update);
+        guard.validate()?;
+        guard.save_to_path(&self.config_path)?;
+        Ok(guard.clone())
     }
 }
 
@@ -202,14 +225,12 @@ impl LearningStats {
         self.success_count as f64 / self.total_attempts as f64
     }
 
-    pub fn should_increase_difficulty(&self) -> bool {
-        let (success_threshold, _, min_attempts) = LearningMetrics::get_thresholds();
-        self.get_success_rate() > success_threshold && self.total_attempts >= min_attempts
+    pub fn should_increase_difficulty(&self, config: &TrainingConfig) -> bool {
+        self.get_success_rate() > config.success_threshold && self.total_attempts >= config.min_attempts
     }
 
-    pub fn should_decrease_difficulty(&self) -> bool {
-        let (_, failure_threshold, min_attempts) = LearningMetrics::get_thresholds();
-        self.get_success_rate() < failure_threshold && self.total_attempts >= min_attempts
+    pub fn should_decrease_difficulty(&self, config: &TrainingConfig) -> bool {
+        self.get_success_rate() < config.failure_threshold && self.total_attempts >= config.min_attempts
     }
 }
 
@@ -217,11 +238,12 @@ impl LearningStats {
 mod tests {
     use super::*;
     use std::env;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     #[tokio::test]
     async fn test_record_attempt() {
-        let metrics = LearningMetrics::new();
+        let (_dir, _path, metrics) = metrics_with_temp_config();
 
         // Проверяем успешную попытку
         metrics.record_attempt(true, 0.5).await;
@@ -243,12 +265,12 @@ mod tests {
         let temp_dir = TempDir::new()?;
         env::set_var("NEIRA_DATA_DIR", temp_dir.path());
 
-        let metrics = LearningMetrics::new();
+        let (_config_guard, _path, metrics) = metrics_with_temp_config();
         metrics.record_attempt(true, 0.5).await;
         metrics.save_progress().await?;
 
         // Создаем новый экземпляр и проверяем загрузку
-        let new_metrics = LearningMetrics::new();
+        let (_config_guard2, _path, new_metrics) = metrics_with_temp_config();
         new_metrics.load_progress().await?;
 
         let stats = new_metrics.stats.read().await;
@@ -261,26 +283,27 @@ mod tests {
     #[test]
     fn test_difficulty_adjustment() {
         let mut stats = LearningStats::default();
+        let config = TrainingConfig::default();
 
         // Проверяем повышение сложности
         for _ in 0..5 {
             stats.update(true, 0.5);
         }
-        assert!(stats.should_increase_difficulty());
-        assert!(!stats.should_decrease_difficulty());
+        assert!(stats.should_increase_difficulty(&config));
+        assert!(!stats.should_decrease_difficulty(&config));
 
         // Проверяем понижение сложности
         let mut stats = LearningStats::default();
         for _ in 0..5 {
             stats.update(false, 0.5);
         }
-        assert!(!stats.should_increase_difficulty());
-        assert!(stats.should_decrease_difficulty());
+        assert!(!stats.should_increase_difficulty(&config));
+        assert!(stats.should_decrease_difficulty(&config));
     }
 
     #[test]
     fn test_metrics_export() {
-        let metrics = LearningMetrics::new();
+        let (_guard, _path, metrics) = metrics_with_temp_config();
 
         // Проверяем начальные значения
         assert_eq!(metrics.get_success_rate_metric(), 0.0);
@@ -293,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_adaptive_difficulty() {
-        let metrics = LearningMetrics::new();
+        let (_guard, _path, metrics) = metrics_with_temp_config();
 
         // Проверяем повышение сложности после успешных попыток
         for _ in 0..5 {
@@ -302,7 +325,7 @@ mod tests {
         assert!(metrics.adjust_difficulty().await > 0.5);
 
         // Проверяем понижение сложности после неудач
-        let metrics = LearningMetrics::new();
+        let (_guard2, _path, metrics) = metrics_with_temp_config();
         for _ in 0..5 {
             metrics.record_attempt(false, 0.5).await;
         }
@@ -311,7 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_pipeline_result() {
-        let metrics = LearningMetrics::new();
+        let (_guard, _path, metrics) = metrics_with_temp_config();
 
         let result = PipelineResult {
             value: serde_json::json!({
@@ -325,5 +348,35 @@ mod tests {
         let stats = metrics.stats.read().await;
         assert_eq!(stats.success_count, 1);
         assert_eq!(stats.current_level, 0.7);
+    }
+
+    #[tokio::test]
+    async fn test_update_training_config_persists_changes() {
+        let (temp_dir, config_path, metrics) = metrics_with_temp_config();
+
+        let updated = metrics
+            .update_training_config(TrainingConfigUpdate {
+                success_threshold: Some(0.9),
+                failure_threshold: Some(0.7),
+                min_attempts: Some(12),
+                data_dir: Some(temp_dir.path().join("custom")),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(updated.success_threshold, 0.9);
+        assert_eq!(updated.failure_threshold, 0.7);
+        assert_eq!(updated.min_attempts, 12);
+        assert_eq!(updated.data_dir, temp_dir.path().join("custom"));
+
+        let persisted = TrainingConfig::load_or_default(&config_path).unwrap();
+        assert_eq!(persisted.success_threshold, 0.9);
+    }
+
+    fn metrics_with_temp_config() -> (TempDir, PathBuf, LearningMetrics) {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("config.toml");
+        let metrics = LearningMetrics::with_config_path(config_path.clone());
+        (temp_dir, config_path, metrics)
     }
 }

--- a/src/training/mod.rs
+++ b/src/training/mod.rs
@@ -1,1 +1,8 @@
+/* neira:meta
+id: NEI-20250211-163900-training-module-index
+intent: chore
+summary: |
+  Экспортировал модуль config для доступа к настройкам обучения из сервера.
+*/
+pub mod config;
 pub mod metrics;

--- a/static/index.html
+++ b/static/index.html
@@ -44,6 +44,32 @@ summary: |
         .button:hover {
             background: #106ebe;
         }
+        .tabs {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+        .tab-button {
+            background: #3a3a3a;
+            color: #ffffff;
+            border: 1px solid #4a4a4a;
+            padding: 10px 18px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 15px;
+            transition: background 0.3s, border-color 0.3s;
+        }
+        .tab-button.active {
+            background: #0078d4;
+            border-color: #0078d4;
+        }
+        .tab-content {
+            display: none;
+        }
+        .tab-content.active {
+            display: block;
+        }
         .metrics {
             font-family: monospace;
             background: #1e1e1e;
@@ -104,6 +130,45 @@ summary: |
             background: #3a3a3a;
             color: white;
         }
+        .form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+            margin-top: 10px;
+            margin-bottom: 10px;
+        }
+        .form-field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .form-field label {
+            font-size: 14px;
+            color: #c9c9c9;
+        }
+        .form-field input {
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #4a4a4a;
+            background: #1e1e1e;
+            color: #ffffff;
+        }
+        .inline-status {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 12px;
+            border-radius: 20px;
+            font-size: 13px;
+            margin-left: 10px;
+        }
+        .inline-status.success {
+            background: rgba(16, 124, 16, 0.15);
+            color: #7ed957;
+        }
+        .inline-status.error {
+            background: rgba(216, 59, 1, 0.15);
+            color: #ff8a65;
+        }
         @media (max-width: 600px) {
             .button { width: 100%; margin: 5px 0; }
         }
@@ -116,25 +181,63 @@ summary: |
             <p>Этот пульт помогает следить за метриками обучения и вести диалог с Нейрой.</p>
         </div>
 
-        <div class="card">
-            <h2>Тренировочный контур</h2>
-            <button class="button" onclick="sendAttempt(true)">Засчитать успешную попытку</button>
-            <button class="button" onclick="sendAttempt(false)">Засчитать неудачную попытку</button>
-            <p>Текущий уровень сложности: <span id="difficulty">0.50</span></p>
+        <div class="tabs">
+            <button class="tab-button active" data-tab="overview">Обзор</button>
+            <button class="tab-button" data-tab="training">Обучение</button>
+            <button class="tab-button" data-tab="dialogue">Диалог</button>
         </div>
 
-        <div class="card">
-            <h2>Системные метрики</h2>
-            <pre class="metrics" id="metrics">Загружаем метрики...</pre>
+        <div id="tab-overview" class="tab-content active">
+            <div class="card">
+                <h2>Системные метрики</h2>
+                <pre class="metrics" id="metrics">Загружаем метрики...</pre>
+            </div>
         </div>
 
-        <div class="card">
-            <h2>Диалог с Нейрой</h2>
-            <div class="chat-container" id="chat">
-                <div class="messages" id="messages"></div>
-                <div class="input-container">
-                    <input type="text" id="messageInput" placeholder="Введите сообщение..." autocomplete="off">
-                    <button class="button" onclick="sendMessage()">Отправить</button>
+        <div id="tab-training" class="tab-content">
+            <div class="card">
+                <h2>Тренировочный контур</h2>
+                <button class="button" onclick="sendAttempt(true)">Засчитать успешную попытку</button>
+                <button class="button" onclick="sendAttempt(false)">Засчитать неудачную попытку</button>
+                <p>Текущий уровень сложности: <span id="difficulty">0.50</span></p>
+            </div>
+            <div class="card">
+                <h2>Настройки обучения
+                    <span id="trainingConfigStatus" class="inline-status" style="display:none"></span>
+                </h2>
+                <form id="trainingConfigForm">
+                    <div class="form-grid">
+                        <div class="form-field">
+                            <label for="successThreshold">Порог успеха (0-1)</label>
+                            <input type="number" id="successThreshold" name="successThreshold" min="0" max="1" step="0.05" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="failureThreshold">Порог неудач (0-1)</label>
+                            <input type="number" id="failureThreshold" name="failureThreshold" min="0" max="1" step="0.05" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="minAttempts">Минимум попыток</label>
+                            <input type="number" id="minAttempts" name="minAttempts" min="1" step="1" required>
+                        </div>
+                        <div class="form-field">
+                            <label for="dataDir">Каталог данных</label>
+                            <input type="text" id="dataDir" name="dataDir" required>
+                        </div>
+                    </div>
+                    <button type="submit" class="button">Сохранить настройки</button>
+                </form>
+            </div>
+        </div>
+
+        <div id="tab-dialogue" class="tab-content">
+            <div class="card">
+                <h2>Диалог с Нейрой</h2>
+                <div class="chat-container" id="chat">
+                    <div class="messages" id="messages"></div>
+                    <div class="input-container">
+                        <input type="text" id="messageInput" placeholder="Введите сообщение..." autocomplete="off">
+                        <button class="button" onclick="sendMessage()">Отправить</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -142,6 +245,20 @@ summary: |
 
     <script>
         const API_URL = '';
+
+        const tabs = document.querySelectorAll('.tab-button');
+        const tabContents = document.querySelectorAll('.tab-content');
+
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => activateTab(tab.dataset.tab));
+        });
+
+        function activateTab(tabId) {
+            tabs.forEach((tab) => tab.classList.toggle('active', tab.dataset.tab === tabId));
+            tabContents.forEach((content) =>
+                content.classList.toggle('active', content.id === `tab-${tabId}`)
+            );
+        }
 
         async function updateMetrics() {
             try {
@@ -178,6 +295,75 @@ summary: |
             } catch (error) {
                 console.error('Ошибка при фиксации попытки:', error);
             }
+        }
+
+        async function loadTrainingConfig() {
+            try {
+                const response = await fetch(`${API_URL}/training/config`);
+                if (!response.ok) {
+                    throw new Error('Сервер вернул ошибку при загрузке настроек');
+                }
+                const config = await response.json();
+                document.getElementById('successThreshold').value = config.success_threshold.toFixed(2);
+                document.getElementById('failureThreshold').value = config.failure_threshold.toFixed(2);
+                document.getElementById('minAttempts').value = config.min_attempts;
+                document.getElementById('dataDir').value = config.data_dir;
+                hideTrainingConfigStatus();
+            } catch (error) {
+                showTrainingConfigStatus(`Не удалось загрузить настройки: ${error.message}`, false);
+            }
+        }
+
+        async function saveTrainingConfig(event) {
+            event.preventDefault();
+            const payload = {
+                success_threshold: Number(document.getElementById('successThreshold').value),
+                failure_threshold: Number(document.getElementById('failureThreshold').value),
+                min_attempts: Number(document.getElementById('minAttempts').value),
+                data_dir: document.getElementById('dataDir').value,
+            };
+
+            try {
+                const response = await fetch(`${API_URL}/training/config`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+
+                if (!response.ok) {
+                    const error = await response.json();
+                    throw new Error(error.message || 'Не удалось сохранить настройки');
+                }
+
+                const config = await response.json();
+                document.getElementById('successThreshold').value = config.success_threshold.toFixed(2);
+                document.getElementById('failureThreshold').value = config.failure_threshold.toFixed(2);
+                document.getElementById('minAttempts').value = config.min_attempts;
+                document.getElementById('dataDir').value = config.data_dir;
+                showTrainingConfigStatus('Настройки сохранены', true);
+            } catch (error) {
+                showTrainingConfigStatus(error.message, false);
+            }
+        }
+
+        function showTrainingConfigStatus(message, success) {
+            const node = document.getElementById('trainingConfigStatus');
+            node.textContent = message;
+            node.classList.remove('success', 'error');
+            node.classList.add(success ? 'success' : 'error');
+            node.style.display = 'inline-flex';
+            if (success) {
+                setTimeout(() => {
+                    hideTrainingConfigStatus();
+                }, 4000);
+            }
+        }
+
+        function hideTrainingConfigStatus() {
+            const node = document.getElementById('trainingConfigStatus');
+            node.textContent = '';
+            node.classList.remove('success', 'error');
+            node.style.display = 'none';
         }
 
         function appendMessage(content, cssClass) {
@@ -229,8 +415,13 @@ summary: |
             }
         });
 
+        document
+            .getElementById('trainingConfigForm')
+            .addEventListener('submit', saveTrainingConfig);
+
         updateMetrics();
         setInterval(updateMetrics, 5000);
+        loadTrainingConfig();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the training config module and load defaults from disk with validation helpers
- wire the metrics service to read and persist training thresholds via new /training/config API endpoints
- refresh the web console with tabbed navigation and a form for editing training parameters; add toml dependency

## Testing
- cargo test -p neira training::


------
https://chatgpt.com/codex/tasks/task_e_69077cd7063483239838eb8fb764ffac