### PR TITLE
fix: roll back training config on validation failure

### DIFF
--- a/src/training/metrics.rs
+++ b/src/training/metrics.rs
@@ -201,10 +201,12 @@ impl LearningMetrics {
         update: TrainingConfigUpdate,
     ) -> Result<TrainingConfig, TrainingConfigError> {
         let mut guard = self.config.write().await;
-        guard.apply_update(update);
-        guard.validate()?;
-        guard.save_to_path(&self.config_path)?;
-        Ok(guard.clone())
+        let mut candidate = guard.clone();
+        candidate.apply_update(update);
+        candidate.validate()?;
+        candidate.save_to_path(&self.config_path)?;
+        *guard = candidate.clone();
+        Ok(candidate)
     }
 }
 
@@ -371,6 +373,29 @@ mod tests {
 
         let persisted = TrainingConfig::load_or_default(&config_path).unwrap();
         assert_eq!(persisted.success_threshold, 0.9);
+    }
+
+    #[tokio::test]
+    async fn test_update_training_config_rolls_back_on_error() {
+        let (_temp_dir, config_path, metrics) = metrics_with_temp_config();
+
+        let original = metrics.get_training_config().await;
+        let result = metrics
+            .update_training_config(TrainingConfigUpdate {
+                success_threshold: Some(0.5),
+                failure_threshold: Some(0.6),
+                ..TrainingConfigUpdate::default()
+            })
+            .await;
+
+        assert!(matches!(result, Err(TrainingConfigError::Validation(_))));
+
+        let current = metrics.get_training_config().await;
+        assert_eq!(current.success_threshold, original.success_threshold);
+        assert_eq!(current.failure_threshold, original.failure_threshold);
+        assert_eq!(current.min_attempts, original.min_attempts);
+        assert_eq!(current.data_dir, original.data_dir);
+        assert!(!config_path.exists());
     }
 
     fn metrics_with_temp_config() -> (TempDir, PathBuf, LearningMetrics) {


### PR DESCRIPTION
## Summary
- expose the training config module and load defaults from disk with validation helpers
- wire the metrics service to read and persist training thresholds via new /training/config API endpoints
- refresh the web console with tabbed navigation and a form for editing training parameters; add toml dependency
- ensure invalid training config updates do not mutate the in-memory state and add regression coverage

## Testing
- cargo test -p neira training::metrics::tests::test_update_training_config_rolls_back_on_error

------
https://chatgpt.com/codex/tasks/task_e_69078e7a36b08323be8f00be14e01ec8